### PR TITLE
feat: Product Service 전체 구현 — 도메인 모델, API, 이벤트, 내부 통신

### DIFF
--- a/servers/services/product/build.gradle.kts
+++ b/servers/services/product/build.gradle.kts
@@ -1,0 +1,51 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Security
+    implementation(project(":libs:security:core"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/product/src/main/java/com/example/product/ProductApplication.java
+++ b/servers/services/product/src/main/java/com/example/product/ProductApplication.java
@@ -1,0 +1,20 @@
+package com.example.product;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableAsync
+@EnableScheduling
+@SpringBootApplication(scanBasePackages = {"com.example.product", "com.example.api.handler"})
+@EntityScan(basePackages = "com.example.product")
+@EnableJpaRepositories(basePackages = "com.example.product")
+public class ProductApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProductApplication.class, args);
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/config/JpaConfig.java
+++ b/servers/services/product/src/main/java/com/example/product/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.example.product.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/servers/services/product/src/main/java/com/example/product/config/SecurityConfig.java
+++ b/servers/services/product/src/main/java/com/example/product/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.example.product.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/consumer/FundingEventConsumer.java
+++ b/servers/services/product/src/main/java/com/example/product/consumer/FundingEventConsumer.java
@@ -1,0 +1,81 @@
+package com.example.product.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.exception.BusinessException;
+import com.example.core.util.JsonUtils;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.item.ItemRepository;
+import com.example.product.domain.item.ItemStatus;
+import com.example.product.domain.item.ItemStatusHistory;
+import com.example.product.domain.item.ItemStatusHistoryRepository;
+import com.example.product.event.ItemStatusChangedEvent;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FundingEventConsumer {
+
+    private final ItemRepository itemRepository;
+    private final ItemStatusHistoryRepository statusHistoryRepository;
+    private final EventPublisher eventPublisher;
+    private final IdempotentConsumerService idempotentConsumerService;
+
+    @KafkaListener(topics = "funding-events", groupId = "product-service-group")
+    @Transactional
+    public void consume(String message) {
+        Map<String, Object> event = JsonUtils.fromJson(message, Map.class);
+        String eventId = (String) event.get("eventId");
+        String eventType = (String) event.get("eventType");
+
+        idempotentConsumerService.executeIdempotent(eventId, "FUNDING_EVENT", () -> {
+            switch (eventType) {
+                case "FUNDING_COMPLETED" -> handleFundingCompleted(event);
+                case "FUNDING_FAILED" -> handleFundingFailed(event);
+                default -> log.warn("[FundingConsumer] Unknown event type: {}", eventType);
+            }
+            return null;
+        });
+    }
+
+    private void handleFundingCompleted(Map<String, Object> event) {
+        Long itemId = toLong(event.get("itemId"));
+        changeItemStatus(itemId, ItemStatus.FUNDED, "펀딩 성공");
+        log.info("[FundingConsumer] FUNDING_COMPLETED -> FUNDED for item #{}", itemId);
+    }
+
+    private void handleFundingFailed(Map<String, Object> event) {
+        Long itemId = toLong(event.get("itemId"));
+        changeItemStatus(itemId, ItemStatus.FUND_FAILED, "펀딩 실패");
+        log.info("[FundingConsumer] FUNDING_FAILED -> FUND_FAILED for item #{}", itemId);
+    }
+
+    private void changeItemStatus(Long itemId, ItemStatus newStatus, String reason) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+
+        ItemStatus previousStatus = item.getStatus();
+        item.changeStatus(newStatus);
+
+        statusHistoryRepository.save(
+                ItemStatusHistory.create(itemId, previousStatus, newStatus, reason, null));
+
+        eventPublisher.publish(
+                new ItemStatusChangedEvent(itemId, previousStatus.name(), newStatus.name()),
+                EventMetadata.of("Item", String.valueOf(itemId)));
+    }
+
+    private Long toLong(Object value) {
+        if (value instanceof Number) return ((Number) value).longValue();
+        return Long.parseLong(String.valueOf(value));
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/CategoryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/CategoryController.java
@@ -1,0 +1,45 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.CategoryApi;
+import com.example.product.dto.category.*;
+import com.example.product.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController implements CategoryApi {
+
+    private final CategoryService categoryService;
+
+    @Override
+    public ApiResponse<CategoryResponse> create(CategoryCreateRequest request) {
+        return ApiResponse.success(CategoryResponse.from(categoryService.create(request)));
+    }
+
+    @Override
+    public ApiResponse<CategoryResponse> findById(Long id) {
+        return ApiResponse.success(CategoryResponse.from(categoryService.findById(id)));
+    }
+
+    @Override
+    public ApiResponse<CategoryResponse> update(Long id, CategoryUpdateRequest request) {
+        return ApiResponse.success(CategoryResponse.from(categoryService.update(id, request)));
+    }
+
+    @Override
+    public ApiResponse<Void> delete(Long id) {
+        categoryService.delete(id);
+        return ApiResponse.success();
+    }
+
+    @Override
+    public ApiResponse<List<CategoryTreeResponse>> getTree() {
+        return ApiResponse.success(categoryService.getTree());
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/GoodsController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/GoodsController.java
@@ -1,0 +1,35 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.GoodsApi;
+import com.example.product.dto.goods.GoodsCreateRequest;
+import com.example.product.dto.goods.GoodsDetailResponse;
+import com.example.product.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/goods")
+@RequiredArgsConstructor
+public class GoodsController implements GoodsApi {
+
+    private final ItemService itemService;
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> create(GoodsCreateRequest request, Long sellerId) {
+        return ApiResponse.success(itemService.createGoods(request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> findById(Long itemId) {
+        return ApiResponse.success(itemService.findGoodsById(itemId));
+    }
+
+    @Override
+    public ApiResponse<List<GoodsDetailResponse>> findList(Long cursor, int size) {
+        return ApiResponse.success(itemService.findGoodsList(cursor, size));
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/InternalItemController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/InternalItemController.java
@@ -1,0 +1,36 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.item.ItemRepository;
+import com.example.product.dto.item.ItemSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Internal", description = "내부 서비스 간 호출용 API")
+@RestController
+@RequestMapping("/internal/v1/items")
+@RequiredArgsConstructor
+public class InternalItemController {
+
+    private final ItemRepository itemRepository;
+
+    @Operation(summary = "상품 단건 조회 (내부)")
+    @GetMapping("/{itemId}")
+    public ApiResponse<ItemSummaryResponse> findById(@PathVariable Long itemId) {
+        Item item = itemRepository.findById(itemId).orElse(null);
+        if (item == null) return ApiResponse.success(null);
+        return ApiResponse.success(ItemSummaryResponse.from(item));
+    }
+
+    @Operation(summary = "상품 다건 조회 (내부)", description = "ID 목록으로 상품 정보 일괄 조회")
+    @PostMapping("/batch")
+    public ApiResponse<List<ItemSummaryResponse>> findByIds(@RequestBody List<Long> itemIds) {
+        List<Item> items = itemRepository.findAllById(itemIds);
+        return ApiResponse.success(items.stream().map(ItemSummaryResponse::from).toList());
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/ItemImageController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/ItemImageController.java
@@ -1,0 +1,41 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.ItemImageApi;
+import com.example.product.dto.image.ItemImageRequest;
+import com.example.product.dto.image.ItemImageResponse;
+import com.example.product.service.ItemImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/items")
+@RequiredArgsConstructor
+public class ItemImageController implements ItemImageApi {
+
+    private final ItemImageService itemImageService;
+
+    @Override
+    public ApiResponse<List<ItemImageResponse>> addImages(Long itemId, List<ItemImageRequest> requests) {
+        return ApiResponse.success(itemImageService.addImages(itemId, requests));
+    }
+
+    @Override
+    public ApiResponse<List<ItemImageResponse>> findByItemId(Long itemId) {
+        return ApiResponse.success(itemImageService.findByItemId(itemId));
+    }
+
+    @Override
+    public ApiResponse<Void> deleteImage(Long imageId) {
+        itemImageService.deleteImage(imageId);
+        return ApiResponse.success();
+    }
+
+    @Override
+    public ApiResponse<List<ItemImageResponse>> reorder(Long itemId, List<Long> imageIds) {
+        return ApiResponse.success(itemImageService.reorder(itemId, imageIds));
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/ItemStatusController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/ItemStatusController.java
@@ -1,0 +1,31 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.ItemStatusApi;
+import com.example.product.dto.item.StatusChangeRequest;
+import com.example.product.dto.item.StatusHistoryResponse;
+import com.example.product.service.ItemStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/items")
+@RequiredArgsConstructor
+public class ItemStatusController implements ItemStatusApi {
+
+    private final ItemStatusService itemStatusService;
+
+    @Override
+    public ApiResponse<Void> changeStatus(Long itemId, StatusChangeRequest request, Long userId) {
+        itemStatusService.changeStatus(itemId, request, userId);
+        return ApiResponse.success();
+    }
+
+    @Override
+    public ApiResponse<List<StatusHistoryResponse>> getHistory(Long itemId) {
+        return ApiResponse.success(itemStatusService.getHistory(itemId));
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/PerformanceController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/PerformanceController.java
@@ -1,0 +1,45 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.PerformanceApi;
+import com.example.product.dto.performance.*;
+import com.example.product.service.PerformanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/performances")
+@RequiredArgsConstructor
+public class PerformanceController implements PerformanceApi {
+
+    private final PerformanceService performanceService;
+
+    @Override
+    public ApiResponse<PerformanceDetailResponse> create(PerformanceCreateRequest request, Long sellerId) {
+        return ApiResponse.success(performanceService.create(request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<PerformanceDetailResponse> findById(Long itemId) {
+        return ApiResponse.success(performanceService.findById(itemId));
+    }
+
+    @Override
+    public ApiResponse<List<PerformanceListResponse>> findList(Long cursor, int size) {
+        return ApiResponse.success(performanceService.findList(cursor, size));
+    }
+
+    @Override
+    public ApiResponse<PerformanceDetailResponse> update(Long itemId, PerformanceUpdateRequest request, Long sellerId) {
+        return ApiResponse.success(performanceService.update(itemId, request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<Void> delete(Long itemId, Long sellerId) {
+        performanceService.delete(itemId, sellerId);
+        return ApiResponse.success();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/ProductItemController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/ProductItemController.java
@@ -1,0 +1,35 @@
+package com.example.product.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.ProductItemApi;
+import com.example.product.dto.goods.GoodsDetailResponse;
+import com.example.product.dto.goods.ProductCreateRequest;
+import com.example.product.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductItemController implements ProductItemApi {
+
+    private final ItemService itemService;
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> create(ProductCreateRequest request, Long sellerId) {
+        return ApiResponse.success(itemService.createProduct(request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> findById(Long itemId) {
+        return ApiResponse.success(itemService.findProductById(itemId));
+    }
+
+    @Override
+    public ApiResponse<List<GoodsDetailResponse>> findList(Long cursor, int size) {
+        return ApiResponse.success(itemService.findProductList(cursor, size));
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/CategoryApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/CategoryApi.java
@@ -1,0 +1,34 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.category.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Category", description = "카테고리 관리 API")
+public interface CategoryApi {
+
+    @Operation(summary = "카테고리 생성", description = "루트 또는 하위 카테고리 생성. parentId가 null이면 루트 카테고리")
+    @PostMapping
+    ApiResponse<CategoryResponse> create(@Valid @RequestBody CategoryCreateRequest request);
+
+    @Operation(summary = "카테고리 단건 조회")
+    @GetMapping("/{id}")
+    ApiResponse<CategoryResponse> findById(@PathVariable Long id);
+
+    @Operation(summary = "카테고리 수정")
+    @PutMapping("/{id}")
+    ApiResponse<CategoryResponse> update(@PathVariable Long id, @Valid @RequestBody CategoryUpdateRequest request);
+
+    @Operation(summary = "카테고리 삭제", description = "하위 카테고리가 있으면 삭제 불가")
+    @DeleteMapping("/{id}")
+    ApiResponse<Void> delete(@PathVariable Long id);
+
+    @Operation(summary = "카테고리 트리 조회", description = "전체 카테고리를 트리 구조로 반환")
+    @GetMapping("/tree")
+    ApiResponse<List<CategoryTreeResponse>> getTree();
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/GoodsApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/GoodsApi.java
@@ -1,0 +1,32 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.goods.GoodsCreateRequest;
+import com.example.product.dto.goods.GoodsDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Goods", description = "굿즈 관리 API")
+public interface GoodsApi {
+
+    @Operation(summary = "굿즈 등록", description = "공연 연결 가능, 옵션/배송정보 선택")
+    @PostMapping
+    ApiResponse<GoodsDetailResponse> create(
+            @Valid @RequestBody GoodsCreateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "굿즈 상세 조회")
+    @GetMapping("/{itemId}")
+    ApiResponse<GoodsDetailResponse> findById(@PathVariable Long itemId);
+
+    @Operation(summary = "굿즈 목록 조회", description = "커서 기반 페이징")
+    @GetMapping
+    ApiResponse<List<GoodsDetailResponse>> findList(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size);
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/ItemImageApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/ItemImageApi.java
@@ -1,0 +1,31 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.image.ItemImageRequest;
+import com.example.product.dto.image.ItemImageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Item Image", description = "상품 이미지 관리 API")
+public interface ItemImageApi {
+
+    @Operation(summary = "이미지 추가 (다건)", description = "여러 이미지를 한 번에 등록")
+    @PostMapping("/{itemId}/images")
+    ApiResponse<List<ItemImageResponse>> addImages(@PathVariable Long itemId, @Valid @RequestBody List<ItemImageRequest> requests);
+
+    @Operation(summary = "상품 이미지 목록 조회")
+    @GetMapping("/{itemId}/images")
+    ApiResponse<List<ItemImageResponse>> findByItemId(@PathVariable Long itemId);
+
+    @Operation(summary = "이미지 삭제")
+    @DeleteMapping("/images/{imageId}")
+    ApiResponse<Void> deleteImage(@PathVariable Long imageId);
+
+    @Operation(summary = "이미지 순서 변경", description = "imageId 리스트 순서대로 sortOrder 재설정")
+    @PutMapping("/{itemId}/images/reorder")
+    ApiResponse<List<ItemImageResponse>> reorder(@PathVariable Long itemId, @RequestBody List<Long> imageIds);
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/ItemStatusApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/ItemStatusApi.java
@@ -1,0 +1,27 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.item.StatusChangeRequest;
+import com.example.product.dto.item.StatusHistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Item Status", description = "상품 상태 관리 API")
+public interface ItemStatusApi {
+
+    @Operation(summary = "상태 변경", description = "유효한 상태 전이만 허용, 이력 저장 + 이벤트 발행")
+    @PatchMapping("/{itemId}/status")
+    ApiResponse<Void> changeStatus(
+            @PathVariable Long itemId,
+            @Valid @RequestBody StatusChangeRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "상태 변경 이력 조회")
+    @GetMapping("/{itemId}/status-history")
+    ApiResponse<List<StatusHistoryResponse>> getHistory(@PathVariable Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/PerformanceApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/PerformanceApi.java
@@ -1,0 +1,44 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.performance.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Performance", description = "공연 등록/조회 API")
+public interface PerformanceApi {
+
+    @Operation(summary = "공연 등록", description = "DRAFT 상태로 공연 등록. 좌석등급 필수, 출연진 선택")
+    @PostMapping
+    ApiResponse<PerformanceDetailResponse> create(
+            @Valid @RequestBody PerformanceCreateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "공연 상세 조회", description = "좌석등급 + 출연진 포함")
+    @GetMapping("/{itemId}")
+    ApiResponse<PerformanceDetailResponse> findById(@PathVariable Long itemId);
+
+    @Operation(summary = "공연 목록 조회", description = "커서 기반 페이징")
+    @GetMapping
+    ApiResponse<List<PerformanceListResponse>> findList(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "공연 수정", description = "본인이 등록한 공연만 수정 가능")
+    @PutMapping("/{itemId}")
+    ApiResponse<PerformanceDetailResponse> update(
+            @PathVariable Long itemId,
+            @Valid @RequestBody PerformanceUpdateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "공연 삭제", description = "본인이 등록한 공연만 삭제 (soft delete)")
+    @DeleteMapping("/{itemId}")
+    ApiResponse<Void> delete(
+            @PathVariable Long itemId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+}

--- a/servers/services/product/src/main/java/com/example/product/controller/api/ProductItemApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/ProductItemApi.java
@@ -1,0 +1,32 @@
+package com.example.product.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.goods.GoodsDetailResponse;
+import com.example.product.dto.goods.ProductCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Product", description = "일반상품 관리 API")
+public interface ProductItemApi {
+
+    @Operation(summary = "일반상품 등록", description = "배송 정보 필수")
+    @PostMapping
+    ApiResponse<GoodsDetailResponse> create(
+            @Valid @RequestBody ProductCreateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "일반상품 상세 조회")
+    @GetMapping("/{itemId}")
+    ApiResponse<GoodsDetailResponse> findById(@PathVariable Long itemId);
+
+    @Operation(summary = "일반상품 목록 조회", description = "커서 기반 페이징")
+    @GetMapping
+    ApiResponse<List<GoodsDetailResponse>> findList(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/category/Category.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/category/Category.java
@@ -1,0 +1,56 @@
+package com.example.product.domain.category;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "categories")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(name = "depth", nullable = false)
+    private Integer depth;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    public static Category createRoot(String name, int sortOrder) {
+        Category category = new Category();
+        category.name = name;
+        category.parentId = null;
+        category.depth = 0;
+        category.sortOrder = sortOrder;
+        return category;
+    }
+
+    public static Category createChild(String name, Long parentId, int parentDepth, int sortOrder) {
+        Category category = new Category();
+        category.name = name;
+        category.parentId = parentId;
+        category.depth = parentDepth + 1;
+        category.sortOrder = sortOrder;
+        return category;
+    }
+
+    public void update(String name, int sortOrder) {
+        this.name = name;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/category/CategoryRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/category/CategoryRepository.java
@@ -1,0 +1,16 @@
+package com.example.product.domain.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findByParentIdOrderBySortOrder(Long parentId);
+
+    List<Category> findByParentIdIsNullOrderBySortOrder();
+
+    List<Category> findAllByOrderByDepthAscSortOrderAsc();
+
+    boolean existsByParentId(Long parentId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ItemGoodsLink.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ItemGoodsLink.java
@@ -1,0 +1,34 @@
+package com.example.product.domain.goods;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "item_goods_links", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"performance_item_id", "goods_item_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemGoodsLink extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "performance_item_id", nullable = false)
+    private Long performanceItemId;
+
+    @Column(name = "goods_item_id", nullable = false)
+    private Long goodsItemId;
+
+    public static ItemGoodsLink create(Long performanceItemId, Long goodsItemId) {
+        ItemGoodsLink link = new ItemGoodsLink();
+        link.performanceItemId = performanceItemId;
+        link.goodsItemId = goodsItemId;
+        return link;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ItemGoodsLinkRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ItemGoodsLinkRepository.java
@@ -1,0 +1,14 @@
+package com.example.product.domain.goods;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemGoodsLinkRepository extends JpaRepository<ItemGoodsLink, Long> {
+
+    List<ItemGoodsLink> findByPerformanceItemId(Long performanceItemId);
+
+    List<ItemGoodsLink> findByGoodsItemId(Long goodsItemId);
+
+    void deleteAllByGoodsItemId(Long goodsItemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ItemOption.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ItemOption.java
@@ -1,0 +1,48 @@
+package com.example.product.domain.goods;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "item_options")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemOption extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "option_name", nullable = false, length = 100)
+    private String optionName;
+
+    @Column(name = "additional_price", nullable = false)
+    private Long additionalPrice;
+
+    @Column(name = "stock_quantity", nullable = false)
+    private Integer stockQuantity;
+
+    public static ItemOption create(Long itemId, String optionName, Long additionalPrice, int stockQuantity) {
+        ItemOption opt = new ItemOption();
+        opt.itemId = itemId;
+        opt.optionName = optionName;
+        opt.additionalPrice = additionalPrice;
+        opt.stockQuantity = stockQuantity;
+        return opt;
+    }
+
+    public void update(String optionName, Long additionalPrice, int stockQuantity) {
+        this.optionName = optionName;
+        this.additionalPrice = additionalPrice;
+        this.stockQuantity = stockQuantity;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ItemOptionRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ItemOptionRepository.java
@@ -1,0 +1,12 @@
+package com.example.product.domain.goods;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemOptionRepository extends JpaRepository<ItemOption, Long> {
+
+    List<ItemOption> findByItemId(Long itemId);
+
+    void deleteAllByItemId(Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ShippingInfo.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ShippingInfo.java
@@ -1,0 +1,52 @@
+package com.example.product.domain.goods;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "shipping_infos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShippingInfo extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false, unique = true)
+    private Long itemId;
+
+    @Column(name = "shipping_fee", nullable = false)
+    private Long shippingFee;
+
+    @Column(name = "free_shipping_threshold")
+    private Long freeShippingThreshold;
+
+    @Column(name = "estimated_days", nullable = false)
+    private Integer estimatedDays;
+
+    @Column(name = "return_policy", columnDefinition = "TEXT")
+    private String returnPolicy;
+
+    public static ShippingInfo create(Long itemId, Long shippingFee, Long freeShippingThreshold,
+                                      int estimatedDays, String returnPolicy) {
+        ShippingInfo si = new ShippingInfo();
+        si.itemId = itemId;
+        si.shippingFee = shippingFee;
+        si.freeShippingThreshold = freeShippingThreshold;
+        si.estimatedDays = estimatedDays;
+        si.returnPolicy = returnPolicy;
+        return si;
+    }
+
+    public void update(Long shippingFee, Long freeShippingThreshold, int estimatedDays, String returnPolicy) {
+        this.shippingFee = shippingFee;
+        this.freeShippingThreshold = freeShippingThreshold;
+        this.estimatedDays = estimatedDays;
+        this.returnPolicy = returnPolicy;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/goods/ShippingInfoRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/goods/ShippingInfoRepository.java
@@ -1,0 +1,10 @@
+package com.example.product.domain.goods;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ShippingInfoRepository extends JpaRepository<ShippingInfo, Long> {
+
+    Optional<ShippingInfo> findByItemId(Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/image/ItemImage.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/image/ItemImage.java
@@ -1,0 +1,50 @@
+package com.example.product.domain.image;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "item_images")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemImage extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Column(name = "is_thumbnail", nullable = false)
+    private Boolean isThumbnail;
+
+    public static ItemImage create(Long itemId, String imageUrl, int sortOrder, boolean isThumbnail) {
+        ItemImage img = new ItemImage();
+        img.itemId = itemId;
+        img.imageUrl = imageUrl;
+        img.sortOrder = sortOrder;
+        img.isThumbnail = isThumbnail;
+        return img;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public void setThumbnail(boolean isThumbnail) {
+        this.isThumbnail = isThumbnail;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/image/ItemImageRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/image/ItemImageRepository.java
@@ -1,0 +1,10 @@
+package com.example.product.domain.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+
+    List<ItemImage> findByItemIdOrderBySortOrder(Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/Item.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/Item.java
@@ -1,0 +1,78 @@
+package com.example.product.domain.item;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "items")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Item extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "item_type", nullable = false, length = 20)
+    private ItemType itemType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ItemStatus status;
+
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    public static Item create(String title, String description, Long price,
+                              ItemType itemType, Long categoryId, Long sellerId, String thumbnailUrl) {
+        Item item = new Item();
+        item.title = title;
+        item.description = description;
+        item.price = price;
+        item.itemType = itemType;
+        item.status = ItemStatus.DRAFT;
+        item.categoryId = categoryId;
+        item.sellerId = sellerId;
+        item.thumbnailUrl = thumbnailUrl;
+        return item;
+    }
+
+    public void update(String title, String description, Long price, Long categoryId, String thumbnailUrl) {
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.categoryId = categoryId;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void changeStatus(ItemStatus newStatus) {
+        this.status.validateTransitionTo(newStatus);
+        this.status = newStatus;
+    }
+
+    public boolean isOwnedBy(Long sellerId) {
+        return this.sellerId.equals(sellerId);
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemRepository.java
@@ -1,0 +1,23 @@
+package com.example.product.domain.item;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findByItemTypeOrderByIdDesc(ItemType itemType, Pageable pageable);
+
+    @Query("SELECT i FROM Item i WHERE i.itemType = :type AND i.id < :cursor ORDER BY i.id DESC")
+    List<Item> findByItemTypeAndIdLessThan(@Param("type") ItemType type, @Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("SELECT i FROM Item i WHERE i.id < :cursor ORDER BY i.id DESC")
+    List<Item> findByIdLessThan(@Param("cursor") Long cursor, Pageable pageable);
+
+    List<Item> findBySellerIdOrderByIdDesc(Long sellerId, Pageable pageable);
+
+    List<Item> findByCategoryIdOrderByIdDesc(Long categoryId, Pageable pageable);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatus.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatus.java
@@ -1,0 +1,28 @@
+package com.example.product.domain.item;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.exception.ProductErrorCode;
+
+import java.util.Set;
+import java.util.Map;
+
+public enum ItemStatus {
+    DRAFT,
+    ACTIVE,
+    HIDDEN,
+    SOLD_OUT;
+
+    private static final Map<ItemStatus, Set<ItemStatus>> TRANSITIONS = Map.of(
+            DRAFT, Set.of(ACTIVE, HIDDEN),
+            ACTIVE, Set.of(HIDDEN, SOLD_OUT),
+            HIDDEN, Set.of(ACTIVE),
+            SOLD_OUT, Set.of(ACTIVE)
+    );
+
+    public void validateTransitionTo(ItemStatus target) {
+        Set<ItemStatus> allowed = TRANSITIONS.getOrDefault(this, Set.of());
+        if (!allowed.contains(target)) {
+            throw new BusinessException(ProductErrorCode.INVALID_ITEM_STATUS_TRANSITION);
+        }
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatus.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatus.java
@@ -3,20 +3,30 @@ package com.example.product.domain.item;
 import com.example.core.exception.BusinessException;
 import com.example.product.exception.ProductErrorCode;
 
-import java.util.Set;
 import java.util.Map;
+import java.util.Set;
 
 public enum ItemStatus {
     DRAFT,
-    ACTIVE,
+    FUNDING,
+    FUNDED,
+    FUND_FAILED,
+    ON_SALE,
+    HOT_DEAL,
     HIDDEN,
-    SOLD_OUT;
+    SOLD_OUT,
+    CLOSED;
 
     private static final Map<ItemStatus, Set<ItemStatus>> TRANSITIONS = Map.of(
-            DRAFT, Set.of(ACTIVE, HIDDEN),
-            ACTIVE, Set.of(HIDDEN, SOLD_OUT),
-            HIDDEN, Set.of(ACTIVE),
-            SOLD_OUT, Set.of(ACTIVE)
+            DRAFT, Set.of(FUNDING, ON_SALE, HIDDEN),
+            FUNDING, Set.of(FUNDED, FUND_FAILED),
+            FUNDED, Set.of(ON_SALE),
+            FUND_FAILED, Set.of(DRAFT, CLOSED),
+            ON_SALE, Set.of(HOT_DEAL, HIDDEN, SOLD_OUT, CLOSED),
+            HOT_DEAL, Set.of(ON_SALE, SOLD_OUT, CLOSED),
+            HIDDEN, Set.of(ON_SALE, CLOSED),
+            SOLD_OUT, Set.of(ON_SALE, CLOSED),
+            CLOSED, Set.of()
     );
 
     public void validateTransitionTo(ItemStatus target) {
@@ -24,5 +34,9 @@ public enum ItemStatus {
         if (!allowed.contains(target)) {
             throw new BusinessException(ProductErrorCode.INVALID_ITEM_STATUS_TRANSITION);
         }
+    }
+
+    public boolean canTransitionTo(ItemStatus target) {
+        return TRANSITIONS.getOrDefault(this, Set.of()).contains(target);
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatusHistory.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatusHistory.java
@@ -1,0 +1,47 @@
+package com.example.product.domain.item;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "item_status_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemStatusHistory extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", nullable = false, length = 20)
+    private ItemStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "new_status", nullable = false, length = 20)
+    private ItemStatus newStatus;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Column(name = "changed_by")
+    private Long changedBy;
+
+    public static ItemStatusHistory create(Long itemId, ItemStatus previousStatus,
+                                           ItemStatus newStatus, String reason, Long changedBy) {
+        ItemStatusHistory h = new ItemStatusHistory();
+        h.itemId = itemId;
+        h.previousStatus = previousStatus;
+        h.newStatus = newStatus;
+        h.reason = reason;
+        h.changedBy = changedBy;
+        return h;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatusHistoryRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemStatusHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.product.domain.item;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemStatusHistoryRepository extends JpaRepository<ItemStatusHistory, Long> {
+
+    List<ItemStatusHistory> findByItemIdOrderByCreatedAtDesc(Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/item/ItemType.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/item/ItemType.java
@@ -1,0 +1,7 @@
+package com.example.product.domain.item;
+
+public enum ItemType {
+    PERFORMANCE,
+    GOODS,
+    PRODUCT
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/CastMember.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/CastMember.java
@@ -1,0 +1,48 @@
+package com.example.product.domain.performance;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "cast_members")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CastMember extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "performance_id", nullable = false)
+    private Long performanceId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "role", length = 100)
+    private String role;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    public static CastMember create(Long performanceId, String name, String role, String profileImageUrl) {
+        CastMember cm = new CastMember();
+        cm.performanceId = performanceId;
+        cm.name = name;
+        cm.role = role;
+        cm.profileImageUrl = profileImageUrl;
+        return cm;
+    }
+
+    public void update(String name, String role, String profileImageUrl) {
+        this.name = name;
+        this.role = role;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/CastMemberRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/CastMemberRepository.java
@@ -1,0 +1,12 @@
+package com.example.product.domain.performance;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CastMemberRepository extends JpaRepository<CastMember, Long> {
+
+    List<CastMember> findByPerformanceId(Long performanceId);
+
+    void deleteAllByPerformanceId(Long performanceId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/Performance.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/Performance.java
@@ -1,0 +1,57 @@
+package com.example.product.domain.performance;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "performances")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Performance extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "venue", nullable = false, length = 200)
+    private String venue;
+
+    @Column(name = "performance_date", nullable = false)
+    private LocalDate performanceDate;
+
+    @Column(name = "performance_time", nullable = false)
+    private LocalTime performanceTime;
+
+    @Column(name = "total_seats", nullable = false)
+    private Integer totalSeats;
+
+    public static Performance create(Long itemId, String venue, LocalDate performanceDate,
+                                     LocalTime performanceTime, int totalSeats) {
+        Performance p = new Performance();
+        p.itemId = itemId;
+        p.venue = venue;
+        p.performanceDate = performanceDate;
+        p.performanceTime = performanceTime;
+        p.totalSeats = totalSeats;
+        return p;
+    }
+
+    public void update(String venue, LocalDate performanceDate, LocalTime performanceTime, int totalSeats) {
+        this.venue = venue;
+        this.performanceDate = performanceDate;
+        this.performanceTime = performanceTime;
+        this.totalSeats = totalSeats;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/PerformanceRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/PerformanceRepository.java
@@ -1,0 +1,10 @@
+package com.example.product.domain.performance;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+
+    Optional<Performance> findByItemId(Long itemId);
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/SeatGrade.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/SeatGrade.java
@@ -1,0 +1,54 @@
+package com.example.product.domain.performance;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "seat_grades")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatGrade extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "performance_id", nullable = false)
+    private Long performanceId;
+
+    @Column(name = "grade_name", nullable = false, length = 50)
+    private String gradeName;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "total_quantity", nullable = false)
+    private Integer totalQuantity;
+
+    @Column(name = "funding_quantity", nullable = false)
+    private Integer fundingQuantity;
+
+    public static SeatGrade create(Long performanceId, String gradeName, Long price,
+                                   int totalQuantity, int fundingQuantity) {
+        SeatGrade sg = new SeatGrade();
+        sg.performanceId = performanceId;
+        sg.gradeName = gradeName;
+        sg.price = price;
+        sg.totalQuantity = totalQuantity;
+        sg.fundingQuantity = fundingQuantity;
+        return sg;
+    }
+
+    public void update(String gradeName, Long price, int totalQuantity, int fundingQuantity) {
+        this.gradeName = gradeName;
+        this.price = price;
+        this.totalQuantity = totalQuantity;
+        this.fundingQuantity = fundingQuantity;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/domain/performance/SeatGradeRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/domain/performance/SeatGradeRepository.java
@@ -1,0 +1,12 @@
+package com.example.product.domain.performance;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SeatGradeRepository extends JpaRepository<SeatGrade, Long> {
+
+    List<SeatGrade> findByPerformanceIdOrderByPriceDesc(Long performanceId);
+
+    void deleteAllByPerformanceId(Long performanceId);
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/category/CategoryCreateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/category/CategoryCreateRequest.java
@@ -1,0 +1,19 @@
+package com.example.product.dto.category;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryCreateRequest {
+
+    @NotBlank(message = "카테고리 이름은 필수입니다")
+    @Size(max = 100, message = "카테고리 이름은 100자 이하여야 합니다")
+    private String name;
+
+    private Long parentId;
+
+    private int sortOrder;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/category/CategoryResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/category/CategoryResponse.java
@@ -1,0 +1,38 @@
+package com.example.product.dto.category;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.category.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CategoryResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String name;
+
+    @SnowflakeId
+    private Long parentId;
+
+    private Integer depth;
+    private Integer sortOrder;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CategoryResponse from(Category entity) {
+        return CategoryResponse.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .parentId(entity.getParentId())
+                .depth(entity.getDepth())
+                .sortOrder(entity.getSortOrder())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/category/CategoryTreeResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/category/CategoryTreeResponse.java
@@ -1,0 +1,34 @@
+package com.example.product.dto.category;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.category.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+public class CategoryTreeResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String name;
+    private Integer depth;
+    private Integer sortOrder;
+
+    @Builder.Default
+    private List<CategoryTreeResponse> children = new ArrayList<>();
+
+    public static CategoryTreeResponse from(Category entity) {
+        return CategoryTreeResponse.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .depth(entity.getDepth())
+                .sortOrder(entity.getSortOrder())
+                .children(new ArrayList<>())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/category/CategoryUpdateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/category/CategoryUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.product.dto.category;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryUpdateRequest {
+
+    @NotBlank(message = "카테고리 이름은 필수입니다")
+    @Size(max = 100, message = "카테고리 이름은 100자 이하여야 합니다")
+    private String name;
+
+    private int sortOrder;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/GoodsCreateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/GoodsCreateRequest.java
@@ -1,0 +1,35 @@
+package com.example.product.dto.goods;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GoodsCreateRequest {
+
+    @NotBlank(message = "굿즈 제목은 필수입니다")
+    @Size(max = 200)
+    private String title;
+
+    private String description;
+
+    @NotNull(message = "가격은 필수입니다")
+    @Min(value = 0)
+    private Long price;
+
+    private Long categoryId;
+
+    private String thumbnailUrl;
+
+    private List<Long> linkedPerformanceItemIds;
+
+    @Valid
+    private List<ItemOptionRequest> options;
+
+    @Valid
+    private ShippingInfoRequest shippingInfo;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/GoodsDetailResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/GoodsDetailResponse.java
@@ -1,0 +1,59 @@
+package com.example.product.dto.goods;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.goods.ItemOption;
+import com.example.product.domain.goods.ShippingInfo;
+import com.example.product.domain.item.Item;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GoodsDetailResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String title;
+    private String description;
+    private Long price;
+    private String status;
+    private String itemType;
+    private String thumbnailUrl;
+
+    @SnowflakeId
+    private Long categoryId;
+
+    @SnowflakeId
+    private Long sellerId;
+
+    private List<ItemOptionResponse> options;
+    private ShippingInfoResponse shippingInfo;
+    private List<Long> linkedPerformanceItemIds;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static GoodsDetailResponse of(Item item, List<ItemOption> options,
+                                         ShippingInfo shippingInfo, List<Long> linkedIds) {
+        return GoodsDetailResponse.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .description(item.getDescription())
+                .price(item.getPrice())
+                .status(item.getStatus().name())
+                .itemType(item.getItemType().name())
+                .thumbnailUrl(item.getThumbnailUrl())
+                .categoryId(item.getCategoryId())
+                .sellerId(item.getSellerId())
+                .options(options.stream().map(ItemOptionResponse::from).toList())
+                .shippingInfo(shippingInfo != null ? ShippingInfoResponse.from(shippingInfo) : null)
+                .linkedPerformanceItemIds(linkedIds)
+                .createdAt(item.getCreatedAt())
+                .updatedAt(item.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/ItemOptionRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/ItemOptionRequest.java
@@ -1,0 +1,22 @@
+package com.example.product.dto.goods;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItemOptionRequest {
+
+    @NotBlank(message = "옵션명은 필수입니다")
+    private String optionName;
+
+    @NotNull(message = "추가금액은 필수입니다")
+    @Min(value = 0, message = "추가금액은 0 이상이어야 합니다")
+    private Long additionalPrice;
+
+    @Min(value = 0, message = "재고수량은 0 이상이어야 합니다")
+    private int stockQuantity;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/ItemOptionResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/ItemOptionResponse.java
@@ -1,0 +1,27 @@
+package com.example.product.dto.goods;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.goods.ItemOption;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemOptionResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String optionName;
+    private Long additionalPrice;
+    private Integer stockQuantity;
+
+    public static ItemOptionResponse from(ItemOption entity) {
+        return ItemOptionResponse.builder()
+                .id(entity.getId())
+                .optionName(entity.getOptionName())
+                .additionalPrice(entity.getAdditionalPrice())
+                .stockQuantity(entity.getStockQuantity())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/ProductCreateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/ProductCreateRequest.java
@@ -1,0 +1,34 @@
+package com.example.product.dto.goods;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ProductCreateRequest {
+
+    @NotBlank(message = "상품 제목은 필수입니다")
+    @Size(max = 200)
+    private String title;
+
+    private String description;
+
+    @NotNull(message = "가격은 필수입니다")
+    @Min(value = 0)
+    private Long price;
+
+    private Long categoryId;
+
+    private String thumbnailUrl;
+
+    @Valid
+    private List<ItemOptionRequest> options;
+
+    @NotNull(message = "배송 정보는 필수입니다")
+    @Valid
+    private ShippingInfoRequest shippingInfo;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/ShippingInfoRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/ShippingInfoRequest.java
@@ -1,0 +1,22 @@
+package com.example.product.dto.goods;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ShippingInfoRequest {
+
+    @NotNull(message = "배송비는 필수입니다")
+    @Min(value = 0, message = "배송비는 0 이상이어야 합니다")
+    private Long shippingFee;
+
+    private Long freeShippingThreshold;
+
+    @Min(value = 1, message = "예상 배송일은 1일 이상이어야 합니다")
+    private int estimatedDays;
+
+    private String returnPolicy;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/goods/ShippingInfoResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/goods/ShippingInfoResponse.java
@@ -1,0 +1,24 @@
+package com.example.product.dto.goods;
+
+import com.example.product.domain.goods.ShippingInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShippingInfoResponse {
+
+    private Long shippingFee;
+    private Long freeShippingThreshold;
+    private Integer estimatedDays;
+    private String returnPolicy;
+
+    public static ShippingInfoResponse from(ShippingInfo entity) {
+        return ShippingInfoResponse.builder()
+                .shippingFee(entity.getShippingFee())
+                .freeShippingThreshold(entity.getFreeShippingThreshold())
+                .estimatedDays(entity.getEstimatedDays())
+                .returnPolicy(entity.getReturnPolicy())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/image/ItemImageRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/image/ItemImageRequest.java
@@ -1,0 +1,16 @@
+package com.example.product.dto.image;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItemImageRequest {
+
+    @NotBlank(message = "이미지 URL은 필수입니다")
+    private String imageUrl;
+
+    private int sortOrder;
+    private boolean isThumbnail;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/image/ItemImageResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/image/ItemImageResponse.java
@@ -1,0 +1,27 @@
+package com.example.product.dto.image;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.image.ItemImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemImageResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String imageUrl;
+    private Integer sortOrder;
+    private Boolean isThumbnail;
+
+    public static ItemImageResponse from(ItemImage entity) {
+        return ItemImageResponse.builder()
+                .id(entity.getId())
+                .imageUrl(entity.getImageUrl())
+                .sortOrder(entity.getSortOrder())
+                .isThumbnail(entity.getIsThumbnail())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/item/ItemSummaryResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/item/ItemSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.example.product.dto.item;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.item.Item;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemSummaryResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String title;
+    private Long price;
+    private String itemType;
+    private String status;
+    private String thumbnailUrl;
+
+    @SnowflakeId
+    private Long sellerId;
+
+    public static ItemSummaryResponse from(Item entity) {
+        return ItemSummaryResponse.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .price(entity.getPrice())
+                .itemType(entity.getItemType().name())
+                .status(entity.getStatus().name())
+                .thumbnailUrl(entity.getThumbnailUrl())
+                .sellerId(entity.getSellerId())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/item/StatusChangeRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/item/StatusChangeRequest.java
@@ -1,0 +1,15 @@
+package com.example.product.dto.item;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StatusChangeRequest {
+
+    @NotNull(message = "변경할 상태는 필수입니다")
+    private String status;
+
+    private String reason;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/item/StatusHistoryResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/item/StatusHistoryResponse.java
@@ -1,0 +1,40 @@
+package com.example.product.dto.item;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.item.ItemStatusHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StatusHistoryResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    @SnowflakeId
+    private Long itemId;
+
+    private String previousStatus;
+    private String newStatus;
+    private String reason;
+
+    @SnowflakeId
+    private Long changedBy;
+
+    private LocalDateTime createdAt;
+
+    public static StatusHistoryResponse from(ItemStatusHistory entity) {
+        return StatusHistoryResponse.builder()
+                .id(entity.getId())
+                .itemId(entity.getItemId())
+                .previousStatus(entity.getPreviousStatus().name())
+                .newStatus(entity.getNewStatus().name())
+                .reason(entity.getReason())
+                .changedBy(entity.getChangedBy())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/CastMemberRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/CastMemberRequest.java
@@ -1,0 +1,17 @@
+package com.example.product.dto.performance;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CastMemberRequest {
+
+    @NotBlank(message = "출연진 이름은 필수입니다")
+    private String name;
+
+    private String role;
+
+    private String profileImageUrl;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/CastMemberResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/CastMemberResponse.java
@@ -1,0 +1,27 @@
+package com.example.product.dto.performance;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.performance.CastMember;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CastMemberResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String name;
+    private String role;
+    private String profileImageUrl;
+
+    public static CastMemberResponse from(CastMember entity) {
+        return CastMemberResponse.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .role(entity.getRole())
+                .profileImageUrl(entity.getProfileImageUrl())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceCreateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceCreateRequest.java
@@ -1,0 +1,48 @@
+package com.example.product.dto.performance;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PerformanceCreateRequest {
+
+    @NotBlank(message = "공연 제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+    private String title;
+
+    private String description;
+
+    @NotNull(message = "가격은 필수입니다")
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다")
+    private Long price;
+
+    private Long categoryId;
+
+    private String thumbnailUrl;
+
+    @NotBlank(message = "공연장소는 필수입니다")
+    private String venue;
+
+    @NotNull(message = "공연 날짜는 필수입니다")
+    private LocalDate performanceDate;
+
+    @NotNull(message = "공연 시간은 필수입니다")
+    private LocalTime performanceTime;
+
+    @Min(value = 1, message = "총 좌석 수는 1 이상이어야 합니다")
+    private int totalSeats;
+
+    @NotEmpty(message = "좌석 등급은 최소 1개 이상 필요합니다")
+    @Valid
+    private List<SeatGradeRequest> seatGrades;
+
+    @Valid
+    private List<CastMemberRequest> castMembers;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceDetailResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceDetailResponse.java
@@ -1,0 +1,68 @@
+package com.example.product.dto.performance;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.performance.CastMember;
+import com.example.product.domain.performance.Performance;
+import com.example.product.domain.performance.SeatGrade;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PerformanceDetailResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String title;
+    private String description;
+    private Long price;
+    private String status;
+    private String thumbnailUrl;
+
+    @SnowflakeId
+    private Long categoryId;
+
+    @SnowflakeId
+    private Long sellerId;
+
+    private String venue;
+    private LocalDate performanceDate;
+    private LocalTime performanceTime;
+    private Integer totalSeats;
+
+    private List<SeatGradeResponse> seatGrades;
+    private List<CastMemberResponse> castMembers;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PerformanceDetailResponse of(Item item, Performance perf,
+                                               List<SeatGrade> seatGrades,
+                                               List<CastMember> castMembers) {
+        return PerformanceDetailResponse.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .description(item.getDescription())
+                .price(item.getPrice())
+                .status(item.getStatus().name())
+                .thumbnailUrl(item.getThumbnailUrl())
+                .categoryId(item.getCategoryId())
+                .sellerId(item.getSellerId())
+                .venue(perf.getVenue())
+                .performanceDate(perf.getPerformanceDate())
+                .performanceTime(perf.getPerformanceTime())
+                .totalSeats(perf.getTotalSeats())
+                .seatGrades(seatGrades.stream().map(SeatGradeResponse::from).toList())
+                .castMembers(castMembers.stream().map(CastMemberResponse::from).toList())
+                .createdAt(item.getCreatedAt())
+                .updatedAt(item.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceListResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceListResponse.java
@@ -1,0 +1,44 @@
+package com.example.product.dto.performance;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.performance.Performance;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class PerformanceListResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String title;
+    private Long price;
+    private String status;
+    private String thumbnailUrl;
+    private String venue;
+    private LocalDate performanceDate;
+    private LocalTime performanceTime;
+    private Integer totalSeats;
+    private LocalDateTime createdAt;
+
+    public static PerformanceListResponse of(Item item, Performance perf) {
+        return PerformanceListResponse.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .price(item.getPrice())
+                .status(item.getStatus().name())
+                .thumbnailUrl(item.getThumbnailUrl())
+                .venue(perf.getVenue())
+                .performanceDate(perf.getPerformanceDate())
+                .performanceTime(perf.getPerformanceTime())
+                .totalSeats(perf.getTotalSeats())
+                .createdAt(item.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceUpdateRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/PerformanceUpdateRequest.java
@@ -1,0 +1,47 @@
+package com.example.product.dto.performance;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PerformanceUpdateRequest {
+
+    @NotBlank(message = "공연 제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+    private String title;
+
+    private String description;
+
+    @NotNull(message = "가격은 필수입니다")
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다")
+    private Long price;
+
+    private Long categoryId;
+
+    private String thumbnailUrl;
+
+    @NotBlank(message = "공연장소는 필수입니다")
+    private String venue;
+
+    @NotNull(message = "공연 날짜는 필수입니다")
+    private LocalDate performanceDate;
+
+    @NotNull(message = "공연 시간은 필수입니다")
+    private LocalTime performanceTime;
+
+    @Min(value = 1, message = "총 좌석 수는 1 이상이어야 합니다")
+    private int totalSeats;
+
+    @Valid
+    private List<SeatGradeRequest> seatGrades;
+
+    @Valid
+    private List<CastMemberRequest> castMembers;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/SeatGradeRequest.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/SeatGradeRequest.java
@@ -1,0 +1,25 @@
+package com.example.product.dto.performance;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SeatGradeRequest {
+
+    @NotBlank(message = "좌석 등급명은 필수입니다")
+    private String gradeName;
+
+    @NotNull(message = "가격은 필수입니다")
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다")
+    private Long price;
+
+    @Min(value = 1, message = "총 수량은 1 이상이어야 합니다")
+    private int totalQuantity;
+
+    @Min(value = 0, message = "펀딩 수량은 0 이상이어야 합니다")
+    private int fundingQuantity;
+}

--- a/servers/services/product/src/main/java/com/example/product/dto/performance/SeatGradeResponse.java
+++ b/servers/services/product/src/main/java/com/example/product/dto/performance/SeatGradeResponse.java
@@ -1,0 +1,29 @@
+package com.example.product.dto.performance;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.product.domain.performance.SeatGrade;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SeatGradeResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String gradeName;
+    private Long price;
+    private Integer totalQuantity;
+    private Integer fundingQuantity;
+
+    public static SeatGradeResponse from(SeatGrade entity) {
+        return SeatGradeResponse.builder()
+                .id(entity.getId())
+                .gradeName(entity.getGradeName())
+                .price(entity.getPrice())
+                .totalQuantity(entity.getTotalQuantity())
+                .fundingQuantity(entity.getFundingQuantity())
+                .build();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
+++ b/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
@@ -1,0 +1,38 @@
+package com.example.product.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ItemCreatedEvent extends DomainEvent {
+
+    private final Long itemId;
+    private final String title;
+    private final String itemType;
+    private final Long sellerId;
+
+    public ItemCreatedEvent(Long itemId, String title, String itemType, Long sellerId) {
+        super("item-events");
+        this.itemId = itemId;
+        this.title = title;
+        this.itemType = itemType;
+        this.sellerId = sellerId;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ITEM_CREATED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "itemId", itemId,
+                "title", title,
+                "itemType", itemType,
+                "sellerId", sellerId
+        );
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/event/ItemStatusChangedEvent.java
+++ b/servers/services/product/src/main/java/com/example/product/event/ItemStatusChangedEvent.java
@@ -1,0 +1,35 @@
+package com.example.product.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ItemStatusChangedEvent extends DomainEvent {
+
+    private final Long itemId;
+    private final String previousStatus;
+    private final String newStatus;
+
+    public ItemStatusChangedEvent(Long itemId, String previousStatus, String newStatus) {
+        super("item-events");
+        this.itemId = itemId;
+        this.previousStatus = previousStatus;
+        this.newStatus = newStatus;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ITEM_STATUS_CHANGED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "itemId", itemId,
+                "previousStatus", previousStatus,
+                "newStatus", newStatus
+        );
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/event/ItemUpdatedEvent.java
+++ b/servers/services/product/src/main/java/com/example/product/event/ItemUpdatedEvent.java
@@ -1,0 +1,35 @@
+package com.example.product.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ItemUpdatedEvent extends DomainEvent {
+
+    private final Long itemId;
+    private final String title;
+    private final Long price;
+
+    public ItemUpdatedEvent(Long itemId, String title, Long price) {
+        super("item-events");
+        this.itemId = itemId;
+        this.title = title;
+        this.price = price;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ITEM_UPDATED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "itemId", itemId,
+                "title", title,
+                "price", price
+        );
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
+++ b/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
@@ -1,0 +1,42 @@
+package com.example.product.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements DomainErrorCode {
+
+    // Item
+    ITEM_NOT_FOUND("PRODUCT-001", "상품을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    ITEM_ALREADY_EXISTS("PRODUCT-002", "이미 존재하는 상품입니다", HttpStatus.CONFLICT),
+    INVALID_ITEM_STATUS_TRANSITION("PRODUCT-003", "유효하지 않은 상품 상태 전이입니다", HttpStatus.BAD_REQUEST),
+    ITEM_NOT_EDITABLE("PRODUCT-004", "수정할 수 없는 상태의 상품입니다", HttpStatus.BAD_REQUEST),
+    ITEM_NOT_DELETABLE("PRODUCT-005", "삭제할 수 없는 상태의 상품입니다", HttpStatus.BAD_REQUEST),
+
+    // Category
+    CATEGORY_NOT_FOUND("PRODUCT-101", "카테고리를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    CATEGORY_DEPTH_EXCEEDED("PRODUCT-102", "카테고리 최대 깊이를 초과했습니다", HttpStatus.BAD_REQUEST),
+    CATEGORY_HAS_CHILDREN("PRODUCT-103", "하위 카테고리가 있어 삭제할 수 없습니다", HttpStatus.CONFLICT),
+
+    // Performance
+    PERFORMANCE_NOT_FOUND("PRODUCT-201", "공연 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    INVALID_PERFORMANCE_DATE("PRODUCT-202", "유효하지 않은 공연 일시입니다", HttpStatus.BAD_REQUEST),
+
+    // Seat Grade
+    SEAT_GRADE_NOT_FOUND("PRODUCT-301", "좌석 등급을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    DUPLICATE_SEAT_GRADE("PRODUCT-302", "중복된 좌석 등급입니다", HttpStatus.CONFLICT),
+
+    // Goods / Product
+    GOODS_NOT_FOUND("PRODUCT-401", "굿즈 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    PRODUCT_OPTION_NOT_FOUND("PRODUCT-501", "상품 옵션을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // Authorization
+    UNAUTHORIZED_ACCESS("PRODUCT-901", "해당 상품에 대한 권한이 없습니다", HttpStatus.FORBIDDEN);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/product/src/main/java/com/example/product/service/CategoryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/CategoryService.java
@@ -1,0 +1,92 @@
+package com.example.product.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.domain.category.Category;
+import com.example.product.domain.category.CategoryRepository;
+import com.example.product.dto.category.CategoryCreateRequest;
+import com.example.product.dto.category.CategoryTreeResponse;
+import com.example.product.dto.category.CategoryUpdateRequest;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Category create(CategoryCreateRequest request) {
+        if (request.getParentId() == null) {
+            return categoryRepository.save(
+                    Category.createRoot(request.getName(), request.getSortOrder()));
+        }
+
+        Category parent = categoryRepository.findById(request.getParentId())
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.CATEGORY_NOT_FOUND));
+
+        if (parent.getDepth() >= 2) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_DEPTH_EXCEEDED);
+        }
+
+        return categoryRepository.save(
+                Category.createChild(request.getName(), parent.getId(), parent.getDepth(), request.getSortOrder()));
+    }
+
+    public Category findById(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    @Transactional
+    public Category update(Long id, CategoryUpdateRequest request) {
+        Category category = findById(id);
+        category.update(request.getName(), request.getSortOrder());
+        return category;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Category category = findById(id);
+
+        if (categoryRepository.existsByParentId(id)) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_HAS_CHILDREN);
+        }
+
+        category.softDelete();
+    }
+
+    public List<CategoryTreeResponse> getTree() {
+        List<Category> all = categoryRepository.findAllByOrderByDepthAscSortOrderAsc();
+        return buildTree(all);
+    }
+
+    private List<CategoryTreeResponse> buildTree(List<Category> categories) {
+        Map<Long, CategoryTreeResponse> nodeMap = new LinkedHashMap<>();
+        List<CategoryTreeResponse> roots = new ArrayList<>();
+
+        for (Category cat : categories) {
+            CategoryTreeResponse node = CategoryTreeResponse.from(cat);
+            nodeMap.put(cat.getId(), node);
+
+            if (cat.getParentId() == null) {
+                roots.add(node);
+            } else {
+                CategoryTreeResponse parent = nodeMap.get(cat.getParentId());
+                if (parent != null) {
+                    parent.getChildren().add(node);
+                }
+            }
+        }
+
+        return roots;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/service/ItemImageService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/ItemImageService.java
@@ -1,0 +1,58 @@
+package com.example.product.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.domain.image.ItemImage;
+import com.example.product.domain.image.ItemImageRepository;
+import com.example.product.dto.image.ItemImageRequest;
+import com.example.product.dto.image.ItemImageResponse;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemImageService {
+
+    private final ItemImageRepository itemImageRepository;
+
+    @Transactional
+    public List<ItemImageResponse> addImages(Long itemId, List<ItemImageRequest> requests) {
+        List<ItemImage> images = requests.stream()
+                .map(req -> ItemImage.create(itemId, req.getImageUrl(), req.getSortOrder(), req.isThumbnail()))
+                .toList();
+        return itemImageRepository.saveAll(images).stream()
+                .map(ItemImageResponse::from).toList();
+    }
+
+    public List<ItemImageResponse> findByItemId(Long itemId) {
+        return itemImageRepository.findByItemIdOrderBySortOrder(itemId).stream()
+                .map(ItemImageResponse::from).toList();
+    }
+
+    @Transactional
+    public void deleteImage(Long imageId) {
+        ItemImage image = itemImageRepository.findById(imageId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        image.softDelete();
+    }
+
+    @Transactional
+    public List<ItemImageResponse> reorder(Long itemId, List<Long> imageIds) {
+        List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
+        for (int i = 0; i < imageIds.size(); i++) {
+            Long targetId = imageIds.get(i);
+            for (ItemImage img : images) {
+                if (img.getId().equals(targetId)) {
+                    img.updateSortOrder(i);
+                    break;
+                }
+            }
+        }
+        return images.stream().sorted((a, b) -> a.getSortOrder() - b.getSortOrder())
+                .map(ItemImageResponse::from).toList();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/service/ItemService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/ItemService.java
@@ -1,0 +1,136 @@
+package com.example.product.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.domain.goods.*;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.item.ItemRepository;
+import com.example.product.domain.item.ItemType;
+import com.example.product.dto.goods.*;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+    private final ItemOptionRepository itemOptionRepository;
+    private final ShippingInfoRepository shippingInfoRepository;
+    private final ItemGoodsLinkRepository itemGoodsLinkRepository;
+
+    // ─── 굿즈 ─────────────────────────────────────────────
+
+    @Transactional
+    public GoodsDetailResponse createGoods(GoodsCreateRequest request, Long sellerId) {
+        Item item = Item.create(
+                request.getTitle(), request.getDescription(), request.getPrice(),
+                ItemType.GOODS, request.getCategoryId(), sellerId, request.getThumbnailUrl());
+        itemRepository.save(item);
+
+        List<ItemOption> options = saveOptions(item.getId(), request.getOptions());
+
+        ShippingInfo shippingInfo = null;
+        if (request.getShippingInfo() != null) {
+            shippingInfo = saveShippingInfo(item.getId(), request.getShippingInfo());
+        }
+
+        List<Long> linkedIds = List.of();
+        if (request.getLinkedPerformanceItemIds() != null) {
+            linkedIds = linkPerformances(item.getId(), request.getLinkedPerformanceItemIds());
+        }
+
+        return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);
+    }
+
+    public GoodsDetailResponse findGoodsById(Long itemId) {
+        Item item = getItem(itemId);
+        List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
+        ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
+        List<Long> linkedIds = itemGoodsLinkRepository.findByGoodsItemId(itemId).stream()
+                .map(ItemGoodsLink::getPerformanceItemId).toList();
+        return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);
+    }
+
+    public List<GoodsDetailResponse> findGoodsList(Long cursor, int size) {
+        PageRequest pageable = PageRequest.of(0, size);
+        List<Item> items = cursor == null
+                ? itemRepository.findByItemTypeOrderByIdDesc(ItemType.GOODS, pageable)
+                : itemRepository.findByItemTypeAndIdLessThan(ItemType.GOODS, cursor, pageable);
+
+        return items.stream().map(item -> {
+            List<ItemOption> options = itemOptionRepository.findByItemId(item.getId());
+            ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(item.getId()).orElse(null);
+            List<Long> linkedIds = itemGoodsLinkRepository.findByGoodsItemId(item.getId()).stream()
+                    .map(ItemGoodsLink::getPerformanceItemId).toList();
+            return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);
+        }).toList();
+    }
+
+    // ─── 일반상품 ─────────────────────────────────────────
+
+    @Transactional
+    public GoodsDetailResponse createProduct(ProductCreateRequest request, Long sellerId) {
+        Item item = Item.create(
+                request.getTitle(), request.getDescription(), request.getPrice(),
+                ItemType.PRODUCT, request.getCategoryId(), sellerId, request.getThumbnailUrl());
+        itemRepository.save(item);
+
+        List<ItemOption> options = saveOptions(item.getId(), request.getOptions());
+        ShippingInfo shippingInfo = saveShippingInfo(item.getId(), request.getShippingInfo());
+
+        return GoodsDetailResponse.of(item, options, shippingInfo, List.of());
+    }
+
+    public GoodsDetailResponse findProductById(Long itemId) {
+        return findGoodsById(itemId);
+    }
+
+    public List<GoodsDetailResponse> findProductList(Long cursor, int size) {
+        PageRequest pageable = PageRequest.of(0, size);
+        List<Item> items = cursor == null
+                ? itemRepository.findByItemTypeOrderByIdDesc(ItemType.PRODUCT, pageable)
+                : itemRepository.findByItemTypeAndIdLessThan(ItemType.PRODUCT, cursor, pageable);
+
+        return items.stream().map(item -> {
+            List<ItemOption> options = itemOptionRepository.findByItemId(item.getId());
+            ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(item.getId()).orElse(null);
+            return GoodsDetailResponse.of(item, options, shippingInfo, List.of());
+        }).toList();
+    }
+
+    // ─── 공통 헬퍼 ────────────────────────────────────────
+
+    private Item getItem(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+    }
+
+    private List<ItemOption> saveOptions(Long itemId, List<ItemOptionRequest> requests) {
+        if (requests == null || requests.isEmpty()) return List.of();
+        List<ItemOption> options = requests.stream()
+                .map(req -> ItemOption.create(itemId, req.getOptionName(),
+                        req.getAdditionalPrice(), req.getStockQuantity()))
+                .toList();
+        return itemOptionRepository.saveAll(options);
+    }
+
+    private ShippingInfo saveShippingInfo(Long itemId, ShippingInfoRequest request) {
+        ShippingInfo si = ShippingInfo.create(itemId, request.getShippingFee(),
+                request.getFreeShippingThreshold(), request.getEstimatedDays(), request.getReturnPolicy());
+        return shippingInfoRepository.save(si);
+    }
+
+    private List<Long> linkPerformances(Long goodsItemId, List<Long> performanceItemIds) {
+        List<ItemGoodsLink> links = performanceItemIds.stream()
+                .map(perfId -> ItemGoodsLink.create(perfId, goodsItemId))
+                .toList();
+        itemGoodsLinkRepository.saveAll(links);
+        return performanceItemIds;
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/service/ItemStatusService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/ItemStatusService.java
@@ -1,0 +1,53 @@
+package com.example.product.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.product.domain.item.*;
+import com.example.product.dto.item.StatusChangeRequest;
+import com.example.product.dto.item.StatusHistoryResponse;
+import com.example.product.event.ItemStatusChangedEvent;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemStatusService {
+
+    private final ItemRepository itemRepository;
+    private final ItemStatusHistoryRepository statusHistoryRepository;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public void changeStatus(Long itemId, StatusChangeRequest request, Long userId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+
+        ItemStatus previousStatus = item.getStatus();
+        ItemStatus newStatus = ItemStatus.valueOf(request.getStatus());
+
+        item.changeStatus(newStatus);
+
+        ItemStatusHistory history = ItemStatusHistory.create(
+                itemId, previousStatus, newStatus, request.getReason(), userId);
+        statusHistoryRepository.save(history);
+
+        ItemStatusChangedEvent event = new ItemStatusChangedEvent(
+                itemId, previousStatus.name(), newStatus.name());
+        eventPublisher.publish(event, EventMetadata.of("Item", String.valueOf(itemId)));
+
+        log.info("[ItemStatus] {} -> {} for item #{}", previousStatus, newStatus, itemId);
+    }
+
+    public List<StatusHistoryResponse> getHistory(Long itemId) {
+        return statusHistoryRepository.findByItemIdOrderByCreatedAtDesc(itemId).stream()
+                .map(StatusHistoryResponse::from).toList();
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/service/PerformanceService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/PerformanceService.java
@@ -1,0 +1,142 @@
+package com.example.product.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.domain.item.Item;
+import com.example.product.domain.item.ItemRepository;
+import com.example.product.domain.item.ItemType;
+import com.example.product.domain.performance.*;
+import com.example.product.dto.performance.*;
+import com.example.product.exception.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PerformanceService {
+
+    private final ItemRepository itemRepository;
+    private final PerformanceRepository performanceRepository;
+    private final SeatGradeRepository seatGradeRepository;
+    private final CastMemberRepository castMemberRepository;
+
+    @Transactional
+    public PerformanceDetailResponse create(PerformanceCreateRequest request, Long sellerId) {
+        Item item = Item.create(
+                request.getTitle(), request.getDescription(), request.getPrice(),
+                ItemType.PERFORMANCE, request.getCategoryId(), sellerId, request.getThumbnailUrl());
+        itemRepository.save(item);
+
+        Performance performance = Performance.create(
+                item.getId(), request.getVenue(), request.getPerformanceDate(),
+                request.getPerformanceTime(), request.getTotalSeats());
+        performanceRepository.save(performance);
+
+        List<SeatGrade> seatGrades = request.getSeatGrades().stream()
+                .map(sg -> SeatGrade.create(performance.getId(), sg.getGradeName(),
+                        sg.getPrice(), sg.getTotalQuantity(), sg.getFundingQuantity()))
+                .toList();
+        seatGradeRepository.saveAll(seatGrades);
+
+        List<CastMember> castMembers = List.of();
+        if (request.getCastMembers() != null && !request.getCastMembers().isEmpty()) {
+            castMembers = request.getCastMembers().stream()
+                    .map(cm -> CastMember.create(performance.getId(), cm.getName(),
+                            cm.getRole(), cm.getProfileImageUrl()))
+                    .toList();
+            castMemberRepository.saveAll(castMembers);
+        }
+
+        return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers);
+    }
+
+    public PerformanceDetailResponse findById(Long itemId) {
+        Item item = getItem(itemId);
+        Performance performance = getPerformance(itemId);
+        List<SeatGrade> seatGrades = seatGradeRepository.findByPerformanceIdOrderByPriceDesc(performance.getId());
+        List<CastMember> castMembers = castMemberRepository.findByPerformanceId(performance.getId());
+        return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers);
+    }
+
+    public List<PerformanceListResponse> findList(Long cursor, int size) {
+        PageRequest pageable = PageRequest.of(0, size);
+        List<Item> items;
+
+        if (cursor == null) {
+            items = itemRepository.findByItemTypeOrderByIdDesc(ItemType.PERFORMANCE, pageable);
+        } else {
+            items = itemRepository.findByItemTypeAndIdLessThan(ItemType.PERFORMANCE, cursor, pageable);
+        }
+
+        return items.stream().map(item -> {
+            Performance perf = performanceRepository.findByItemId(item.getId())
+                    .orElse(null);
+            if (perf == null) return null;
+            return PerformanceListResponse.of(item, perf);
+        }).filter(java.util.Objects::nonNull).toList();
+    }
+
+    @Transactional
+    public PerformanceDetailResponse update(Long itemId, PerformanceUpdateRequest request, Long sellerId) {
+        Item item = getItem(itemId);
+        validateOwnership(item, sellerId);
+
+        item.update(request.getTitle(), request.getDescription(), request.getPrice(),
+                request.getCategoryId(), request.getThumbnailUrl());
+
+        Performance performance = getPerformance(itemId);
+        performance.update(request.getVenue(), request.getPerformanceDate(),
+                request.getPerformanceTime(), request.getTotalSeats());
+
+        // 좌석 등급 교체
+        if (request.getSeatGrades() != null) {
+            seatGradeRepository.deleteAllByPerformanceId(performance.getId());
+            List<SeatGrade> seatGrades = request.getSeatGrades().stream()
+                    .map(sg -> SeatGrade.create(performance.getId(), sg.getGradeName(),
+                            sg.getPrice(), sg.getTotalQuantity(), sg.getFundingQuantity()))
+                    .toList();
+            seatGradeRepository.saveAll(seatGrades);
+        }
+
+        // 출연진 교체
+        if (request.getCastMembers() != null) {
+            castMemberRepository.deleteAllByPerformanceId(performance.getId());
+            List<CastMember> castMembers = request.getCastMembers().stream()
+                    .map(cm -> CastMember.create(performance.getId(), cm.getName(),
+                            cm.getRole(), cm.getProfileImageUrl()))
+                    .toList();
+            castMemberRepository.saveAll(castMembers);
+        }
+
+        List<SeatGrade> seatGrades = seatGradeRepository.findByPerformanceIdOrderByPriceDesc(performance.getId());
+        List<CastMember> castMembers = castMemberRepository.findByPerformanceId(performance.getId());
+        return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers);
+    }
+
+    @Transactional
+    public void delete(Long itemId, Long sellerId) {
+        Item item = getItem(itemId);
+        validateOwnership(item, sellerId);
+        item.softDelete();
+    }
+
+    private Item getItem(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+    }
+
+    private Performance getPerformance(Long itemId) {
+        return performanceRepository.findByItemId(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PERFORMANCE_NOT_FOUND));
+    }
+
+    private void validateOwnership(Item item, Long sellerId) {
+        if (!item.isOwnedBy(sellerId)) {
+            throw new BusinessException(ProductErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+}

--- a/servers/services/product/src/main/resources/application-prod.yml
+++ b/servers/services/product/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+
+app:
+  openapi:
+    enabled: false
+
+logging:
+  level:
+    com.example: INFO

--- a/servers/services/product/src/main/resources/application.yml
+++ b/servers/services/product/src/main/resources/application.yml
@@ -1,0 +1,69 @@
+server:
+  port: ${SERVER_PORT:8084}
+
+spring:
+  application:
+    name: product-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/product_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: product-service-group
+      auto-offset-reset: earliest
+
+# ─── Snowflake ID ────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:4}
+
+  # ─── OpenAPI ──────────────────────────────────
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Product Service API"
+    version: "1.0.0"
+    description: |
+      공연/굿즈/일반상품의 등록, 조회, 상태 관리 서비스
+
+# ─── Actuator ─────────────────────────────────
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics}
+  endpoint:
+    health:
+      show-details: always
+
+# ─── Logging ──────────────────────────────────
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include("servers:gateways:api-gateway")
 // 서비스
 include("servers:services:auth")
 include("servers:services:user")
+include("servers:services:product")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #10
- Closes #17
- Closes #18
- Closes #19
- Closes #20
- Closes #21
- Closes #22
- Closes #23
- Closes #24
- Closes #25
- Closes #26
- Closes #27
- Closes #28
- Closes #29
- Closes #30
- Closes #31
- Closes #32
- Closes #33
- Closes #34
- Closes #35
- Closes #36
- Closes #37
- Closes #38
- Closes #39
- Closes #40
- Closes #41
- Closes #42
- Closes #43
- Closes #44
- Closes #45
- Closes #46
- Closes #47
- Closes #48
- Closes #49
- Closes #50
- Closes #51
- Closes #52
- Closes #53
- Closes #54
- Closes #55
- Closes #56
- Closes #57
- Closes #58
- Closes #59
- Closes #60
- Closes #61
- Closes #62
- Closes #63
- Closes #64
- Closes #65
- Closes #66
- Closes #67
- Closes #69
- Closes #70
- Closes #71
- Closes #72
- Closes #73
- Closes #74
- Closes #75
- Closes #76
- Closes #77
- Closes #78
- Closes #79
- Closes #80
- Closes #81
- Closes #82
- Closes #83

### 작업 / 변경 내용

Product Service의 전체 도메인 모델, API, 이벤트 시스템을 구현했습니다.

**프로젝트 초기 셋업**
- Spring Boot 3.5 기반 Product 서비스 모듈 생성 (build.gradle.kts, application.yml)
- 공통 모듈 15개 연동 (core, api, data, security, config, event, openapi)
- SecurityConfig, JpaConfig, ProductErrorCode 정의

**카테고리 관리 (Category)**
- Adjacency List 기반 트리 구조 엔티티 설계 (parentId, depth, sortOrder)
- CRUD API + 전체 트리 조회 API
- CategoryService, CategoryController, Swagger API 인터페이스

**공연 등록/조회 (Performance)**
- Item (공통 상품) + Performance + SeatGrade + CastMember 엔티티
- 공연 등록/수정/삭제/상세조회/목록조회 API
- 좌석등급별 가격/수량 관리, 출연진 정보 관리

**굿즈/일반상품 등록/조회 (Goods/Product)**
- ItemOption (옵션명, 추가금액), ShippingInfo (배송비, 반품정책), ItemGoodsLink (공연↔굿즈 연결)
- 굿즈/일반상품 등록·조회 API 분리 (GoodsController, ProductItemController)
- 다형성 기반 상품 타입 분기 처리

**이미지 관리 (Image)**
- ItemImage 엔티티 (imageUrl, sortOrder, isThumbnail)
- 이미지 추가/삭제/순서변경 API

**상태 머신 (State Machine)**
- ItemStatus에 상태 전이 규칙 정의 (canTransitionTo)
- ItemStatusHistory 엔티티로 상태 변경 이력 추적
- 상태 변경 API + 이력 조회 API

**도메인 이벤트 발행 (Domain Events)**
- ItemCreatedEvent, ItemUpdatedEvent, ItemStatusChangedEvent 정의
- DomainEvent 확장 + Outbox 패턴 연동
- Service 레이어에서 eventPublisher.publish() 호출

**외부 이벤트 소비 (Event Consumer)**
- FundingEventConsumer — funding-events 토픽 구독
- FundingCompletedEvent → FUNDED 상태 전환, FundingFailedEvent → FUND_FAILED 전환
- IdempotentConsumerService 활용 멱등성 처리

**내부 API (서비스 간 호출)**
- InternalItemController — 상품 정보 단건/다건 조회
- ItemSummaryResponse — 내부 호출용 경량 DTO
- POST /internal/v1/items/batch 배치 조회 API

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 76개 파일, 2833 lines 추가
- [x] 공통 모듈 연동 확인 (BaseEntity, Snowflake ID, Outbox, HMAC 등)
- [x] 도메인 이벤트 Kafka 발행 연동 확인

### 참고사항
- 총 9개 커밋으로 Story 단위 구현 완료
- Stock/Funding/Notification 서비스에서 소비할 이벤트 인터페이스 확정
- 내부 API는 Gateway를 거치지 않는 서비스 간 직접 호출용