### PR TITLE
feat: Stock Service 전체 구현

### DIFF
--- a/libs/config/redis/build.gradle.kts
+++ b/libs/config/redis/build.gradle.kts
@@ -20,6 +20,12 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
+    // Redisson (Distributed Lock)
+    api("org.redisson:redisson:3.37.0")
+
+    // AOP (for @DistributedLock)
+    api("org.springframework.boot:spring-boot-starter-aop")
+
     // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/libs/config/redis/src/main/java/com/example/config/redis/RedissonConfig.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/RedissonConfig.java
@@ -1,0 +1,24 @@
+package com.example.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RedissonClient redissonClient(
+            @Value("${spring.data.redis.host:localhost}") String host,
+            @Value("${spring.data.redis.port:6379}") int port) {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLock.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLock.java
@@ -1,0 +1,31 @@
+package com.example.config.redis.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 분산 락 AOP 어노테이션.
+ * SpEL 기반 동적 락 키를 지원한다.
+ *
+ * 사용 예시:
+ * {@code @DistributedLock(key = "'stock:' + #stockItemId")}
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /** SpEL expression for lock key */
+    String key();
+
+    /** 락 획득 대기 시간 (default 3초) */
+    long waitTime() default 3;
+
+    /** 락 보유 시간 (default 5초, 비즈니스 로직 완료 후 자동 해제) */
+    long leaseTime() default 5;
+
+    /** 시간 단위 */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockAspect.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockAspect.java
@@ -1,0 +1,75 @@
+package com.example.config.redis.lock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(distributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String lockKey = LOCK_PREFIX + parseLockKey(distributedLock.key(), joinPoint);
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(
+                    distributedLock.waitTime(),
+                    distributedLock.leaseTime(),
+                    distributedLock.timeUnit()
+            );
+
+            if (!acquired) {
+                throw new DistributedLockException("락 획득 실패: " + lockKey);
+            }
+
+            log.debug("락 획득 성공: {}", lockKey);
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DistributedLockException("락 획득 중 인터럽트: " + lockKey, e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("락 해제: {}", lockKey);
+            }
+        }
+    }
+
+    private String parseLockKey(String keyExpression, ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        EvaluationContext context = new StandardEvaluationContext();
+
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        if (paramNames != null) {
+            for (int i = 0; i < paramNames.length; i++) {
+                context.setVariable(paramNames[i], args[i]);
+            }
+        }
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockAspect.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockAspect.java
@@ -15,6 +15,8 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Method;
+
 @Slf4j
 @Aspect
 @Component
@@ -27,8 +29,12 @@ public class DistributedLockAspect {
     private final RedissonClient redissonClient;
     private final SpelExpressionParser parser = new SpelExpressionParser();
 
-    @Around("@annotation(distributedLock)")
-    public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+    @Around("@annotation(com.example.config.redis.lock.DistributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
         String lockKey = LOCK_PREFIX + parseLockKey(distributedLock.key(), joinPoint);
         RLock lock = redissonClient.getLock(lockKey);
 

--- a/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockException.java
+++ b/libs/config/redis/src/main/java/com/example/config/redis/lock/DistributedLockException.java
@@ -1,0 +1,12 @@
+package com.example.config.redis.lock;
+
+public class DistributedLockException extends RuntimeException {
+
+    public DistributedLockException(String message) {
+        super(message);
+    }
+
+    public DistributedLockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servers/services/stock/build.gradle.kts
+++ b/servers/services/stock/build.gradle.kts
@@ -1,0 +1,48 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/stock/src/main/java/com/example/stock/StockApplication.java
+++ b/servers/services/stock/src/main/java/com/example/stock/StockApplication.java
@@ -1,0 +1,16 @@
+package com.example.stock;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(scanBasePackages = "com.example")
+@EnableAsync
+@EnableScheduling
+public class StockApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(StockApplication.class, args);
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/config/JpaConfig.java
+++ b/servers/services/stock/src/main/java/com/example/stock/config/JpaConfig.java
@@ -1,9 +1,11 @@
 package com.example.stock.config;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
+@EntityScan(basePackages = "com.example")
 @EnableJpaRepositories(basePackages = "com.example.stock.repository")
 public class JpaConfig {
 }

--- a/servers/services/stock/src/main/java/com/example/stock/config/JpaConfig.java
+++ b/servers/services/stock/src/main/java/com/example/stock/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.example.stock.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.example.stock.repository")
+public class JpaConfig {
+}

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventConsumer.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventConsumer.java
@@ -1,36 +1,47 @@
 package com.example.stock.consumer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ItemEventConsumer {
 
-    private final ObjectMapper objectMapper;
+    private final IdempotentConsumerService idempotentConsumerService;
 
     @KafkaListener(topics = "item-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
     public void consume(String message) {
         try {
-            ItemEventMessage event = objectMapper.readValue(message, ItemEventMessage.class);
-            log.info("아이템 이벤트 수신: type={}, itemId={}", event.getEventType(), event.getItemId());
+            ItemEventMessage event = JsonUtils.fromJson(message, ItemEventMessage.class);
 
-            switch (event.getEventType()) {
-                case "ITEM_CREATED" -> handleItemCreated(event);
-                default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+            if (event.getEventId() == null || event.getEventType() == null) {
+                log.error("[ItemConsumer] eventId 또는 eventType이 null입니다. message={}", message);
+                return;
             }
+
+            idempotentConsumerService.executeIdempotent(event.getEventId(), "ITEM_EVENT", () -> {
+                switch (event.getEventType()) {
+                    case "ITEM_CREATED" -> handleItemCreated(event);
+                    default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+                }
+                return null;
+            });
         } catch (Exception e) {
-            log.error("아이템 이벤트 처리 실패: {}", message, e);
+            log.error("[ItemConsumer] 이벤트 처리 실패: {}", message, e);
+            throw e;
         }
     }
 
     private void handleItemCreated(ItemEventMessage event) {
         // 향후 재고 자동 초기화 로직 — Product에서 SeatGrade/ItemOption 정보와 함께
         // 별도 이벤트로 전달받아 자동 초기화할 예정
-        log.info("아이템 생성 이벤트 수신 — 재고 초기화 대기: itemId={}, type={}", event.getItemId(), event.getItemType());
+        log.info("[ItemConsumer] 아이템 생성 이벤트 수신 — 재고 초기화 대기: itemId={}, type={}", event.getItemId(), event.getItemType());
     }
 }

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventConsumer.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventConsumer.java
@@ -1,0 +1,36 @@
+package com.example.stock.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ItemEventConsumer {
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "item-events", groupId = "${spring.kafka.consumer.group-id}")
+    public void consume(String message) {
+        try {
+            ItemEventMessage event = objectMapper.readValue(message, ItemEventMessage.class);
+            log.info("아이템 이벤트 수신: type={}, itemId={}", event.getEventType(), event.getItemId());
+
+            switch (event.getEventType()) {
+                case "ITEM_CREATED" -> handleItemCreated(event);
+                default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+            }
+        } catch (Exception e) {
+            log.error("아이템 이벤트 처리 실패: {}", message, e);
+        }
+    }
+
+    private void handleItemCreated(ItemEventMessage event) {
+        // 향후 재고 자동 초기화 로직 — Product에서 SeatGrade/ItemOption 정보와 함께
+        // 별도 이벤트로 전달받아 자동 초기화할 예정
+        log.info("아이템 생성 이벤트 수신 — 재고 초기화 대기: itemId={}, type={}", event.getItemId(), event.getItemType());
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventMessage.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventMessage.java
@@ -1,0 +1,15 @@
+package com.example.stock.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItemEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long itemId;
+    private String itemType;
+    private String title;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventConsumer.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventConsumer.java
@@ -1,0 +1,53 @@
+package com.example.stock.consumer;
+
+import com.example.stock.dto.request.ConfirmReservationRequest;
+import com.example.stock.service.command.StockCommandService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final StockCommandService stockCommandService;
+
+    @KafkaListener(topics = "payment-events", groupId = "${spring.kafka.consumer.group-id}")
+    public void consume(String message) {
+        try {
+            PaymentEventMessage event = objectMapper.readValue(message, PaymentEventMessage.class);
+            log.info("결제 이벤트 수신: type={}, reservationId={}", event.getEventType(), event.getReservationId());
+
+            switch (event.getEventType()) {
+                case "PAYMENT_COMPLETED" -> handlePaymentCompleted(event);
+                case "PAYMENT_CANCELLED" -> handlePaymentCancelled(event);
+                case "PAYMENT_TIMED_OUT" -> handlePaymentTimedOut(event);
+                default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+            }
+        } catch (Exception e) {
+            log.error("결제 이벤트 처리 실패: {}", message, e);
+        }
+    }
+
+    private void handlePaymentCompleted(PaymentEventMessage event) {
+        ConfirmReservationRequest request = new ConfirmReservationRequest();
+        // ConfirmReservationRequest에는 setter가 없으므로 서비스 메서드를 직접 호출
+        // 실제로는 reservationId를 직접 사용
+        log.info("결제 완료 → 예약 확정 처리: reservationId={}", event.getReservationId());
+        // stockCommandService.confirmReservationById(event.getReservationId());
+    }
+
+    private void handlePaymentCancelled(PaymentEventMessage event) {
+        log.info("결제 취소 → 예약 취소 처리: reservationId={}", event.getReservationId());
+        stockCommandService.cancelReservation(event.getReservationId());
+    }
+
+    private void handlePaymentTimedOut(PaymentEventMessage event) {
+        log.info("결제 타임아웃 → 예약 취소 처리: reservationId={}", event.getReservationId());
+        stockCommandService.cancelReservation(event.getReservationId());
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventConsumer.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventConsumer.java
@@ -1,44 +1,51 @@
 package com.example.stock.consumer;
 
-import com.example.stock.dto.request.ConfirmReservationRequest;
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
 import com.example.stock.service.command.StockCommandService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentEventConsumer {
 
-    private final ObjectMapper objectMapper;
     private final StockCommandService stockCommandService;
+    private final IdempotentConsumerService idempotentConsumerService;
 
     @KafkaListener(topics = "payment-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
     public void consume(String message) {
         try {
-            PaymentEventMessage event = objectMapper.readValue(message, PaymentEventMessage.class);
-            log.info("결제 이벤트 수신: type={}, reservationId={}", event.getEventType(), event.getReservationId());
+            PaymentEventMessage event = JsonUtils.fromJson(message, PaymentEventMessage.class);
 
-            switch (event.getEventType()) {
-                case "PAYMENT_COMPLETED" -> handlePaymentCompleted(event);
-                case "PAYMENT_CANCELLED" -> handlePaymentCancelled(event);
-                case "PAYMENT_TIMED_OUT" -> handlePaymentTimedOut(event);
-                default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+            if (event.getEventId() == null || event.getEventType() == null) {
+                log.error("[PaymentConsumer] eventId 또는 eventType이 null입니다. message={}", message);
+                return;
             }
+
+            idempotentConsumerService.executeIdempotent(event.getEventId(), "PAYMENT_EVENT", () -> {
+                switch (event.getEventType()) {
+                    case "PAYMENT_COMPLETED" -> handlePaymentCompleted(event);
+                    case "PAYMENT_CANCELLED" -> handlePaymentCancelled(event);
+                    case "PAYMENT_TIMED_OUT" -> handlePaymentTimedOut(event);
+                    default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+                }
+                return null;
+            });
         } catch (Exception e) {
-            log.error("결제 이벤트 처리 실패: {}", message, e);
+            log.error("[PaymentConsumer] 이벤트 처리 실패: {}", message, e);
+            throw e;
         }
     }
 
     private void handlePaymentCompleted(PaymentEventMessage event) {
-        ConfirmReservationRequest request = new ConfirmReservationRequest();
-        // ConfirmReservationRequest에는 setter가 없으므로 서비스 메서드를 직접 호출
-        // 실제로는 reservationId를 직접 사용
         log.info("결제 완료 → 예약 확정 처리: reservationId={}", event.getReservationId());
-        // stockCommandService.confirmReservationById(event.getReservationId());
+        stockCommandService.confirmReservationById(event.getReservationId());
     }
 
     private void handlePaymentCancelled(PaymentEventMessage event) {

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventMessage.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/PaymentEventMessage.java
@@ -1,0 +1,14 @@
+package com.example.stock.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long reservationId;
+    private Long userId;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/controller/api/command/StockCommandApi.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/api/command/StockCommandApi.java
@@ -1,0 +1,43 @@
+package com.example.stock.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.stock.dto.request.*;
+import com.example.stock.dto.response.ReservationResponse;
+import com.example.stock.dto.response.StockResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Stock Command", description = "재고 변경 내부 API")
+public interface StockCommandApi {
+
+    @Operation(summary = "재고 차감")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "차감 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "재고 부족")
+    })
+    @PostMapping("/internal/v1/stock/decrease")
+    ApiResponse<StockResponse> decreaseStock(@RequestBody StockDecreaseRequest request);
+
+    @Operation(summary = "재고 증가")
+    @PostMapping("/internal/v1/stock/increase")
+    ApiResponse<StockResponse> increaseStock(@RequestBody StockIncreaseRequest request);
+
+    @Operation(summary = "재고 예약 (TCC Try)")
+    @PostMapping("/internal/v1/stock/reserve")
+    ApiResponse<ReservationResponse> reserveStock(@RequestBody ReserveStockRequest request);
+
+    @Operation(summary = "예약 확정 (TCC Confirm)")
+    @PostMapping("/internal/v1/stock/confirm")
+    ApiResponse<ReservationResponse> confirmReservation(@RequestBody ConfirmReservationRequest request);
+
+    @Operation(summary = "예약 취소 (TCC Cancel)")
+    @PostMapping("/internal/v1/stock/cancel")
+    ApiResponse<ReservationResponse> cancelReservation(@RequestBody CancelReservationRequest request);
+
+    @Operation(summary = "재고 초기화")
+    @PostMapping("/internal/v1/stock/initialize")
+    ApiResponse<StockResponse> initializeStock(@RequestBody InitializeStockRequest request);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
@@ -1,12 +1,16 @@
 package com.example.stock.controller.api.query;
 
 import com.example.api.response.ApiResponse;
+import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "Stock Query", description = "재고 조회 내부 API")
 public interface StockQueryApi {
@@ -18,4 +22,11 @@ public interface StockQueryApi {
     @Operation(summary = "아이템별 재고 목록 조회")
     @GetMapping("/internal/v1/stock/items/{itemId}")
     ApiResponse<StockSummaryResponse> getStocksByItemId(@PathVariable Long itemId);
+
+    @Operation(summary = "재고 변경 이력 조회")
+    @GetMapping("/internal/v1/stock/{stockItemId}/history")
+    ApiResponse<List<StockHistoryResponse>> getStockHistory(
+            @PathVariable Long stockItemId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size);
 }

--- a/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
@@ -1,0 +1,21 @@
+package com.example.stock.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.stock.dto.response.StockResponse;
+import com.example.stock.dto.response.StockSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Stock Query", description = "재고 조회 내부 API")
+public interface StockQueryApi {
+
+    @Operation(summary = "재고 단건 조회")
+    @GetMapping("/internal/v1/stock/{stockItemId}")
+    ApiResponse<StockResponse> getStock(@PathVariable Long stockItemId);
+
+    @Operation(summary = "아이템별 재고 목록 조회")
+    @GetMapping("/internal/v1/stock/items/{itemId}")
+    ApiResponse<StockSummaryResponse> getStocksByItemId(@PathVariable Long itemId);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/controller/command/StockCommandController.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/command/StockCommandController.java
@@ -1,0 +1,49 @@
+package com.example.stock.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.stock.controller.api.command.StockCommandApi;
+import com.example.stock.dto.request.*;
+import com.example.stock.dto.response.ReservationResponse;
+import com.example.stock.dto.response.StockResponse;
+import com.example.stock.service.command.StockCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StockCommandController implements StockCommandApi {
+
+    private final StockCommandService stockCommandService;
+
+    @Override
+    public ApiResponse<StockResponse> decreaseStock(@Valid @RequestBody StockDecreaseRequest request) {
+        return ApiResponse.success(stockCommandService.decreaseStock(request));
+    }
+
+    @Override
+    public ApiResponse<StockResponse> increaseStock(@Valid @RequestBody StockIncreaseRequest request) {
+        return ApiResponse.success(stockCommandService.increaseStock(request));
+    }
+
+    @Override
+    public ApiResponse<ReservationResponse> reserveStock(@Valid @RequestBody ReserveStockRequest request) {
+        return ApiResponse.success(stockCommandService.reserveStock(request));
+    }
+
+    @Override
+    public ApiResponse<ReservationResponse> confirmReservation(@Valid @RequestBody ConfirmReservationRequest request) {
+        return ApiResponse.success(stockCommandService.confirmReservation(request));
+    }
+
+    @Override
+    public ApiResponse<ReservationResponse> cancelReservation(@Valid @RequestBody CancelReservationRequest request) {
+        return ApiResponse.success(stockCommandService.cancelReservation(request.getReservationId()));
+    }
+
+    @Override
+    public ApiResponse<StockResponse> initializeStock(@Valid @RequestBody InitializeStockRequest request) {
+        return ApiResponse.success(stockCommandService.initializeStock(request));
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
@@ -2,12 +2,16 @@ package com.example.stock.controller.query;
 
 import com.example.api.response.ApiResponse;
 import com.example.stock.controller.api.query.StockQueryApi;
+import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
 import com.example.stock.service.query.StockQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +27,13 @@ public class StockQueryController implements StockQueryApi {
     @Override
     public ApiResponse<StockSummaryResponse> getStocksByItemId(@PathVariable Long itemId) {
         return ApiResponse.success(stockQueryService.getStocksByItemId(itemId));
+    }
+
+    @Override
+    public ApiResponse<List<StockHistoryResponse>> getStockHistory(
+            @PathVariable Long stockItemId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.success(stockQueryService.getStockHistory(stockItemId, page, size));
     }
 }

--- a/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
@@ -1,0 +1,27 @@
+package com.example.stock.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.stock.controller.api.query.StockQueryApi;
+import com.example.stock.dto.response.StockResponse;
+import com.example.stock.dto.response.StockSummaryResponse;
+import com.example.stock.service.query.StockQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StockQueryController implements StockQueryApi {
+
+    private final StockQueryService stockQueryService;
+
+    @Override
+    public ApiResponse<StockResponse> getStock(@PathVariable Long stockItemId) {
+        return ApiResponse.success(stockQueryService.getStock(stockItemId));
+    }
+
+    @Override
+    public ApiResponse<StockSummaryResponse> getStocksByItemId(@PathVariable Long itemId) {
+        return ApiResponse.success(stockQueryService.getStocksByItemId(itemId));
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/CancelReservationRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/CancelReservationRequest.java
@@ -1,0 +1,13 @@
+package com.example.stock.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CancelReservationRequest {
+
+    @NotNull
+    private Long reservationId;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/ConfirmReservationRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/ConfirmReservationRequest.java
@@ -1,0 +1,13 @@
+package com.example.stock.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ConfirmReservationRequest {
+
+    @NotNull
+    private Long reservationId;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/InitializeStockRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/InitializeStockRequest.java
@@ -1,0 +1,25 @@
+package com.example.stock.dto.request;
+
+import com.example.stock.entity.StockItemType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InitializeStockRequest {
+
+    @NotNull
+    private Long itemId;
+
+    @NotNull
+    private StockItemType stockItemType;
+
+    @NotNull
+    private Long referenceId;
+
+    @NotNull
+    @Min(0)
+    private Integer totalQuantity;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/ReserveStockRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/ReserveStockRequest.java
@@ -1,0 +1,21 @@
+package com.example.stock.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReserveStockRequest {
+
+    @NotNull
+    private Long stockItemId;
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/StockDecreaseRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/StockDecreaseRequest.java
@@ -1,0 +1,20 @@
+package com.example.stock.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StockDecreaseRequest {
+
+    @NotNull
+    private Long stockItemId;
+
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+
+    private String reason;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/StockIncreaseRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/StockIncreaseRequest.java
@@ -1,0 +1,20 @@
+package com.example.stock.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StockIncreaseRequest {
+
+    @NotNull
+    private Long stockItemId;
+
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+
+    private String reason;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/response/ReservationResponse.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/response/ReservationResponse.java
@@ -1,0 +1,31 @@
+package com.example.stock.dto.response;
+
+import com.example.stock.entity.ReservationStatus;
+import com.example.stock.entity.StockReservation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReservationResponse {
+
+    private Long id;
+    private Long stockItemId;
+    private Long userId;
+    private int quantity;
+    private ReservationStatus status;
+    private LocalDateTime expiredAt;
+
+    public static ReservationResponse from(StockReservation reservation) {
+        return ReservationResponse.builder()
+                .id(reservation.getId())
+                .stockItemId(reservation.getStockItemId())
+                .userId(reservation.getUserId())
+                .quantity(reservation.getQuantity())
+                .status(reservation.getStatus())
+                .expiredAt(reservation.getExpiredAt())
+                .build();
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/response/StockHistoryResponse.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/response/StockHistoryResponse.java
@@ -1,0 +1,33 @@
+package com.example.stock.dto.response;
+
+import com.example.stock.entity.ChangeType;
+import com.example.stock.entity.StockHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StockHistoryResponse {
+
+    private final Long id;
+    private final Long stockItemId;
+    private final ChangeType changeType;
+    private final int quantity;
+    private final String reason;
+    private final Long reservationId;
+    private final LocalDateTime createdAt;
+
+    public static StockHistoryResponse from(StockHistory history) {
+        return StockHistoryResponse.builder()
+                .id(history.getId())
+                .stockItemId(history.getStockItemId())
+                .changeType(history.getChangeType())
+                .quantity(history.getQuantity())
+                .reason(history.getReason())
+                .reservationId(history.getReservationId())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/response/StockResponse.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/response/StockResponse.java
@@ -1,0 +1,31 @@
+package com.example.stock.dto.response;
+
+import com.example.stock.entity.StockItem;
+import com.example.stock.entity.StockItemType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockResponse {
+
+    private Long id;
+    private Long itemId;
+    private StockItemType stockItemType;
+    private Long referenceId;
+    private int totalQuantity;
+    private int availableQuantity;
+    private int reservedQuantity;
+
+    public static StockResponse from(StockItem stockItem) {
+        return StockResponse.builder()
+                .id(stockItem.getId())
+                .itemId(stockItem.getItemId())
+                .stockItemType(stockItem.getStockItemType())
+                .referenceId(stockItem.getReferenceId())
+                .totalQuantity(stockItem.getTotalQuantity())
+                .availableQuantity(stockItem.getAvailableQuantity())
+                .reservedQuantity(stockItem.getReservedQuantity())
+                .build();
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/dto/response/StockSummaryResponse.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/response/StockSummaryResponse.java
@@ -1,0 +1,45 @@
+package com.example.stock.dto.response;
+
+import com.example.stock.entity.StockItem;
+import com.example.stock.entity.StockItemType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StockSummaryResponse {
+
+    private Long itemId;
+    private List<StockDetail> stocks;
+
+    @Getter
+    @Builder
+    public static class StockDetail {
+        private Long stockItemId;
+        private StockItemType stockItemType;
+        private Long referenceId;
+        private int totalQuantity;
+        private int availableQuantity;
+        private int reservedQuantity;
+
+        public static StockDetail from(StockItem stockItem) {
+            return StockDetail.builder()
+                    .stockItemId(stockItem.getId())
+                    .stockItemType(stockItem.getStockItemType())
+                    .referenceId(stockItem.getReferenceId())
+                    .totalQuantity(stockItem.getTotalQuantity())
+                    .availableQuantity(stockItem.getAvailableQuantity())
+                    .reservedQuantity(stockItem.getReservedQuantity())
+                    .build();
+        }
+    }
+
+    public static StockSummaryResponse of(Long itemId, List<StockItem> stockItems) {
+        return StockSummaryResponse.builder()
+                .itemId(itemId)
+                .stocks(stockItems.stream().map(StockDetail::from).toList())
+                .build();
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/ChangeType.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/ChangeType.java
@@ -1,0 +1,10 @@
+package com.example.stock.entity;
+
+public enum ChangeType {
+    DECREASE,
+    INCREASE,
+    RESERVE,
+    CONFIRM,
+    EXPIRE,
+    CANCEL
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/ReservationStatus.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/ReservationStatus.java
@@ -1,0 +1,8 @@
+package com.example.stock.entity;
+
+public enum ReservationStatus {
+    RESERVED,
+    CONFIRMED,
+    EXPIRED,
+    CANCELLED
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockHistory.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockHistory.java
@@ -1,0 +1,50 @@
+package com.example.stock.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stock_histories", indexes = {
+        @Index(name = "idx_history_stock_item", columnList = "stockItemId")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockHistory extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(nullable = false)
+    private Long stockItemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ChangeType changeType;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(length = 500)
+    private String reason;
+
+    private Long reservationId;
+
+    public static StockHistory create(Long stockItemId, ChangeType changeType, int quantity, String reason, Long reservationId) {
+        StockHistory history = new StockHistory();
+        history.stockItemId = stockItemId;
+        history.changeType = changeType;
+        history.quantity = quantity;
+        history.reason = reason;
+        history.reservationId = reservationId;
+        return history;
+    }
+
+    public static StockHistory create(Long stockItemId, ChangeType changeType, int quantity, String reason) {
+        return create(stockItemId, changeType, quantity, reason, null);
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockItem.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockItem.java
@@ -1,0 +1,100 @@
+package com.example.stock.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "stock_items", indexes = {
+        @Index(name = "idx_stock_item_ref", columnList = "itemId, stockItemType, referenceId", unique = true)
+})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockItem extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(nullable = false)
+    private Long itemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StockItemType stockItemType;
+
+    @Column(nullable = false)
+    private Long referenceId;
+
+    @Column(nullable = false)
+    private int totalQuantity;
+
+    @Column(nullable = false)
+    private int availableQuantity;
+
+    @Column(nullable = false)
+    private int reservedQuantity;
+
+    public static StockItem create(Long itemId, StockItemType stockItemType, Long referenceId, int totalQuantity) {
+        StockItem stockItem = new StockItem();
+        stockItem.itemId = itemId;
+        stockItem.stockItemType = stockItemType;
+        stockItem.referenceId = referenceId;
+        stockItem.totalQuantity = totalQuantity;
+        stockItem.availableQuantity = totalQuantity;
+        stockItem.reservedQuantity = 0;
+        return stockItem;
+    }
+
+    public void decrease(int quantity) {
+        if (this.availableQuantity < quantity) {
+            throw new IllegalStateException("Insufficient stock");
+        }
+        this.availableQuantity -= quantity;
+    }
+
+    public void increase(int quantity) {
+        this.availableQuantity += quantity;
+        if (this.availableQuantity > this.totalQuantity) {
+            this.availableQuantity = this.totalQuantity;
+        }
+    }
+
+    public void reserve(int quantity) {
+        if (this.availableQuantity < quantity) {
+            throw new IllegalStateException("Insufficient stock for reservation");
+        }
+        this.availableQuantity -= quantity;
+        this.reservedQuantity += quantity;
+    }
+
+    public void confirmReservation(int quantity) {
+        this.reservedQuantity -= quantity;
+    }
+
+    public void cancelReservation(int quantity) {
+        this.reservedQuantity -= quantity;
+        this.availableQuantity += quantity;
+    }
+
+    public void updateTotal(int totalQuantity) {
+        int diff = totalQuantity - this.totalQuantity;
+        this.totalQuantity = totalQuantity;
+        this.availableQuantity += diff;
+        if (this.availableQuantity < 0) this.availableQuantity = 0;
+    }
+
+    public boolean isDepleted() {
+        return this.availableQuantity == 0;
+    }
+
+    public boolean isThresholdReached(double thresholdPercent) {
+        if (this.totalQuantity == 0) return false;
+        return ((double) this.availableQuantity / this.totalQuantity) <= thresholdPercent;
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockItemType.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockItemType.java
@@ -1,0 +1,6 @@
+package com.example.stock.entity;
+
+public enum StockItemType {
+    SEAT_GRADE,
+    ITEM_OPTION
+}

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockReservation.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockReservation.java
@@ -1,0 +1,79 @@
+package com.example.stock.entity;
+
+import com.example.core.exception.BusinessException;
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import com.example.stock.exception.StockErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stock_reservations", indexes = {
+        @Index(name = "idx_reservation_stock_item", columnList = "stockItemId"),
+        @Index(name = "idx_reservation_status_expired", columnList = "status, expiredAt")
+})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockReservation extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(nullable = false)
+    private Long stockItemId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReservationStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    public static StockReservation create(Long stockItemId, Long userId, int quantity, int ttlMinutes) {
+        StockReservation reservation = new StockReservation();
+        reservation.stockItemId = stockItemId;
+        reservation.userId = userId;
+        reservation.quantity = quantity;
+        reservation.status = ReservationStatus.RESERVED;
+        reservation.expiredAt = LocalDateTime.now().plusMinutes(ttlMinutes);
+        return reservation;
+    }
+
+    public void confirm() {
+        validateStatus(ReservationStatus.RESERVED);
+        this.status = ReservationStatus.CONFIRMED;
+    }
+
+    public void cancel() {
+        validateStatus(ReservationStatus.RESERVED);
+        this.status = ReservationStatus.CANCELLED;
+    }
+
+    public void expire() {
+        validateStatus(ReservationStatus.RESERVED);
+        this.status = ReservationStatus.EXPIRED;
+    }
+
+    public boolean isExpired() {
+        return this.status == ReservationStatus.RESERVED && LocalDateTime.now().isAfter(this.expiredAt);
+    }
+
+    private void validateStatus(ReservationStatus expected) {
+        if (this.status != expected) {
+            throw new BusinessException(StockErrorCode.INVALID_RESERVATION_STATUS);
+        }
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/StockDecreasedEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/StockDecreasedEvent.java
@@ -1,0 +1,38 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class StockDecreasedEvent extends DomainEvent {
+
+    private final Long stockItemId;
+    private final Long itemId;
+    private final int quantity;
+    private final int remainingQuantity;
+
+    public StockDecreasedEvent(Long stockItemId, Long itemId, int quantity, int remainingQuantity) {
+        super("stock-events");
+        this.stockItemId = stockItemId;
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.remainingQuantity = remainingQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "STOCK_DECREASED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "stockItemId", stockItemId,
+                "itemId", itemId,
+                "quantity", quantity,
+                "remainingQuantity", remainingQuantity
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/StockDepletedEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/StockDepletedEvent.java
@@ -1,0 +1,32 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class StockDepletedEvent extends DomainEvent {
+
+    private final Long stockItemId;
+    private final Long itemId;
+
+    public StockDepletedEvent(Long stockItemId, Long itemId) {
+        super("stock-events");
+        this.stockItemId = stockItemId;
+        this.itemId = itemId;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "STOCK_DEPLETED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "stockItemId", stockItemId,
+                "itemId", itemId
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/StockIncreasedEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/StockIncreasedEvent.java
@@ -1,0 +1,38 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class StockIncreasedEvent extends DomainEvent {
+
+    private final Long stockItemId;
+    private final Long itemId;
+    private final int quantity;
+    private final int currentQuantity;
+
+    public StockIncreasedEvent(Long stockItemId, Long itemId, int quantity, int currentQuantity) {
+        super("stock-events");
+        this.stockItemId = stockItemId;
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.currentQuantity = currentQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "STOCK_INCREASED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "stockItemId", stockItemId,
+                "itemId", itemId,
+                "quantity", quantity,
+                "currentQuantity", currentQuantity
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/StockThresholdEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/StockThresholdEvent.java
@@ -1,0 +1,38 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class StockThresholdEvent extends DomainEvent {
+
+    private final Long stockItemId;
+    private final Long itemId;
+    private final int remainingQuantity;
+    private final int totalQuantity;
+
+    public StockThresholdEvent(Long stockItemId, Long itemId, int remainingQuantity, int totalQuantity) {
+        super("stock-events");
+        this.stockItemId = stockItemId;
+        this.itemId = itemId;
+        this.remainingQuantity = remainingQuantity;
+        this.totalQuantity = totalQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "STOCK_THRESHOLD_REACHED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "stockItemId", stockItemId,
+                "itemId", itemId,
+                "remainingQuantity", remainingQuantity,
+                "totalQuantity", totalQuantity
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/exception/StockErrorCode.java
+++ b/servers/services/stock/src/main/java/com/example/stock/exception/StockErrorCode.java
@@ -1,0 +1,34 @@
+package com.example.stock.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockErrorCode implements DomainErrorCode {
+
+    // ─── 재고 ────────────────────────────────
+    STOCK_NOT_FOUND("STOCK-001", "재고 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INSUFFICIENT_STOCK("STOCK-002", "재고가 부족합니다.", HttpStatus.CONFLICT),
+    STOCK_ALREADY_EXISTS("STOCK-003", "이미 재고가 등록되어 있습니다.", HttpStatus.CONFLICT),
+    STOCK_OVERFLOW("STOCK-004", "재고 수량이 총 수량을 초과합니다.", HttpStatus.BAD_REQUEST),
+
+    // ─── 예약 ────────────────────────────────
+    RESERVATION_NOT_FOUND("STOCK-101", "예약 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RESERVATION_ALREADY_CONFIRMED("STOCK-102", "이미 확정된 예약입니다.", HttpStatus.CONFLICT),
+    RESERVATION_ALREADY_CANCELLED("STOCK-103", "이미 취소된 예약입니다.", HttpStatus.CONFLICT),
+    RESERVATION_EXPIRED("STOCK-104", "만료된 예약입니다.", HttpStatus.CONFLICT),
+    INVALID_RESERVATION_STATUS("STOCK-105", "유효하지 않은 예약 상태 변경입니다.", HttpStatus.BAD_REQUEST),
+
+    // ─── 분산 락 ────────────────────────────────
+    LOCK_ACQUISITION_FAILED("STOCK-201", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE),
+
+    // ─── 권한 ────────────────────────────────
+    UNAUTHORIZED_ACCESS("STOCK-901", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockHistoryRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.example.stock.repository;
+
+import com.example.stock.entity.StockHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockHistoryRepository extends JpaRepository<StockHistory, Long> {
+
+    Page<StockHistory> findByStockItemIdOrderByCreatedAtDesc(Long stockItemId, Pageable pageable);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
@@ -1,0 +1,25 @@
+package com.example.stock.repository;
+
+import com.example.stock.entity.StockItem;
+import com.example.stock.entity.StockItemType;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockItemRepository extends JpaRepository<StockItem, Long> {
+
+    Optional<StockItem> findByItemIdAndStockItemTypeAndReferenceId(Long itemId, StockItemType stockItemType, Long referenceId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM StockItem s WHERE s.id = :id")
+    Optional<StockItem> findByIdWithLock(@Param("id") Long id);
+
+    List<StockItem> findByItemId(Long itemId);
+
+    List<StockItem> findByItemIdAndStockItemType(Long itemId, StockItemType stockItemType);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
@@ -1,0 +1,18 @@
+package com.example.stock.repository;
+
+import com.example.stock.entity.ReservationStatus;
+import com.example.stock.entity.StockReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StockReservationRepository extends JpaRepository<StockReservation, Long> {
+
+    @Query("SELECT r FROM StockReservation r WHERE r.status = :status AND r.expiredAt < :now")
+    List<StockReservation> findExpiredReservations(@Param("status") ReservationStatus status, @Param("now") LocalDateTime now);
+
+    List<StockReservation> findByStockItemIdAndStatus(Long stockItemId, ReservationStatus status);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/scheduler/StockReservationScheduler.java
+++ b/servers/services/stock/src/main/java/com/example/stock/scheduler/StockReservationScheduler.java
@@ -1,0 +1,45 @@
+package com.example.stock.scheduler;
+
+import com.example.stock.entity.ReservationStatus;
+import com.example.stock.entity.StockReservation;
+import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.service.command.StockCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockReservationScheduler {
+
+    private final StockReservationRepository stockReservationRepository;
+    private final StockCommandService stockCommandService;
+
+    @Scheduled(fixedDelay = 60000) // 1분마다
+    @Transactional
+    public void expireReservations() {
+        List<StockReservation> expired = stockReservationRepository
+                .findExpiredReservations(ReservationStatus.RESERVED, LocalDateTime.now());
+
+        if (expired.isEmpty()) return;
+
+        log.info("만료 예약 처리 시작: {}건", expired.size());
+
+        for (StockReservation reservation : expired) {
+            try {
+                stockCommandService.expireReservation(reservation);
+                log.info("예약 만료 처리 완료: reservationId={}", reservation.getId());
+            } catch (Exception e) {
+                log.error("예약 만료 처리 실패: reservationId={}", reservation.getId(), e);
+            }
+        }
+
+        log.info("만료 예약 처리 완료: {}건", expired.size());
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/service/StockCacheService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/StockCacheService.java
@@ -1,0 +1,85 @@
+package com.example.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockCacheService {
+
+    private static final String STOCK_KEY_PREFIX = "stock:";
+    private static final Duration STOCK_TTL = Duration.ofHours(1);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // Lua Script: 원자적 재고 확인 + 차감
+    private static final String DECREASE_LUA_SCRIPT =
+            "local current = tonumber(redis.call('GET', KEYS[1]) or -1) " +
+            "if current < 0 then return -1 end " +
+            "if current < tonumber(ARGV[1]) then return -2 end " +
+            "return redis.call('DECRBY', KEYS[1], ARGV[1])";
+
+    // Lua Script: 원자적 재고 증가 (상한 체크)
+    private static final String INCREASE_LUA_SCRIPT =
+            "local current = tonumber(redis.call('GET', KEYS[1]) or -1) " +
+            "if current < 0 then return -1 end " +
+            "local max = tonumber(ARGV[2]) " +
+            "local added = tonumber(ARGV[1]) " +
+            "local result = current + added " +
+            "if result > max then result = max end " +
+            "redis.call('SET', KEYS[1], result) " +
+            "redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3])) " +
+            "return result";
+
+    public void cacheStock(Long stockItemId, int availableQuantity) {
+        String key = buildKey(stockItemId);
+        redisTemplate.opsForValue().set(key, availableQuantity, STOCK_TTL);
+        log.debug("캐시 저장: {} = {}", key, availableQuantity);
+    }
+
+    public Integer getStock(Long stockItemId) {
+        String key = buildKey(stockItemId);
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return ((Number) value).intValue();
+    }
+
+    /**
+     * Lua Script로 원자적 재고 차감.
+     * @return 차감 후 잔여 수량. -1이면 캐시 미스, -2이면 재고 부족
+     */
+    public long decrementStock(Long stockItemId, int quantity) {
+        String key = buildKey(stockItemId);
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>(DECREASE_LUA_SCRIPT, Long.class);
+        Long result = redisTemplate.execute(script, Collections.singletonList(key), quantity);
+        return result != null ? result : -1;
+    }
+
+    /**
+     * Lua Script로 원자적 재고 증가 (totalQuantity 상한).
+     */
+    public long incrementStock(Long stockItemId, int quantity, int totalQuantity) {
+        String key = buildKey(stockItemId);
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCREASE_LUA_SCRIPT, Long.class);
+        Long result = redisTemplate.execute(script, Collections.singletonList(key),
+                quantity, totalQuantity, STOCK_TTL.toSeconds());
+        return result != null ? result : -1;
+    }
+
+    public void invalidateStock(Long stockItemId) {
+        String key = buildKey(stockItemId);
+        redisTemplate.delete(key);
+        log.debug("캐시 무효화: {}", key);
+    }
+
+    private String buildKey(Long stockItemId) {
+        return STOCK_KEY_PREFIX + stockItemId;
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
@@ -1,0 +1,200 @@
+package com.example.stock.service.command;
+
+import com.example.config.redis.lock.DistributedLock;
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.stock.dto.request.*;
+import com.example.stock.dto.response.ReservationResponse;
+import com.example.stock.dto.response.StockResponse;
+import com.example.stock.entity.*;
+import com.example.stock.event.StockDecreasedEvent;
+import com.example.stock.event.StockDepletedEvent;
+import com.example.stock.event.StockIncreasedEvent;
+import com.example.stock.event.StockThresholdEvent;
+import com.example.stock.exception.StockErrorCode;
+import com.example.stock.repository.StockHistoryRepository;
+import com.example.stock.repository.StockItemRepository;
+import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.service.StockCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StockCommandService {
+
+    private static final double THRESHOLD_PERCENT = 0.1; // 10%
+    private static final int RESERVATION_TTL_MINUTES = 10;
+
+    private final StockItemRepository stockItemRepository;
+    private final StockReservationRepository stockReservationRepository;
+    private final StockHistoryRepository stockHistoryRepository;
+    private final StockCacheService stockCacheService;
+    private final EventPublisher eventPublisher;
+
+    @DistributedLock(key = "'stock:' + #request.stockItemId")
+    public StockResponse decreaseStock(StockDecreaseRequest request) {
+        StockItem stockItem = getStockItemWithLock(request.getStockItemId());
+
+        if (stockItem.getAvailableQuantity() < request.getQuantity()) {
+            throw new BusinessException(StockErrorCode.INSUFFICIENT_STOCK);
+        }
+
+        stockItem.decrease(request.getQuantity());
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.DECREASE, request.getQuantity(), request.getReason()));
+
+        // Redis 캐시 동기화
+        stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+        // 이벤트 발행
+        publishStockEvents(stockItem, request.getQuantity());
+
+        return StockResponse.from(stockItem);
+    }
+
+    @DistributedLock(key = "'stock:' + #request.stockItemId")
+    public StockResponse increaseStock(StockIncreaseRequest request) {
+        StockItem stockItem = getStockItemWithLock(request.getStockItemId());
+
+        stockItem.increase(request.getQuantity());
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.INCREASE, request.getQuantity(), request.getReason()));
+
+        stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+        eventPublisher.publish(
+                new StockIncreasedEvent(stockItem.getId(), stockItem.getItemId(), request.getQuantity(), stockItem.getAvailableQuantity()),
+                EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+
+        return StockResponse.from(stockItem);
+    }
+
+    // ─── TCC: Try ─────────────────────────────
+    @DistributedLock(key = "'stock:' + #request.stockItemId")
+    public ReservationResponse reserveStock(ReserveStockRequest request) {
+        StockItem stockItem = getStockItemWithLock(request.getStockItemId());
+
+        if (stockItem.getAvailableQuantity() < request.getQuantity()) {
+            throw new BusinessException(StockErrorCode.INSUFFICIENT_STOCK);
+        }
+
+        stockItem.reserve(request.getQuantity());
+
+        StockReservation reservation = StockReservation.create(
+                stockItem.getId(), request.getUserId(), request.getQuantity(), RESERVATION_TTL_MINUTES);
+        stockReservationRepository.save(reservation);
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.RESERVE, request.getQuantity(),
+                "예약 생성 (userId=" + request.getUserId() + ")", reservation.getId()));
+
+        stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+        return ReservationResponse.from(reservation);
+    }
+
+    // ─── TCC: Confirm ─────────────────────────
+    public ReservationResponse confirmReservation(ConfirmReservationRequest request) {
+        StockReservation reservation = getReservation(request.getReservationId());
+        reservation.confirm();
+
+        StockItem stockItem = getStockItemWithLock(reservation.getStockItemId());
+        stockItem.confirmReservation(reservation.getQuantity());
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.CONFIRM, reservation.getQuantity(),
+                "예약 확정", reservation.getId()));
+
+        publishStockEvents(stockItem, reservation.getQuantity());
+
+        return ReservationResponse.from(reservation);
+    }
+
+    // ─── TCC: Cancel ──────────────────────────
+    @DistributedLock(key = "'stock:' + #reservationId", waitTime = 5)
+    public ReservationResponse cancelReservation(Long reservationId) {
+        StockReservation reservation = getReservation(reservationId);
+        reservation.cancel();
+
+        StockItem stockItem = getStockItemWithLock(reservation.getStockItemId());
+        stockItem.cancelReservation(reservation.getQuantity());
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.CANCEL, reservation.getQuantity(),
+                "예약 취소", reservation.getId()));
+
+        stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+        return ReservationResponse.from(reservation);
+    }
+
+    public StockResponse initializeStock(InitializeStockRequest request) {
+        stockItemRepository.findByItemIdAndStockItemTypeAndReferenceId(
+                request.getItemId(), request.getStockItemType(), request.getReferenceId()
+        ).ifPresent(existing -> {
+            throw new BusinessException(StockErrorCode.STOCK_ALREADY_EXISTS);
+        });
+
+        StockItem stockItem = StockItem.create(
+                request.getItemId(), request.getStockItemType(),
+                request.getReferenceId(), request.getTotalQuantity());
+        stockItemRepository.save(stockItem);
+
+        stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+        stockHistoryRepository.save(StockHistory.create(
+                stockItem.getId(), ChangeType.INCREASE, request.getTotalQuantity(), "재고 초기화"));
+
+        return StockResponse.from(stockItem);
+    }
+
+    public void expireReservation(StockReservation reservation) {
+        reservation.expire();
+
+        StockItem stockItem = stockItemRepository.findByIdWithLock(reservation.getStockItemId())
+                .orElse(null);
+        if (stockItem != null) {
+            stockItem.cancelReservation(reservation.getQuantity());
+            stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+
+            stockHistoryRepository.save(StockHistory.create(
+                    stockItem.getId(), ChangeType.EXPIRE, reservation.getQuantity(),
+                    "예약 만료 자동 복원", reservation.getId()));
+        }
+    }
+
+    private void publishStockEvents(StockItem stockItem, int quantity) {
+        eventPublisher.publish(
+                new StockDecreasedEvent(stockItem.getId(), stockItem.getItemId(), quantity, stockItem.getAvailableQuantity()),
+                EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+
+        if (stockItem.isDepleted()) {
+            eventPublisher.publish(
+                    new StockDepletedEvent(stockItem.getId(), stockItem.getItemId()),
+                    EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+        } else if (stockItem.isThresholdReached(THRESHOLD_PERCENT)) {
+            eventPublisher.publish(
+                    new StockThresholdEvent(stockItem.getId(), stockItem.getItemId(),
+                            stockItem.getAvailableQuantity(), stockItem.getTotalQuantity()),
+                    EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+        }
+    }
+
+    private StockItem getStockItemWithLock(Long stockItemId) {
+        return stockItemRepository.findByIdWithLock(stockItemId)
+                .orElseThrow(() -> new BusinessException(StockErrorCode.STOCK_NOT_FOUND));
+    }
+
+    private StockReservation getReservation(Long reservationId) {
+        return stockReservationRepository.findById(reservationId)
+                .orElseThrow(() -> new BusinessException(StockErrorCode.RESERVATION_NOT_FOUND));
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
@@ -1,13 +1,17 @@
 package com.example.stock.service.query;
 
 import com.example.core.exception.BusinessException;
+import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
 import com.example.stock.entity.StockItem;
 import com.example.stock.exception.StockErrorCode;
+import com.example.stock.repository.StockHistoryRepository;
 import com.example.stock.repository.StockItemRepository;
 import com.example.stock.service.StockCacheService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,10 +23,10 @@ import java.util.List;
 public class StockQueryService {
 
     private final StockItemRepository stockItemRepository;
+    private final StockHistoryRepository stockHistoryRepository;
     private final StockCacheService stockCacheService;
 
     public StockResponse getStock(Long stockItemId) {
-        // Redis 캐시 우선 조회는 availableQuantity만 해당 — 전체 정보는 DB에서
         StockItem stockItem = stockItemRepository.findById(stockItemId)
                 .orElseThrow(() -> new BusinessException(StockErrorCode.STOCK_NOT_FOUND));
         return StockResponse.from(stockItem);
@@ -31,5 +35,17 @@ public class StockQueryService {
     public StockSummaryResponse getStocksByItemId(Long itemId) {
         List<StockItem> stockItems = stockItemRepository.findByItemId(itemId);
         return StockSummaryResponse.of(itemId, stockItems);
+    }
+
+    public List<StockHistoryResponse> getStockHistory(Long stockItemId, int page, int size) {
+        // 재고 존재 확인
+        stockItemRepository.findById(stockItemId)
+                .orElseThrow(() -> new BusinessException(StockErrorCode.STOCK_NOT_FOUND));
+
+        return stockHistoryRepository.findByStockItemIdOrderByCreatedAtDesc(
+                        stockItemId, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")))
+                .stream()
+                .map(StockHistoryResponse::from)
+                .toList();
     }
 }

--- a/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
@@ -1,0 +1,35 @@
+package com.example.stock.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.stock.dto.response.StockResponse;
+import com.example.stock.dto.response.StockSummaryResponse;
+import com.example.stock.entity.StockItem;
+import com.example.stock.exception.StockErrorCode;
+import com.example.stock.repository.StockItemRepository;
+import com.example.stock.service.StockCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockQueryService {
+
+    private final StockItemRepository stockItemRepository;
+    private final StockCacheService stockCacheService;
+
+    public StockResponse getStock(Long stockItemId) {
+        // Redis 캐시 우선 조회는 availableQuantity만 해당 — 전체 정보는 DB에서
+        StockItem stockItem = stockItemRepository.findById(stockItemId)
+                .orElseThrow(() -> new BusinessException(StockErrorCode.STOCK_NOT_FOUND));
+        return StockResponse.from(stockItem);
+    }
+
+    public StockSummaryResponse getStocksByItemId(Long itemId) {
+        List<StockItem> stockItems = stockItemRepository.findByItemId(itemId);
+        return StockSummaryResponse.of(itemId, stockItems);
+    }
+}

--- a/servers/services/stock/src/main/resources/application.yml
+++ b/servers/services/stock/src/main/resources/application.yml
@@ -1,0 +1,70 @@
+server:
+  port: ${SERVER_PORT:8085}
+
+spring:
+  application:
+    name: stock-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/stock_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: stock-service-group
+      auto-offset-reset: earliest
+
+# ─── Snowflake ID ────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:5}
+
+  # ─── OpenAPI ──────────────────────────────────
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Stock Service API"
+    version: "1.0.0"
+    description: |
+      재고 관리, 동시성 처리, 임시 예약 시스템
+
+# ─── Actuator ─────────────────────────────────
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+# ─── Logging ──────────────────────────────────
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ include("servers:gateways:api-gateway")
 include("servers:services:auth")
 include("servers:services:user")
 include("servers:services:product")
+include("servers:services:stock")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## Summary
- Redisson 기반 분산 락 AOP 공통 모듈 추가 (`libs:config:redis`)
- Stock Service 전체 구현 (Entity, Repository, Service, Controller, Event, Consumer, Scheduler)
- 실행 검증 후 코드 보완 (AOP 바인딩 수정, JPA Strict Mode 대응, 멱등성 적용, Upsert 로직)

## 주요 구현 내용

### 공통 모듈
- `@DistributedLock` 어노테이션 + `DistributedLockAspect` (Redisson, SpEL 동적 키)

### 도메인 모델
- `StockItem`: 통합 재고 관리 (SEAT_GRADE/ITEM_OPTION), available/reserved/total 3가지 수량
- `StockReservation`: TCC 패턴 임시 예약 (RESERVED→CONFIRMED/CANCELLED/EXPIRED)
- `StockHistory`: 변경 이력 추적 (DECREASE/INCREASE/RESERVE/CONFIRM/EXPIRE/CANCEL)

### CQRS 서비스
- **Command**: 재고 차감/증가, TCC(Try/Confirm/Cancel), 초기화(Upsert), 만료 처리
- **Query**: 단건/목록 조회, 변경 이력 조회

### 동시성 제어 (이중 보호)
- 1차: Redis 분산 락 (`@DistributedLock` AOP, `@Order(HIGHEST_PRECEDENCE)`)
- 2차: DB 비관적 잠금 (`@Lock(PESSIMISTIC_WRITE)`, SELECT FOR UPDATE)

### Redis 캐시
- Lua Script 원자적 연산 (DECREASE/INCREASE)
- Write-Through 캐시 전략, TTL 1시간

### 이벤트
- **발행**: StockDecreased/Depleted/Threshold/Increased (Outbox 패턴)
- **소비**: ItemEventConsumer (item-events), PaymentEventConsumer (payment-events)
- **멱등성**: IdempotentConsumerService 적용

### 스케줄러
- `StockReservationScheduler`: 만료 예약 자동 복원 (1분 주기)

## 검증 결과
- 전 API 엔드포인트 curl 테스트 통과
- 동시성 테스트: 50개 동시 차감 → 음수 재고 없음
- 동시성 테스트: 30개 동시 예약(재고 20) → 정확히 20개만 성공

## Test plan
- [x] `./gradlew :servers:services:stock:compileJava` 빌드 성공
- [x] Docker 인프라(PostgreSQL, Redis, Kafka) 기동 후 서비스 실행 확인
- [x] Health check, 재고 초기화, 차감, 증가, 예약, 확정, 취소, Upsert, 이력 조회 API 테스트
- [x] 동시성 테스트 (50 concurrent decrease, 30 concurrent reserve)
- [x] Swagger UI 접근 확인