### PR TITLE
feat: Product → Stock 이벤트 기반 재고 자동 초기화 (#487)

### DIFF
--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
@@ -9,6 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -25,7 +28,11 @@ public class OutboxService implements EventPublisher {
     @Override
     @Transactional
     public void publish(DomainEvent event, EventMetadata metadata) {
-        String payload = JsonUtils.toJson(event.getPayload());
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("eventId", event.getEventId());
+        envelope.put("eventType", event.getEventTypeName());
+        envelope.putAll(event.getPayload());
+        String payload = JsonUtils.toJson(envelope);
 
         OutboxMessage message = OutboxMessage.create(
                 event.getEventId(),

--- a/servers/services/product/src/main/java/com/example/product/controller/command/GoodsCommandController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/command/GoodsCommandController.java
@@ -7,6 +7,7 @@ import com.example.product.dto.goods.request.GoodsUpdateRequest;
 import com.example.product.dto.goods.response.GoodsDetailResponse;
 import com.example.product.service.command.GoodsCommandService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
+++ b/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
@@ -3,6 +3,8 @@ package com.example.product.event;
 import com.example.event.DomainEvent;
 import lombok.Getter;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -12,13 +14,16 @@ public class ItemCreatedEvent extends DomainEvent {
     private final String title;
     private final String itemType;
     private final Long sellerId;
+    private final List<StockItemInfo> stockItems;
 
-    public ItemCreatedEvent(Long itemId, String title, String itemType, Long sellerId) {
+    public ItemCreatedEvent(Long itemId, String title, String itemType, Long sellerId,
+                            List<StockItemInfo> stockItems) {
         super("item-events");
         this.itemId = itemId;
         this.title = title;
         this.itemType = itemType;
         this.sellerId = sellerId;
+        this.stockItems = stockItems != null ? stockItems : List.of();
     }
 
     @Override
@@ -28,11 +33,30 @@ public class ItemCreatedEvent extends DomainEvent {
 
     @Override
     public Map<String, Object> getPayload() {
-        return Map.of(
-                "itemId", itemId,
-                "title", title,
-                "itemType", itemType,
-                "sellerId", sellerId
-        );
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("itemId", itemId);
+        payload.put("title", title);
+        payload.put("itemType", itemType);
+        payload.put("sellerId", sellerId);
+        payload.put("stockItems", stockItems.stream()
+                .map(si -> Map.of(
+                        "type", si.getType(),
+                        "referenceId", si.getReferenceId(),
+                        "totalQuantity", si.getTotalQuantity()))
+                .toList());
+        return payload;
+    }
+
+    @Getter
+    public static class StockItemInfo {
+        private final String type;
+        private final Long referenceId;
+        private final int totalQuantity;
+
+        public StockItemInfo(String type, Long referenceId, int totalQuantity) {
+            this.type = type;
+            this.referenceId = referenceId;
+            this.totalQuantity = totalQuantity;
+        }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -14,6 +14,7 @@ import com.example.product.entity.goods.ItemGoodsLink;
 import com.example.product.entity.goods.ItemOption;
 import com.example.product.entity.goods.ShippingInfo;
 import com.example.product.event.ItemCreatedEvent;
+import com.example.product.event.ItemCreatedEvent.StockItemInfo;
 import com.example.product.event.ItemUpdatedEvent;
 import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.*;
@@ -53,8 +54,13 @@ public class GoodsCommandService {
             linkedIds = linkPerformances(item.getId(), request.getLinkedPerformanceItemIds());
         }
 
+        List<ItemCreatedEvent.StockItemInfo> stockItems = options.stream()
+                .map(opt -> new ItemCreatedEvent.StockItemInfo(
+                        "ITEM_OPTION", opt.getId(), opt.getStockQuantity()))
+                .toList();
+
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -59,8 +59,13 @@ public class PerformanceCommandService {
             castMemberRepository.saveAll(castMembers);
         }
 
+        List<ItemCreatedEvent.StockItemInfo> stockItems = seatGrades.stream()
+                .map(sg -> new ItemCreatedEvent.StockItemInfo(
+                        "SEAT_GRADE", sg.getId(), sg.getTotalQuantity()))
+                .toList();
+
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers);

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -49,8 +49,13 @@ public class ProductCommandService {
             shippingInfo = saveShippingInfo(item.getId(), request.getShippingInfo());
         }
 
+        List<ItemCreatedEvent.StockItemInfo> stockItems = options.stream()
+                .map(opt -> new ItemCreatedEvent.StockItemInfo(
+                        "ITEM_OPTION", opt.getId(), opt.getStockQuantity()))
+                .toList();
+
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return GoodsDetailResponse.of(item, options, shippingInfo, List.of());

--- a/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventMessage.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/ItemEventMessage.java
@@ -3,6 +3,8 @@ package com.example.stock.consumer;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class ItemEventMessage {
@@ -12,4 +14,13 @@ public class ItemEventMessage {
     private Long itemId;
     private String itemType;
     private String title;
+    private List<StockItemPayload> stockItems;
+
+    @Getter
+    @NoArgsConstructor
+    public static class StockItemPayload {
+        private String type;
+        private Long referenceId;
+        private int totalQuantity;
+    }
 }

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/InitializeStockRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/InitializeStockRequest.java
@@ -22,4 +22,14 @@ public class InitializeStockRequest {
     @NotNull
     @Min(0)
     private Integer totalQuantity;
+
+    public static InitializeStockRequest of(Long itemId, StockItemType stockItemType,
+                                            Long referenceId, int totalQuantity) {
+        InitializeStockRequest req = new InitializeStockRequest();
+        req.itemId = itemId;
+        req.stockItemType = stockItemType;
+        req.referenceId = referenceId;
+        req.totalQuantity = totalQuantity;
+        return req;
+    }
 }

--- a/servers/test/test-server/src/main/java/com/example/testserver/service/TestService.java
+++ b/servers/test/test-server/src/main/java/com/example/testserver/service/TestService.java
@@ -15,6 +15,7 @@ import com.example.event.outbox.OutboxStatus;
 import com.example.testserver.domain.TestItem;
 import com.example.testserver.domain.TestItemRepository;
 import com.example.testserver.event.TestItemCreatedEvent;
+import com.example.testserver.exception.TestErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;


### PR DESCRIPTION
## Summary

- Product 서비스에서 아이템 생성 시 발행하는 `ItemCreatedEvent`에 재고 초기화에 필요한 상세 정보(SeatGrade/ItemOption의 type, referenceId, totalQuantity)를 포함하도록 보강
- Stock 서비스의 `ItemEventConsumer`가 `ITEM_CREATED` 이벤트 수신 시 자동으로 `initializeStock()`을 호출하여 재고 초기화
- Outbox 모듈의 Kafka payload에 `eventId`/`eventType` envelope을 포함하도록 수정 (모든 Consumer의 멱등성 처리 지원)

## 변경 사항

### Product Service
- `ItemCreatedEvent`: `StockItemInfo` 내부 클래스 및 `stockItems` 필드 추가
- `PerformanceCommandService`: 공연 생성 시 SeatGrade → StockItemInfo 매핑 후 이벤트 발행
- `GoodsCommandService`: 굿즈 생성 시 ItemOption → StockItemInfo 매핑 후 이벤트 발행
- `ProductCommandService`: 일반상품 생성 시 동일 패턴 적용

### Stock Service
- `ItemEventMessage`: `stockItems` 필드 + `StockItemPayload` 내부 클래스 추가
- `ItemEventConsumer`: `handleItemCreated()`에서 stockItems 루프 → `initializeStock()` 호출
- `InitializeStockRequest`: `of()` 팩토리 메서드 추가

### Outbox 공통 모듈
- `OutboxService`: payload에 `eventId`/`eventType` envelope 포함

## 검증

- 공연 생성 → Kafka 이벤트 → Stock SEAT_GRADE 자동 초기화 (VIP: 100, R석: 400) ✅
- 굿즈 생성 → Kafka 이벤트 → Stock ITEM_OPTION 자동 초기화 (블랙: 50, 화이트: 30) ✅  
- 일반상품 생성 → Kafka 이벤트 → Stock ITEM_OPTION 자동 초기화 (기본: 200) ✅
- TCC Reserve → Confirm → 재고 차감 확정 ✅
- TCC Reserve → Cancel → 재고 복구 ✅

Closes #487