### PR TITLE
공통 모듈 및 마이크로서비스 기반 구조 구현

### DIFF
--- a/libs/api/exception-handler/src/main/java/com/example/api/handler/GlobalExceptionHandler.java
+++ b/libs/api/exception-handler/src/main/java/com/example/api/handler/GlobalExceptionHandler.java
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
         log.error("[Technical] code={}, message={}", e.getErrorCode().getCode(), e.getMessage(), e);
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
-                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+                .body(ApiResponse.error(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 
     @ExceptionHandler(ApplicationException.class)

--- a/libs/api/response/src/main/java/com/example/api/response/ApiResponse.java
+++ b/libs/api/response/src/main/java/com/example/api/response/ApiResponse.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -15,20 +15,20 @@ public class ApiResponse<T> {
     private final boolean success;
     private final T data;
     private final ErrorResponse error;
-    private final LocalDateTime timestamp;
+    private final Instant timestamp;
 
     public static <T> ApiResponse<T> success(T data) {
         return ApiResponse.<T>builder()
                 .success(true)
                 .data(data)
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 
     public static <T> ApiResponse<T> success() {
         return ApiResponse.<T>builder()
                 .success(true)
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -36,7 +36,7 @@ public class ApiResponse<T> {
         return ApiResponse.<T>builder()
                 .success(false)
                 .error(ErrorResponse.of(errorCode))
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 
@@ -44,7 +44,7 @@ public class ApiResponse<T> {
         return ApiResponse.<T>builder()
                 .success(false)
                 .error(ErrorResponse.of(errorCode.getCode(), message))
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 }

--- a/libs/config/kafka/src/main/java/com/example/config/kafka/KafkaConfig.java
+++ b/libs/config/kafka/src/main/java/com/example/config/kafka/KafkaConfig.java
@@ -36,7 +36,7 @@ public class KafkaConfig {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties(null));
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.example.*");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/libs/config/kafka/src/main/java/com/example/config/kafka/KafkaConfig.java
+++ b/libs/config/kafka/src/main/java/com/example/config/kafka/KafkaConfig.java
@@ -23,6 +23,9 @@ public class KafkaConfig {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties(null));
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
         return new DefaultKafkaProducerFactory<>(props);
     }
 

--- a/libs/config/redis/src/main/java/com/example/config/redis/RedisConfig.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/RedisConfig.java
@@ -2,14 +2,13 @@ package com.example.config.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -20,21 +19,27 @@ import java.time.Duration;
 @Configuration
 public class RedisConfig {
 
+    private GenericJackson2JsonRedisSerializer createJsonSerializer() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType("com.example.")
+                        .allowIfSubType("java.util.")
+                        .allowIfSubType("java.time.")
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        objectMapper.activateDefaultTyping(
-                objectMapper.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL
-        );
-
-        GenericJackson2JsonRedisSerializer jsonSerializer =
-                new GenericJackson2JsonRedisSerializer(objectMapper);
+        GenericJackson2JsonRedisSerializer jsonSerializer = createJsonSerializer();
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(jsonSerializer);
@@ -52,8 +57,7 @@ public class RedisConfig {
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(
-                                new GenericJackson2JsonRedisSerializer()));
+                        RedisSerializationContext.SerializationPair.fromSerializer(createJsonSerializer()));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)

--- a/libs/config/resilience/src/main/java/com/example/config/resilience/CircuitBreakerHelper.java
+++ b/libs/config/resilience/src/main/java/com/example/config/resilience/CircuitBreakerHelper.java
@@ -43,8 +43,8 @@ public class CircuitBreakerHelper {
     public <T> T executeWithCircuitBreakerAndRetry(String name, Supplier<T> supplier) {
         CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker(name);
         Retry retry = retryRegistry.retry(name);
-        Supplier<T> decorated = CircuitBreaker.decorateSupplier(cb,
-                Retry.decorateSupplier(retry, supplier));
+        Supplier<T> decorated = Retry.decorateSupplier(retry,
+                CircuitBreaker.decorateSupplier(cb, supplier));
         return decorated.get();
     }
 

--- a/libs/config/resilience/src/main/java/com/example/config/resilience/FallbackRegistry.java
+++ b/libs/config/resilience/src/main/java/com/example/config/resilience/FallbackRegistry.java
@@ -1,10 +1,12 @@
 package com.example.config.resilience;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,10 +16,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FallbackRegistry {
 
     private static final Duration DEFAULT_TTL = Duration.ofMinutes(5);
+    private static final int MAX_CACHE_SIZE = 1000;
 
     private final Map<String, CachedResponse<?>> cache = new ConcurrentHashMap<>();
 
     public <T> void cacheResponse(String key, T response) {
+        if (cache.size() >= MAX_CACHE_SIZE) {
+            evictExpiredEntries();
+        }
+        if (cache.size() >= MAX_CACHE_SIZE) {
+            log.warn("[FallbackRegistry] Cache full (max={}), skipping cache for: {}", MAX_CACHE_SIZE, key);
+            return;
+        }
         cache.put(key, new CachedResponse<>(response, Instant.now()));
         log.debug("[FallbackRegistry] Cached response for: {}", key);
     }
@@ -42,6 +52,23 @@ public class FallbackRegistry {
 
     public void clear() {
         cache.clear();
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void evictExpiredEntries() {
+        Instant now = Instant.now();
+        Iterator<Map.Entry<String, CachedResponse<?>>> it = cache.entrySet().iterator();
+        int evicted = 0;
+        while (it.hasNext()) {
+            Map.Entry<String, CachedResponse<?>> entry = it.next();
+            if (Duration.between(entry.getValue().cachedAt(), now).compareTo(DEFAULT_TTL) > 0) {
+                it.remove();
+                evicted++;
+            }
+        }
+        if (evicted > 0) {
+            log.debug("[FallbackRegistry] Evicted {} expired entries", evicted);
+        }
     }
 
     private record CachedResponse<T>(T response, Instant cachedAt) {}

--- a/libs/config/webclient/build.gradle.kts
+++ b/libs/config/webclient/build.gradle.kts
@@ -8,6 +8,7 @@ tasks.bootJar { enabled = false }
 tasks.jar { enabled = true }
 
 dependencies {
+    api(project(":libs:core:exception"))
     api("org.springframework.boot:spring-boot-starter-webflux")
     api("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/libs/config/webclient/src/main/java/com/example/config/webclient/WebClientErrorHandler.java
+++ b/libs/config/webclient/src/main/java/com/example/config/webclient/WebClientErrorHandler.java
@@ -23,11 +23,14 @@ public class WebClientErrorHandler implements ExchangeFilterFunction {
                         return response.bodyToMono(String.class)
                                 .defaultIfEmpty("")
                                 .flatMap(body -> {
-                                    log.error("WebClient error response: {} {} - Status: {} - Body: {}",
+                                    String truncatedBody = body.length() > 500
+                                            ? body.substring(0, 500) + "...[truncated]"
+                                            : body;
+                                    log.error("WebClient error response: {} {} - Status: {}",
                                             request.method(),
-                                            request.url(),
-                                            statusCode.value(),
-                                            body);
+                                            request.url().getPath(),
+                                            statusCode.value());
+                                    log.debug("WebClient error body: {}", truncatedBody);
                                     return Mono.error(new WebClientException(
                                             statusCode.value(),
                                             body

--- a/libs/config/webclient/src/main/java/com/example/config/webclient/WebClientException.java
+++ b/libs/config/webclient/src/main/java/com/example/config/webclient/WebClientException.java
@@ -1,27 +1,26 @@
 package com.example.config.webclient;
 
-public class WebClientException extends RuntimeException {
+import com.example.core.exception.CommonErrorCode;
+import com.example.core.exception.TechnicalException;
+import lombok.Getter;
+
+@Getter
+public class WebClientException extends TechnicalException {
 
     private final int statusCode;
     private final String responseBody;
 
     public WebClientException(int statusCode, String responseBody) {
-        super("WebClient error with status code: " + statusCode + ", body: " + responseBody);
+        super(CommonErrorCode.EXTERNAL_API_ERROR,
+                "외부 API 호출 실패 - status: " + statusCode);
         this.statusCode = statusCode;
         this.responseBody = responseBody;
     }
 
     public WebClientException(int statusCode, String responseBody, Throwable cause) {
-        super("WebClient error with status code: " + statusCode + ", body: " + responseBody, cause);
+        super(CommonErrorCode.EXTERNAL_API_ERROR,
+                "외부 API 호출 실패 - status: " + statusCode, cause);
         this.statusCode = statusCode;
         this.responseBody = responseBody;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public String getResponseBody() {
-        return responseBody;
     }
 }

--- a/libs/core/id/src/main/java/com/example/core/id/SnowflakeAutoConfiguration.java
+++ b/libs/core/id/src/main/java/com/example/core/id/SnowflakeAutoConfiguration.java
@@ -1,7 +1,6 @@
 package com.example.core.id;
 
 import com.example.core.id.jpa.SnowflakeIdentifierGenerator;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -29,14 +28,9 @@ public class SnowflakeAutoConfiguration {
     @Bean
     public Snowflake snowflake() {
         Snowflake snowflake = new Snowflake(properties.getDatacenterId(), properties.getWorkerId());
+        SnowflakeIdentifierGenerator.setInstance(snowflake);
         log.info("[Snowflake] Initialized: datacenterId={}, workerId={}",
                 properties.getDatacenterId(), properties.getWorkerId());
         return snowflake;
-    }
-
-    @PostConstruct
-    void registerJpaGenerator() {
-        Snowflake snowflake = new Snowflake(properties.getDatacenterId(), properties.getWorkerId());
-        SnowflakeIdentifierGenerator.setInstance(snowflake);
     }
 }

--- a/libs/core/id/src/main/java/com/example/core/id/SnowflakeProperties.java
+++ b/libs/core/id/src/main/java/com/example/core/id/SnowflakeProperties.java
@@ -1,5 +1,6 @@
 package com.example.core.id;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -7,14 +8,26 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * app:
  *   snowflake:
- *     datacenter-id: 1   # 0~31
- *     worker-id: 1       # 0~31
+ *     datacenter-id: 1   # 0~31 (필수 설정 권장)
+ *     worker-id: 1       # 0~31 (필수 설정 권장)
  */
 @ConfigurationProperties(prefix = "app.snowflake")
 public class SnowflakeProperties {
 
-    private long datacenterId = 1;
-    private long workerId = 1;
+    private long datacenterId = 0;
+    private long workerId = 0;
+
+    @PostConstruct
+    void validate() {
+        if (datacenterId < 0 || datacenterId > 31) {
+            throw new IllegalArgumentException(
+                    "app.snowflake.datacenter-id must be between 0 and 31, got: " + datacenterId);
+        }
+        if (workerId < 0 || workerId > 31) {
+            throw new IllegalArgumentException(
+                    "app.snowflake.worker-id must be between 0 and 31, got: " + workerId);
+        }
+    }
 
     public long getDatacenterId() {
         return datacenterId;

--- a/libs/core/pagination/src/main/java/com/example/core/pagination/CursorRequest.java
+++ b/libs/core/pagination/src/main/java/com/example/core/pagination/CursorRequest.java
@@ -1,5 +1,6 @@
 package com.example.core.pagination;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import lombok.Getter;
  * - API 요청 제한 (무상태 커서)
  */
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class CursorRequest {
 
     private static final int DEFAULT_SIZE = 20;

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/DomainEventPublisher.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/DomainEventPublisher.java
@@ -1,14 +1,16 @@
 package com.example.event.outbox;
 
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class DomainEventPublisher {
 
     private final ApplicationEventPublisher eventPublisher;
-    private static ApplicationEventPublisher staticPublisher;
+    private static volatile ApplicationEventPublisher staticPublisher;
 
     public DomainEventPublisher(ApplicationEventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
@@ -22,6 +24,8 @@ public class DomainEventPublisher {
     public static void publish(Object event) {
         if (staticPublisher != null) {
             staticPublisher.publishEvent(event);
+        } else {
+            log.warn("ApplicationEventPublisher가 초기화되지 않았습니다. 이벤트가 발행되지 않습니다: {}", event);
         }
     }
 }

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/ImmediatePublisher.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/ImmediatePublisher.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -19,21 +20,53 @@ public class ImmediatePublisher {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOutboxSaved(OutboxSavedEvent event) {
-        OutboxMessage message = event.getOutboxMessage();
+        Long messageId = event.getOutboxMessage().getId();
         try {
+            if (!tryMarkAsSending(messageId)) {
+                log.debug("Message already picked up by another publisher: id={}", messageId);
+                return;
+            }
+
+            OutboxMessage message = outboxRepository.findById(messageId).orElse(null);
+            if (message == null) {
+                return;
+            }
+
             kafkaTemplate.send(message.getTopic(), message.getAggregateId(), message.getPayload())
                     .whenComplete((result, ex) -> {
                         if (ex == null) {
-                            message.markAsPublished();
-                            outboxRepository.save(message);
+                            markAsPublished(messageId);
                             log.debug("Immediate publish success: eventId={}", message.getEventId());
                         } else {
+                            revertToPending(messageId);
                             log.warn("Immediate publish failed, relay will retry: eventId={}, error={}",
                                     message.getEventId(), ex.getMessage());
                         }
                     });
         } catch (Exception e) {
-            log.warn("Immediate publish error, relay will retry: eventId={}", message.getEventId(), e);
+            revertToPending(messageId);
+            log.warn("Immediate publish error, relay will retry: id={}", messageId, e);
         }
+    }
+
+    @Transactional
+    public boolean tryMarkAsSending(Long messageId) {
+        return outboxRepository.updateStatusById(messageId, OutboxStatus.PENDING, OutboxStatus.SENDING) > 0;
+    }
+
+    @Transactional
+    public void markAsPublished(Long messageId) {
+        outboxRepository.findById(messageId).ifPresent(msg -> {
+            msg.markAsPublished();
+            outboxRepository.save(msg);
+        });
+    }
+
+    @Transactional
+    public void revertToPending(Long messageId) {
+        outboxRepository.findById(messageId).ifPresent(msg -> {
+            msg.revertToPending();
+            outboxRepository.save(msg);
+        });
     }
 }

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxCleanupScheduler.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxCleanupScheduler.java
@@ -1,0 +1,36 @@
+package com.example.event.outbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 발행 완료된 Outbox 메시지를 주기적으로 정리하여 테이블 무한 증가를 방지한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxCleanupScheduler {
+
+    private static final int RETENTION_DAYS = 7;
+
+    private final OutboxRepository outboxRepository;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    @Transactional
+    public void cleanupPublishedMessages() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(RETENTION_DAYS);
+
+        int deletedPublished = outboxRepository.deleteByStatusAndCreatedBefore(OutboxStatus.PUBLISHED, cutoff);
+        int deletedFailed = outboxRepository.deleteByStatusAndCreatedBefore(OutboxStatus.FAILED, cutoff);
+
+        if (deletedPublished > 0 || deletedFailed > 0) {
+            log.info("[OutboxCleanup] Deleted {} published and {} failed messages older than {} days",
+                    deletedPublished, deletedFailed, RETENTION_DAYS);
+        }
+    }
+}

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxMessage.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxMessage.java
@@ -54,8 +54,20 @@ public class OutboxMessage extends BaseEntity {
     @Column(name = "error_message")
     private String errorMessage;
 
+    @Column(name = "correlation_id")
+    private String correlationId;
+
+    @Column(name = "causation_id")
+    private String causationId;
+
     public static OutboxMessage create(String eventId, String aggregateType, String aggregateId,
                                         String topic, String eventType, String payload) {
+        return create(eventId, aggregateType, aggregateId, topic, eventType, payload, null, null);
+    }
+
+    public static OutboxMessage create(String eventId, String aggregateType, String aggregateId,
+                                        String topic, String eventType, String payload,
+                                        String correlationId, String causationId) {
         OutboxMessage message = new OutboxMessage();
         message.eventId = eventId;
         message.aggregateType = aggregateType;
@@ -65,6 +77,8 @@ public class OutboxMessage extends BaseEntity {
         message.payload = payload;
         message.status = OutboxStatus.PENDING;
         message.retryCount = 0;
+        message.correlationId = correlationId;
+        message.causationId = causationId;
         return message;
     }
 

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxMessage.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxMessage.java
@@ -68,9 +68,17 @@ public class OutboxMessage extends BaseEntity {
         return message;
     }
 
+    public void markAsSending() {
+        this.status = OutboxStatus.SENDING;
+    }
+
     public void markAsPublished() {
         this.status = OutboxStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
+    }
+
+    public void revertToPending() {
+        this.status = OutboxStatus.PENDING;
     }
 
     public void markAsFailed(String errorMessage) {

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
@@ -30,4 +30,10 @@ public interface OutboxRepository extends JpaRepository<OutboxMessage, Long> {
                          @Param("newStatus") OutboxStatus newStatus);
 
     List<OutboxMessage> findByStatusOrderByCreatedAtAsc(OutboxStatus status);
+
+    @Modifying
+    @Query("DELETE FROM OutboxMessage o WHERE o.status = :status AND o.createdAt < :before")
+    int deleteByStatusAndCreatedBefore(
+            @Param("status") OutboxStatus status,
+            @Param("before") LocalDateTime before);
 }

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
@@ -1,6 +1,7 @@
 package com.example.event.outbox;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,6 +14,20 @@ public interface OutboxRepository extends JpaRepository<OutboxMessage, Long> {
     List<OutboxMessage> findByStatusAndCreatedBefore(
             @Param("status") OutboxStatus status,
             @Param("before") LocalDateTime before);
+
+    @Query(value = "SELECT * FROM outbox_messages WHERE status = :status AND created_at < :before " +
+            "ORDER BY created_at ASC LIMIT :limit FOR UPDATE SKIP LOCKED",
+            nativeQuery = true)
+    List<OutboxMessage> findPendingMessagesForRelay(
+            @Param("status") String status,
+            @Param("before") LocalDateTime before,
+            @Param("limit") int limit);
+
+    @Modifying
+    @Query("UPDATE OutboxMessage o SET o.status = :newStatus WHERE o.id = :id AND o.status = :currentStatus")
+    int updateStatusById(@Param("id") Long id,
+                         @Param("currentStatus") OutboxStatus currentStatus,
+                         @Param("newStatus") OutboxStatus newStatus);
 
     List<OutboxMessage> findByStatusOrderByCreatedAtAsc(OutboxStatus status);
 }

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
@@ -33,7 +33,9 @@ public class OutboxService implements EventPublisher {
                 metadata.aggregateId(),
                 event.getTopic(),
                 event.getEventTypeName(),
-                payload
+                payload,
+                metadata.correlationId(),
+                metadata.causationId()
         );
 
         outboxRepository.save(message);

--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxStatus.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxStatus.java
@@ -2,6 +2,7 @@ package com.example.event.outbox;
 
 public enum OutboxStatus {
     PENDING,
+    SENDING,
     PUBLISHED,
     FAILED
 }

--- a/libs/security/core/build.gradle.kts
+++ b/libs/security/core/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
     // Spring Security
     api("org.springframework.boot:spring-boot-starter-security")
 
+    // Servlet API (for AuthContextCleanupFilter)
+    compileOnly("org.springframework.boot:spring-boot-starter-web")
+
     // JWT
     // implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     // runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")

--- a/libs/security/core/src/main/java/com/example/security/core/AuthContextCleanupFilter.java
+++ b/libs/security/core/src/main/java/com/example/security/core/AuthContextCleanupFilter.java
@@ -1,0 +1,32 @@
+package com.example.security.core;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 요청 완료 후 AuthContextHolder의 ThreadLocal을 정리하여
+ * 스레드 풀에서의 메모리 누수 및 컨텍스트 유출을 방지한다.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AuthContextCleanupFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                     HttpServletResponse response,
+                                     FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            AuthContextHolder.clear();
+        }
+    }
+}

--- a/libs/security/core/src/main/java/com/example/security/core/HmacSigner.java
+++ b/libs/security/core/src/main/java/com/example/security/core/HmacSigner.java
@@ -28,7 +28,9 @@ public class HmacSigner {
 
     public boolean verify(String payload, String signature) {
         String computed = sign(payload);
-        return computed.equals(signature);
+        return java.security.MessageDigest.isEqual(
+                computed.getBytes(StandardCharsets.UTF_8),
+                signature.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String buildSignaturePayload(String userId, String roles, String nonce, long timestamp) {

--- a/libs/security/core/src/main/java/com/example/security/core/HmacSigner.java
+++ b/libs/security/core/src/main/java/com/example/security/core/HmacSigner.java
@@ -34,6 +34,9 @@ public class HmacSigner {
     }
 
     public static String buildSignaturePayload(String userId, String roles, String nonce, long timestamp) {
+        if (userId.contains("|") || roles.contains("|") || nonce.contains("|")) {
+            throw new IllegalArgumentException("서명 페이로드 필드에 구분자(|)를 포함할 수 없습니다");
+        }
         return String.join("|", userId, roles, nonce, String.valueOf(timestamp));
     }
 }

--- a/libs/security/core/src/main/java/com/example/security/core/SignedHeaderParser.java
+++ b/libs/security/core/src/main/java/com/example/security/core/SignedHeaderParser.java
@@ -25,7 +25,12 @@ public class SignedHeaderParser {
             throw new HeaderSecurityException("필수 보안 헤더가 누락되었습니다");
         }
 
-        long timestamp = Long.parseLong(timestampStr);
+        long timestamp;
+        try {
+            timestamp = Long.parseLong(timestampStr);
+        } catch (NumberFormatException e) {
+            throw new HeaderSecurityException("유효하지 않은 타임스탬프입니다");
+        }
 
         long age = System.currentTimeMillis() - timestamp;
         if (age > maxAgeMillis || age < -maxAgeMillis) {

--- a/libs/security/core/src/main/java/com/example/security/core/encryption/AesGcmEncryptor.java
+++ b/libs/security/core/src/main/java/com/example/security/core/encryption/AesGcmEncryptor.java
@@ -71,8 +71,7 @@ public class AesGcmEncryptor implements Encryptor {
         if (key.length == 16 || key.length == 24 || key.length == 32) {
             return key;
         }
-        byte[] normalized = new byte[32];
-        System.arraycopy(key, 0, normalized, 0, Math.min(key.length, 32));
-        return normalized;
+        throw new EncryptionException(
+                "AES 키 길이는 16, 24, 32 바이트 중 하나여야 합니다. 현재: " + key.length + " 바이트");
     }
 }

--- a/servers/test/test-server/src/main/java/com/example/testserver/domain/TestItem.java
+++ b/servers/test/test-server/src/main/java/com/example/testserver/domain/TestItem.java
@@ -6,9 +6,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "test_items")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TestItem extends BaseEntity {


### PR DESCRIPTION
## Summary
- Gradle 멀티모듈 프로젝트 구성 (15개 공통 라이브러리 + 4개 서버)
- Docker 개발 환경 구성 (PostgreSQL, Redis, Kafka, Zipkin)
- 공통 모듈 구현: 예외 계층, ApiResponse, Snowflake ID, 페이지네이션, JsonUtils
- 인프라 설정 모듈: Kafka, Redis, Resilience4j, WebClient, Tracing, OpenAPI
- 보안 모듈: HMAC 서명, AES-GCM 암호화, PII 마스킹, AuthContext 관리
- 이벤트 모듈: DomainEvent, Transactional Outbox 패턴
- 서버 초기 구성: API Gateway, Auth, User, Test Server
- 공통 모듈 통합 테스트 서버 구현

## 보안 및 안정성 개선
- HMAC 서명 검증: 상수 시간 비교 (`MessageDigest.isEqual`) 적용
- HMAC 페이로드 구분자 인젝션 방지
- AES 키 검증 강화 (유효하지 않은 키 길이 예외 발생)
- Redis `BasicPolymorphicTypeValidator` 적용
- Kafka `TRUSTED_PACKAGES` 제한 및 Producer idempotence 활성화
- `AuthContextCleanupFilter` 추가 (ThreadLocal 메모리 누수 방지)
- `GlobalExceptionHandler` TechnicalException 내부 메시지 비노출

## Outbox 패턴 개선
- `SENDING` 중간 상태 도입 (ImmediatePublisher ↔ RelayScheduler 경합 방지)
- `FOR UPDATE SKIP LOCKED` + `LIMIT` 적용 (다중 인스턴스 안전)
- 메시지별 독립 트랜잭션 (`REQUIRES_NEW`)
- `correlationId/causationId` 저장
- `OutboxCleanupScheduler` 추가 (7일 보존 후 자동 정리)
- `DeadLetterMessage` 이벤트 메타데이터 및 상태 관리 추가

## 기타 개선
- Snowflake 단일 인스턴스 통합 (ID 중복 방지)
- CircuitBreaker + Retry 적용 순서 교정
- `ApiResponse` 타임스탬프 `Instant` 전환
- `WebClientException` 예외 계층 통합
- `FallbackRegistry` max-size 제한 + 만료 정리
- `TestItem` `@SQLRestriction` soft delete 필터 적용

## Test plan
- [x] `./gradlew compileJava` 전체 컴파일 성공
- [x] `./gradlew test` 전체 테스트 통과
- [ ] Docker Compose 환경에서 통합 테스트 서버 동작 확인
- [ ] Outbox → Kafka 이벤트 발행 흐름 검증