### PR TITLE
feat: Funding Service 핵심 기능 구현

### DIFF
--- a/servers/services/funding/build.gradle.kts
+++ b/servers/services/funding/build.gradle.kts
@@ -1,0 +1,49 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+    implementation(project(":libs:config:webclient"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/funding/src/main/java/com/example/funding/FundingApplication.java
+++ b/servers/services/funding/src/main/java/com/example/funding/FundingApplication.java
@@ -1,0 +1,16 @@
+package com.example.funding;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(scanBasePackages = "com.example")
+@EnableAsync
+@EnableScheduling
+public class FundingApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FundingApplication.class, args);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
+++ b/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
@@ -1,0 +1,104 @@
+package com.example.funding.client;
+
+import com.example.core.exception.BusinessException;
+import com.example.funding.exception.FundingErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class StockClient {
+
+    private final WebClient webClient;
+
+    public StockClient(WebClient.Builder webClientBuilder,
+                       @Value("${app.service.stock-url}") String stockUrl) {
+        this.webClient = webClientBuilder.baseUrl(stockUrl).build();
+    }
+
+    public Long reserveStock(Long stockItemId, Long userId, int quantity) {
+        Map<String, Object> body = Map.of(
+                "stockItemId", stockItemId,
+                "userId", userId,
+                "quantity", quantity
+        );
+
+        try {
+            JsonNode response = webClient.post()
+                    .uri("/internal/v1/stock/reserve")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
+            }
+
+            return response.path("data").path("id").asLong();
+        } catch (WebClientResponseException.Conflict e) {
+            throw new BusinessException(FundingErrorCode.STOCK_INSUFFICIENT);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Stock reserve failed: stockItemId={}, userId={}, quantity={}",
+                    stockItemId, userId, quantity, e);
+            throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
+        }
+    }
+
+    public void cancelReservation(Long reservationId) {
+        Map<String, Object> body = Map.of("reservationId", reservationId);
+
+        try {
+            webClient.post()
+                    .uri("/internal/v1/stock/cancel")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+        } catch (Exception e) {
+            log.error("Stock cancel failed: reservationId={}", reservationId, e);
+            throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
+        }
+    }
+
+    public Long findStockItemId(Long itemId, Long referenceId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/stock/item/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
+            }
+
+            JsonNode dataNode = response.path("data");
+            List<JsonNode> stocks = new ArrayList<>();
+            if (dataNode.isArray()) {
+                dataNode.forEach(stocks::add);
+            }
+
+            return stocks.stream()
+                    .filter(s -> s.path("referenceId").asLong() == referenceId)
+                    .findFirst()
+                    .map(s -> s.path("id").asLong())
+                    .orElseThrow(() -> new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR));
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Stock lookup failed: itemId={}, referenceId={}", itemId, referenceId, e);
+            throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
+        }
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
+++ b/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
@@ -74,7 +74,7 @@ public class StockClient {
     public Long findStockItemId(Long itemId, Long referenceId) {
         try {
             JsonNode response = webClient.get()
-                    .uri("/internal/v1/stock/item/{itemId}", itemId)
+                    .uri("/internal/v1/stock/items/{itemId}", itemId)
                     .retrieve()
                     .bodyToMono(JsonNode.class)
                     .block();
@@ -83,16 +83,16 @@ public class StockClient {
                 throw new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR);
             }
 
-            JsonNode dataNode = response.path("data");
+            JsonNode stocksNode = response.path("data").path("stocks");
             List<JsonNode> stocks = new ArrayList<>();
-            if (dataNode.isArray()) {
-                dataNode.forEach(stocks::add);
+            if (stocksNode.isArray()) {
+                stocksNode.forEach(stocks::add);
             }
 
             return stocks.stream()
                     .filter(s -> s.path("referenceId").asLong() == referenceId)
                     .findFirst()
-                    .map(s -> s.path("id").asLong())
+                    .map(s -> s.path("stockItemId").asLong())
                     .orElseThrow(() -> new BusinessException(FundingErrorCode.STOCK_SERVICE_ERROR));
         } catch (BusinessException e) {
             throw e;

--- a/servers/services/funding/src/main/java/com/example/funding/config/JpaConfig.java
+++ b/servers/services/funding/src/main/java/com/example/funding/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.example.funding.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example.funding.repository")
+public class JpaConfig {
+}

--- a/servers/services/funding/src/main/java/com/example/funding/consumer/PaymentEventConsumer.java
+++ b/servers/services/funding/src/main/java/com/example/funding/consumer/PaymentEventConsumer.java
@@ -1,0 +1,70 @@
+package com.example.funding.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import com.example.funding.entity.FundingParticipation;
+import com.example.funding.repository.FundingParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventConsumer {
+
+    private final FundingParticipationRepository participationRepository;
+    private final IdempotentConsumerService idempotentConsumerService;
+
+    @KafkaListener(topics = "payment-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) {
+        PaymentEventMessage event = JsonUtils.fromJson(message, PaymentEventMessage.class);
+
+        if (event.getEventId() == null || event.getEventType() == null) {
+            log.error("[PaymentConsumer] eventId 또는 eventType이 null입니다. message={}", message);
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), "PAYMENT_EVENT", () -> {
+            switch (event.getEventType()) {
+                case "PAYMENT_COMPLETED" -> handlePaymentCompleted(event);
+                case "PAYMENT_CANCELLED", "PAYMENT_TIMED_OUT" -> handlePaymentFailed(event);
+                default -> log.debug("처리하지 않는 이벤트 타입: {}", event.getEventType());
+            }
+            return null;
+        });
+    }
+
+    private void handlePaymentCompleted(PaymentEventMessage event) {
+        FundingParticipation participation = participationRepository
+                .findById(event.getParticipationId())
+                .orElse(null);
+
+        if (participation == null) {
+            log.warn("[PaymentConsumer] 참여 내역 없음: participationId={}", event.getParticipationId());
+            return;
+        }
+
+        participation.confirm(event.getPaymentId());
+        log.info("[PaymentConsumer] 참여 확정: participationId={}, paymentId={}",
+                event.getParticipationId(), event.getPaymentId());
+    }
+
+    private void handlePaymentFailed(PaymentEventMessage event) {
+        FundingParticipation participation = participationRepository
+                .findById(event.getParticipationId())
+                .orElse(null);
+
+        if (participation == null) {
+            log.warn("[PaymentConsumer] 참여 내역 없음: participationId={}", event.getParticipationId());
+            return;
+        }
+
+        participation.refund();
+        log.info("[PaymentConsumer] 참여 환불 처리: participationId={}, eventType={}",
+                event.getParticipationId(), event.getEventType());
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/consumer/PaymentEventMessage.java
+++ b/servers/services/funding/src/main/java/com/example/funding/consumer/PaymentEventMessage.java
@@ -1,0 +1,15 @@
+package com.example.funding.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long participationId;
+    private Long paymentId;
+    private Long userId;
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/api/command/CampaignCommandApi.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/api/command/CampaignCommandApi.java
@@ -1,0 +1,51 @@
+package com.example.funding.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.funding.dto.campaign.request.CampaignCreateRequest;
+import com.example.funding.dto.campaign.request.CampaignUpdateRequest;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Campaign Command", description = "펀딩 캠페인 관리 API (쓰기)")
+public interface CampaignCommandApi {
+
+    @Operation(summary = "펀딩 캠페인 생성")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 캠페인")
+    })
+    @PostMapping
+    ApiResponse<CampaignResponse> create(
+            @Valid @RequestBody CampaignCreateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "펀딩 캠페인 수정")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음")
+    })
+    @PutMapping("/{campaignId}")
+    ApiResponse<CampaignResponse> update(
+            @PathVariable Long campaignId,
+            @Valid @RequestBody CampaignUpdateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+
+    @Operation(summary = "펀딩 캠페인 취소")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "취소 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "취소 불가 상태")
+    })
+    @PostMapping("/{campaignId}/cancel")
+    ApiResponse<Void> cancel(
+            @PathVariable Long campaignId,
+            @RequestParam(required = false) String reason,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/api/command/ParticipationCommandApi.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/api/command/ParticipationCommandApi.java
@@ -1,0 +1,41 @@
+package com.example.funding.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.funding.dto.participation.request.ParticipateRequest;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Participation Command", description = "펀딩 참여 API (쓰기)")
+public interface ParticipationCommandApi {
+
+    @Operation(summary = "펀딩 참여")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "참여 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "재고 부족")
+    })
+    @PostMapping("/{campaignId}/participate")
+    ApiResponse<ParticipationResponse> participate(
+            @PathVariable Long campaignId,
+            @Valid @RequestBody ParticipateRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "펀딩 참여 환불")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "환불 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "참여 내역 없음")
+    })
+    @PostMapping("/participations/{participationId}/refund")
+    ApiResponse<Void> refund(
+            @PathVariable Long participationId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/api/query/CampaignQueryApi.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/api/query/CampaignQueryApi.java
@@ -3,6 +3,7 @@ package com.example.funding.controller.api.query;
 import com.example.api.response.ApiResponse;
 import com.example.core.pagination.CursorResponse;
 import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.dto.campaign.response.ProgressResponse;
 import com.example.funding.dto.campaign.response.StatusHistoryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -41,6 +42,14 @@ public interface CampaignQueryApi {
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String status);
+
+    @Operation(summary = "펀딩 진행률 조회 (실시간 캐시)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음")
+    })
+    @GetMapping("/{campaignId}/progress")
+    ApiResponse<ProgressResponse> getProgress(@PathVariable Long campaignId);
 
     @Operation(summary = "펀딩 캠페인 상태 이력 조회")
     @ApiResponses({

--- a/servers/services/funding/src/main/java/com/example/funding/controller/api/query/CampaignQueryApi.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/api/query/CampaignQueryApi.java
@@ -1,0 +1,52 @@
+package com.example.funding.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.dto.campaign.response.StatusHistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Campaign Query", description = "펀딩 캠페인 조회 API (읽기)")
+public interface CampaignQueryApi {
+
+    @Operation(summary = "펀딩 캠페인 상세 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음")
+    })
+    @GetMapping("/{campaignId}")
+    ApiResponse<CampaignResponse> findById(@PathVariable Long campaignId);
+
+    @Operation(summary = "상품별 펀딩 캠페인 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음")
+    })
+    @GetMapping("/item/{itemId}")
+    ApiResponse<CampaignResponse> findByItemId(@PathVariable Long itemId);
+
+    @Operation(summary = "펀딩 캠페인 목록 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping
+    ApiResponse<CursorResponse<CampaignResponse>> findList(
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String status);
+
+    @Operation(summary = "펀딩 캠페인 상태 이력 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인 없음")
+    })
+    @GetMapping("/{campaignId}/status-history")
+    ApiResponse<List<StatusHistoryResponse>> findStatusHistory(@PathVariable Long campaignId);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/api/query/ParticipationQueryApi.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/api/query/ParticipationQueryApi.java
@@ -1,0 +1,36 @@
+package com.example.funding.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Participation Query", description = "펀딩 참여 조회 API (읽기)")
+public interface ParticipationQueryApi {
+
+    @Operation(summary = "내 펀딩 참여 내역 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/participations/me")
+    ApiResponse<CursorResponse<ParticipationResponse>> findMyParticipations(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "캠페인별 참여 내역 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/{campaignId}/participations")
+    ApiResponse<List<ParticipationResponse>> findByCampaignId(@PathVariable Long campaignId);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/command/CampaignCommandController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/command/CampaignCommandController.java
@@ -1,0 +1,35 @@
+package com.example.funding.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.funding.controller.api.command.CampaignCommandApi;
+import com.example.funding.dto.campaign.request.CampaignCreateRequest;
+import com.example.funding.dto.campaign.request.CampaignUpdateRequest;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.service.command.CampaignCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/campaigns")
+@RequiredArgsConstructor
+public class CampaignCommandController implements CampaignCommandApi {
+
+    private final CampaignCommandService campaignCommandService;
+
+    @Override
+    public ApiResponse<CampaignResponse> create(CampaignCreateRequest request, Long sellerId) {
+        return ApiResponse.success(campaignCommandService.create(request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<CampaignResponse> update(Long campaignId, CampaignUpdateRequest request, Long sellerId) {
+        return ApiResponse.success(campaignCommandService.update(campaignId, request, sellerId));
+    }
+
+    @Override
+    public ApiResponse<Void> cancel(Long campaignId, String reason, Long sellerId) {
+        campaignCommandService.cancel(campaignId, reason, sellerId);
+        return ApiResponse.success();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/command/ParticipationCommandController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/command/ParticipationCommandController.java
@@ -1,0 +1,30 @@
+package com.example.funding.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.funding.controller.api.command.ParticipationCommandApi;
+import com.example.funding.dto.participation.request.ParticipateRequest;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import com.example.funding.service.command.ParticipationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/campaigns")
+@RequiredArgsConstructor
+public class ParticipationCommandController implements ParticipationCommandApi {
+
+    private final ParticipationCommandService participationCommandService;
+
+    @Override
+    public ApiResponse<ParticipationResponse> participate(Long campaignId,
+                                                           ParticipateRequest request, Long userId) {
+        return ApiResponse.success(participationCommandService.participate(campaignId, request, userId));
+    }
+
+    @Override
+    public ApiResponse<Void> refund(Long participationId, Long userId) {
+        participationCommandService.refund(participationId, userId);
+        return ApiResponse.success();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/query/CampaignQueryController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/query/CampaignQueryController.java
@@ -4,7 +4,9 @@ import com.example.api.response.ApiResponse;
 import com.example.core.pagination.CursorResponse;
 import com.example.funding.controller.api.query.CampaignQueryApi;
 import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.dto.campaign.response.ProgressResponse;
 import com.example.funding.dto.campaign.response.StatusHistoryResponse;
+import com.example.funding.service.CampaignCacheService;
 import com.example.funding.service.query.CampaignQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +20,7 @@ import java.util.List;
 public class CampaignQueryController implements CampaignQueryApi {
 
     private final CampaignQueryService campaignQueryService;
+    private final CampaignCacheService campaignCacheService;
 
     @Override
     public ApiResponse<CampaignResponse> findById(Long campaignId) {
@@ -32,6 +35,11 @@ public class CampaignQueryController implements CampaignQueryApi {
     @Override
     public ApiResponse<CursorResponse<CampaignResponse>> findList(String cursor, int size, String status) {
         return ApiResponse.success(campaignQueryService.findList(cursor, size, status));
+    }
+
+    @Override
+    public ApiResponse<ProgressResponse> getProgress(Long campaignId) {
+        return ApiResponse.success(campaignCacheService.getProgress(campaignId));
     }
 
     @Override

--- a/servers/services/funding/src/main/java/com/example/funding/controller/query/CampaignQueryController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/query/CampaignQueryController.java
@@ -1,0 +1,41 @@
+package com.example.funding.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.funding.controller.api.query.CampaignQueryApi;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.dto.campaign.response.StatusHistoryResponse;
+import com.example.funding.service.query.CampaignQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/campaigns")
+@RequiredArgsConstructor
+public class CampaignQueryController implements CampaignQueryApi {
+
+    private final CampaignQueryService campaignQueryService;
+
+    @Override
+    public ApiResponse<CampaignResponse> findById(Long campaignId) {
+        return ApiResponse.success(campaignQueryService.findById(campaignId));
+    }
+
+    @Override
+    public ApiResponse<CampaignResponse> findByItemId(Long itemId) {
+        return ApiResponse.success(campaignQueryService.findByItemId(itemId));
+    }
+
+    @Override
+    public ApiResponse<CursorResponse<CampaignResponse>> findList(String cursor, int size, String status) {
+        return ApiResponse.success(campaignQueryService.findList(cursor, size, status));
+    }
+
+    @Override
+    public ApiResponse<List<StatusHistoryResponse>> findStatusHistory(Long campaignId) {
+        return ApiResponse.success(campaignQueryService.findStatusHistory(campaignId));
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/query/InternalCampaignQueryController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/query/InternalCampaignQueryController.java
@@ -1,0 +1,38 @@
+package com.example.funding.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.service.query.InternalCampaignQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Internal", description = "내부 서비스 간 호출용 API")
+@RestController
+@RequestMapping("/internal/v1/campaigns")
+@RequiredArgsConstructor
+public class InternalCampaignQueryController {
+
+    private final InternalCampaignQueryService internalCampaignQueryService;
+
+    @Operation(summary = "캠페인 단건 조회 (내부)")
+    @GetMapping("/{campaignId}")
+    public ApiResponse<CampaignResponse> findById(@PathVariable Long campaignId) {
+        return ApiResponse.success(internalCampaignQueryService.findById(campaignId));
+    }
+
+    @Operation(summary = "상품별 캠페인 조회 (내부)")
+    @GetMapping("/item/{itemId}")
+    public ApiResponse<CampaignResponse> findByItemId(@PathVariable Long itemId) {
+        return ApiResponse.success(internalCampaignQueryService.findByItemId(itemId));
+    }
+
+    @Operation(summary = "캠페인 다건 조회 (내부)")
+    @PostMapping("/batch")
+    public ApiResponse<List<CampaignResponse>> findByIds(@RequestBody List<Long> campaignIds) {
+        return ApiResponse.success(internalCampaignQueryService.findByIds(campaignIds));
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/controller/query/ParticipationQueryController.java
+++ b/servers/services/funding/src/main/java/com/example/funding/controller/query/ParticipationQueryController.java
@@ -1,0 +1,31 @@
+package com.example.funding.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.funding.controller.api.query.ParticipationQueryApi;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import com.example.funding.service.query.ParticipationQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/campaigns")
+@RequiredArgsConstructor
+public class ParticipationQueryController implements ParticipationQueryApi {
+
+    private final ParticipationQueryService participationQueryService;
+
+    @Override
+    public ApiResponse<CursorResponse<ParticipationResponse>> findMyParticipations(
+            Long userId, String cursor, int size) {
+        return ApiResponse.success(participationQueryService.findByUserId(userId, cursor, size));
+    }
+
+    @Override
+    public ApiResponse<List<ParticipationResponse>> findByCampaignId(Long campaignId) {
+        return ApiResponse.success(participationQueryService.findByCampaignId(campaignId));
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/campaign/request/CampaignCreateRequest.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/campaign/request/CampaignCreateRequest.java
@@ -1,0 +1,35 @@
+package com.example.funding.dto.campaign.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CampaignCreateRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다")
+    private Long itemId;
+
+    @NotNull(message = "펀딩 유형은 필수입니다")
+    private String fundingType;
+
+    @NotNull(message = "목표 금액은 필수입니다")
+    @Min(value = 1, message = "목표 금액은 1 이상이어야 합니다")
+    private Long goalAmount;
+
+    @Min(value = 1, message = "목표 수량은 1 이상이어야 합니다")
+    private Integer goalQuantity;
+
+    @Min(value = 1, message = "최소 참여 금액은 1 이상이어야 합니다")
+    private Long minAmount;
+
+    @NotNull(message = "시작 일시는 필수입니다")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "종료 일시는 필수입니다")
+    private LocalDateTime endAt;
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/campaign/request/CampaignUpdateRequest.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/campaign/request/CampaignUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.example.funding.dto.campaign.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CampaignUpdateRequest {
+
+    @NotNull(message = "목표 금액은 필수입니다")
+    @Min(value = 1, message = "목표 금액은 1 이상이어야 합니다")
+    private Long goalAmount;
+
+    @Min(value = 1, message = "목표 수량은 1 이상이어야 합니다")
+    private Integer goalQuantity;
+
+    @Min(value = 1, message = "최소 참여 금액은 1 이상이어야 합니다")
+    private Long minAmount;
+
+    @NotNull(message = "시작 일시는 필수입니다")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "종료 일시는 필수입니다")
+    private LocalDateTime endAt;
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/CampaignResponse.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/CampaignResponse.java
@@ -1,0 +1,53 @@
+package com.example.funding.dto.campaign.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.funding.entity.FundingCampaign;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CampaignResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    @SnowflakeId
+    private Long itemId;
+
+    @SnowflakeId
+    private Long sellerId;
+
+    private String fundingType;
+    private Long goalAmount;
+    private Long currentAmount;
+    private Integer goalQuantity;
+    private Integer currentQuantity;
+    private Long minAmount;
+    private String status;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CampaignResponse from(FundingCampaign campaign) {
+        return CampaignResponse.builder()
+                .id(campaign.getId())
+                .itemId(campaign.getItemId())
+                .sellerId(campaign.getSellerId())
+                .fundingType(campaign.getFundingType().name())
+                .goalAmount(campaign.getGoalAmount())
+                .currentAmount(campaign.getCurrentAmount())
+                .goalQuantity(campaign.getGoalQuantity())
+                .currentQuantity(campaign.getCurrentQuantity())
+                .minAmount(campaign.getMinAmount())
+                .status(campaign.getStatus().name())
+                .startAt(campaign.getStartAt())
+                .endAt(campaign.getEndAt())
+                .createdAt(campaign.getCreatedAt())
+                .updatedAt(campaign.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/ProgressResponse.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/ProgressResponse.java
@@ -1,0 +1,35 @@
+package com.example.funding.dto.campaign.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProgressResponse {
+
+    @SnowflakeId
+    private Long campaignId;
+
+    private Long currentAmount;
+    private Long goalAmount;
+    private Integer currentQuantity;
+    private Integer goalQuantity;
+    private double progressRate;
+
+    public static ProgressResponse of(Long campaignId, Long currentAmount, Long goalAmount,
+                                       Integer currentQuantity, Integer goalQuantity) {
+        double rate = goalAmount > 0
+                ? Math.round((double) currentAmount / goalAmount * 10000) / 100.0
+                : 0.0;
+
+        return ProgressResponse.builder()
+                .campaignId(campaignId)
+                .currentAmount(currentAmount)
+                .goalAmount(goalAmount)
+                .currentQuantity(currentQuantity)
+                .goalQuantity(goalQuantity)
+                .progressRate(rate)
+                .build();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/StatusHistoryResponse.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/campaign/response/StatusHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.example.funding.dto.campaign.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.funding.entity.FundingStatusHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StatusHistoryResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    @SnowflakeId
+    private Long campaignId;
+
+    private String previousStatus;
+    private String newStatus;
+    private String reason;
+    private LocalDateTime createdAt;
+
+    public static StatusHistoryResponse from(FundingStatusHistory history) {
+        return StatusHistoryResponse.builder()
+                .id(history.getId())
+                .campaignId(history.getCampaignId())
+                .previousStatus(history.getPreviousStatus().name())
+                .newStatus(history.getNewStatus().name())
+                .reason(history.getReason())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/participation/request/ParticipateRequest.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/participation/request/ParticipateRequest.java
@@ -1,0 +1,22 @@
+package com.example.funding.dto.participation.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParticipateRequest {
+
+    @NotNull(message = "참여 금액은 필수입니다")
+    @Min(value = 1, message = "참여 금액은 1 이상이어야 합니다")
+    private Long amount;
+
+    @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+    private Integer quantity;
+
+    private Long seatGradeId;
+
+    private Long itemOptionId;
+}

--- a/servers/services/funding/src/main/java/com/example/funding/dto/participation/response/ParticipationResponse.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/participation/response/ParticipationResponse.java
@@ -1,0 +1,59 @@
+package com.example.funding.dto.participation.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.funding.entity.FundingParticipation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ParticipationResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    @SnowflakeId
+    private Long campaignId;
+
+    @SnowflakeId
+    private Long userId;
+
+    private Long amount;
+    private Integer quantity;
+
+    @SnowflakeId
+    private Long seatGradeId;
+
+    @SnowflakeId
+    private Long itemOptionId;
+
+    private String status;
+
+    @SnowflakeId
+    private Long reservationId;
+
+    @SnowflakeId
+    private Long paymentId;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ParticipationResponse from(FundingParticipation p) {
+        return ParticipationResponse.builder()
+                .id(p.getId())
+                .campaignId(p.getCampaignId())
+                .userId(p.getUserId())
+                .amount(p.getAmount())
+                .quantity(p.getQuantity())
+                .seatGradeId(p.getSeatGradeId())
+                .itemOptionId(p.getItemOptionId())
+                .status(p.getStatus().name())
+                .reservationId(p.getReservationId())
+                .paymentId(p.getPaymentId())
+                .createdAt(p.getCreatedAt())
+                .updatedAt(p.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
@@ -1,6 +1,7 @@
 package com.example.funding.entity;
 
 import com.example.core.exception.BusinessException;
+import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import com.example.funding.exception.FundingErrorCode;
 import jakarta.persistence.*;
@@ -24,7 +25,7 @@ import java.time.LocalDateTime;
 public class FundingCampaign extends BaseEntity {
 
     @Id
-    @com.example.core.id.jpa.SnowflakeGenerated
+    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "item_id", nullable = false, unique = true)

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
@@ -1,0 +1,131 @@
+package com.example.funding.entity;
+
+import com.example.core.exception.BusinessException;
+import com.example.data.entity.BaseEntity;
+import com.example.funding.exception.FundingErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "funding_campaigns",
+        indexes = {
+                @Index(name = "idx_campaign_item_id", columnList = "itemId", unique = true),
+                @Index(name = "idx_campaign_status", columnList = "status"),
+                @Index(name = "idx_campaign_end_at", columnList = "endAt")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class FundingCampaign extends BaseEntity {
+
+    @Id
+    @com.example.core.id.jpa.SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false, unique = true)
+    private Long itemId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "funding_type", nullable = false, length = 20)
+    private FundingType fundingType;
+
+    @Column(name = "goal_amount", nullable = false)
+    private Long goalAmount;
+
+    @Column(name = "current_amount", nullable = false)
+    private Long currentAmount;
+
+    @Column(name = "goal_quantity")
+    private Integer goalQuantity;
+
+    @Column(name = "current_quantity", nullable = false)
+    private Integer currentQuantity;
+
+    @Column(name = "min_amount")
+    private Long minAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FundingStatus status;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    public static FundingCampaign create(Long itemId, Long sellerId, FundingType fundingType,
+                                          Long goalAmount, Integer goalQuantity, Long minAmount,
+                                          LocalDateTime startAt, LocalDateTime endAt) {
+        FundingCampaign campaign = new FundingCampaign();
+        campaign.itemId = itemId;
+        campaign.sellerId = sellerId;
+        campaign.fundingType = fundingType;
+        campaign.goalAmount = goalAmount;
+        campaign.currentAmount = 0L;
+        campaign.goalQuantity = goalQuantity;
+        campaign.currentQuantity = 0;
+        campaign.minAmount = minAmount;
+        campaign.status = FundingStatus.ACTIVE;
+        campaign.startAt = startAt;
+        campaign.endAt = endAt;
+        return campaign;
+    }
+
+    public void changeStatus(FundingStatus newStatus) {
+        this.status.validateTransitionTo(newStatus);
+        this.status = newStatus;
+    }
+
+    public void addParticipation(Long amount, int quantity) {
+        this.currentAmount += amount;
+        this.currentQuantity += quantity;
+    }
+
+    public void removeParticipation(Long amount, int quantity) {
+        this.currentAmount -= amount;
+        this.currentQuantity -= quantity;
+    }
+
+    public boolean isGoalReached() {
+        if (fundingType == FundingType.AMOUNT_BASED) {
+            return currentAmount >= goalAmount;
+        }
+        return (goalQuantity != null && currentQuantity >= goalQuantity)
+                || currentAmount >= goalAmount;
+    }
+
+    public boolean isActive() {
+        return this.status == FundingStatus.ACTIVE;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.endAt);
+    }
+
+    public void validateOwnership(Long sellerId) {
+        if (!this.sellerId.equals(sellerId)) {
+            throw new BusinessException(FundingErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    public void update(Long goalAmount, Integer goalQuantity, Long minAmount,
+                       LocalDateTime startAt, LocalDateTime endAt) {
+        if (!isActive()) {
+            throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_EDITABLE);
+        }
+        this.goalAmount = goalAmount;
+        this.goalQuantity = goalQuantity;
+        this.minAmount = minAmount;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
@@ -1,0 +1,77 @@
+package com.example.funding.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "funding_participations",
+        indexes = {
+                @Index(name = "idx_participation_campaign_id", columnList = "campaignId"),
+                @Index(name = "idx_participation_user_id", columnList = "userId"),
+                @Index(name = "idx_participation_status", columnList = "status")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class FundingParticipation extends BaseEntity {
+
+    @Id
+    @com.example.core.id.jpa.SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "campaign_id", nullable = false)
+    private Long campaignId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "seat_grade_id")
+    private Long seatGradeId;
+
+    @Column(name = "item_option_id")
+    private Long itemOptionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ParticipationStatus status;
+
+    @Column(name = "reservation_id")
+    private Long reservationId;
+
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    public static FundingParticipation create(Long campaignId, Long userId, Long amount,
+                                               Integer quantity, Long seatGradeId,
+                                               Long itemOptionId, Long reservationId) {
+        FundingParticipation p = new FundingParticipation();
+        p.campaignId = campaignId;
+        p.userId = userId;
+        p.amount = amount;
+        p.quantity = quantity;
+        p.seatGradeId = seatGradeId;
+        p.itemOptionId = itemOptionId;
+        p.reservationId = reservationId;
+        p.status = ParticipationStatus.PENDING;
+        return p;
+    }
+
+    public void confirm(Long paymentId) {
+        this.status = ParticipationStatus.CONFIRMED;
+        this.paymentId = paymentId;
+    }
+
+    public void refund() {
+        this.status = ParticipationStatus.REFUNDED;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
@@ -1,5 +1,6 @@
 package com.example.funding.entity;
 
+import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -20,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class FundingParticipation extends BaseEntity {
 
     @Id
-    @com.example.core.id.jpa.SnowflakeGenerated
+    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "campaign_id", nullable = false)

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatus.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatus.java
@@ -1,0 +1,32 @@
+package com.example.funding.entity;
+
+import com.example.core.exception.BusinessException;
+import com.example.funding.exception.FundingErrorCode;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum FundingStatus {
+
+    ACTIVE,
+    SUCCEEDED,
+    FAILED,
+    CANCELLED;
+
+    private static final Map<FundingStatus, Set<FundingStatus>> TRANSITIONS = Map.of(
+            ACTIVE, Set.of(SUCCEEDED, FAILED, CANCELLED),
+            SUCCEEDED, Set.of(),
+            FAILED, Set.of(),
+            CANCELLED, Set.of()
+    );
+
+    public void validateTransitionTo(FundingStatus target) {
+        if (!canTransitionTo(target)) {
+            throw new BusinessException(FundingErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
+
+    public boolean canTransitionTo(FundingStatus target) {
+        return TRANSITIONS.getOrDefault(this, Set.of()).contains(target);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatusHistory.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatusHistory.java
@@ -1,0 +1,45 @@
+package com.example.funding.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "funding_status_histories",
+        indexes = {
+                @Index(name = "idx_funding_status_history_campaign_id", columnList = "campaignId")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FundingStatusHistory extends BaseEntity {
+
+    @Id
+    @com.example.core.id.jpa.SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "campaign_id", nullable = false)
+    private Long campaignId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", nullable = false, length = 20)
+    private FundingStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "new_status", nullable = false, length = 20)
+    private FundingStatus newStatus;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    public static FundingStatusHistory create(Long campaignId, FundingStatus previousStatus,
+                                               FundingStatus newStatus, String reason) {
+        FundingStatusHistory history = new FundingStatusHistory();
+        history.campaignId = campaignId;
+        history.previousStatus = previousStatus;
+        history.newStatus = newStatus;
+        history.reason = reason;
+        return history;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatusHistory.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingStatusHistory.java
@@ -1,5 +1,6 @@
 package com.example.funding.entity;
 
+import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class FundingStatusHistory extends BaseEntity {
 
     @Id
-    @com.example.core.id.jpa.SnowflakeGenerated
+    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "campaign_id", nullable = false)

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingType.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingType.java
@@ -1,0 +1,6 @@
+package com.example.funding.entity;
+
+public enum FundingType {
+    QUANTITY_BASED,
+    AMOUNT_BASED
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/ParticipationStatus.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/ParticipationStatus.java
@@ -1,0 +1,7 @@
+package com.example.funding.entity;
+
+public enum ParticipationStatus {
+    PENDING,
+    CONFIRMED,
+    REFUNDED
+}

--- a/servers/services/funding/src/main/java/com/example/funding/event/FundingCreatedEvent.java
+++ b/servers/services/funding/src/main/java/com/example/funding/event/FundingCreatedEvent.java
@@ -1,0 +1,51 @@
+package com.example.funding.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class FundingCreatedEvent extends DomainEvent {
+
+    private final Long campaignId;
+    private final Long itemId;
+    private final Long sellerId;
+    private final String fundingType;
+    private final Long goalAmount;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+
+    public FundingCreatedEvent(Long campaignId, Long itemId, Long sellerId,
+                                String fundingType, Long goalAmount,
+                                LocalDateTime startAt, LocalDateTime endAt) {
+        super("funding-events");
+        this.campaignId = campaignId;
+        this.itemId = itemId;
+        this.sellerId = sellerId;
+        this.fundingType = fundingType;
+        this.goalAmount = goalAmount;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "FUNDING_CREATED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("campaignId", campaignId);
+        payload.put("itemId", itemId);
+        payload.put("sellerId", sellerId);
+        payload.put("fundingType", fundingType);
+        payload.put("goalAmount", goalAmount);
+        payload.put("startAt", startAt.toString());
+        payload.put("endAt", endAt.toString());
+        return payload;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/event/FundingFailedEvent.java
+++ b/servers/services/funding/src/main/java/com/example/funding/event/FundingFailedEvent.java
@@ -1,0 +1,50 @@
+package com.example.funding.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class FundingFailedEvent extends DomainEvent {
+
+    private final Long campaignId;
+    private final Long itemId;
+    private final Long sellerId;
+    private final String fundingType;
+    private final Long goalAmount;
+    private final Long currentAmount;
+    private final Integer currentQuantity;
+
+    public FundingFailedEvent(Long campaignId, Long itemId, Long sellerId,
+                               String fundingType, Long goalAmount,
+                               Long currentAmount, Integer currentQuantity) {
+        super("funding-events");
+        this.campaignId = campaignId;
+        this.itemId = itemId;
+        this.sellerId = sellerId;
+        this.fundingType = fundingType;
+        this.goalAmount = goalAmount;
+        this.currentAmount = currentAmount;
+        this.currentQuantity = currentQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "FUNDING_FAILED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("campaignId", campaignId);
+        payload.put("itemId", itemId);
+        payload.put("sellerId", sellerId);
+        payload.put("fundingType", fundingType);
+        payload.put("goalAmount", goalAmount);
+        payload.put("currentAmount", currentAmount);
+        payload.put("currentQuantity", currentQuantity);
+        return payload;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/event/FundingSucceededEvent.java
+++ b/servers/services/funding/src/main/java/com/example/funding/event/FundingSucceededEvent.java
@@ -1,0 +1,50 @@
+package com.example.funding.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class FundingSucceededEvent extends DomainEvent {
+
+    private final Long campaignId;
+    private final Long itemId;
+    private final Long sellerId;
+    private final String fundingType;
+    private final Long goalAmount;
+    private final Long currentAmount;
+    private final Integer currentQuantity;
+
+    public FundingSucceededEvent(Long campaignId, Long itemId, Long sellerId,
+                                  String fundingType, Long goalAmount,
+                                  Long currentAmount, Integer currentQuantity) {
+        super("funding-events");
+        this.campaignId = campaignId;
+        this.itemId = itemId;
+        this.sellerId = sellerId;
+        this.fundingType = fundingType;
+        this.goalAmount = goalAmount;
+        this.currentAmount = currentAmount;
+        this.currentQuantity = currentQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "FUNDING_SUCCEEDED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("campaignId", campaignId);
+        payload.put("itemId", itemId);
+        payload.put("sellerId", sellerId);
+        payload.put("fundingType", fundingType);
+        payload.put("goalAmount", goalAmount);
+        payload.put("currentAmount", currentAmount);
+        payload.put("currentQuantity", currentQuantity);
+        return payload;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/exception/FundingErrorCode.java
+++ b/servers/services/funding/src/main/java/com/example/funding/exception/FundingErrorCode.java
@@ -1,0 +1,39 @@
+package com.example.funding.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FundingErrorCode implements DomainErrorCode {
+
+    // ─── 캠페인 ────────────────────────────────
+    CAMPAIGN_NOT_FOUND("FUNDING-001", "펀딩 캠페인을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CAMPAIGN_NOT_ACTIVE("FUNDING-002", "진행 중인 펀딩이 아닙니다.", HttpStatus.BAD_REQUEST),
+    CAMPAIGN_ALREADY_EXISTS("FUNDING-003", "해당 상품에 이미 펀딩 캠페인이 존재합니다.", HttpStatus.CONFLICT),
+    CAMPAIGN_NOT_EDITABLE("FUNDING-004", "수정할 수 없는 상태의 캠페인입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CAMPAIGN_PERIOD("FUNDING-005", "유효하지 않은 펀딩 기간입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_STATUS_TRANSITION("FUNDING-006", "유효하지 않은 상태 전이입니다.", HttpStatus.BAD_REQUEST),
+
+    // ─── 참여 ────────────────────────────────
+    PARTICIPATION_NOT_FOUND("FUNDING-101", "참여 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    GOAL_QUANTITY_EXCEEDED("FUNDING-102", "펀딩 목표 수량을 초과했습니다.", HttpStatus.CONFLICT),
+    BELOW_MIN_AMOUNT("FUNDING-103", "최소 참여 금액 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_PARTICIPATED("FUNDING-104", "이미 참여한 펀딩입니다.", HttpStatus.CONFLICT),
+    INVALID_PARTICIPATION_STATUS("FUNDING-105", "유효하지 않은 참여 상태 변경입니다.", HttpStatus.BAD_REQUEST),
+
+    // ─── 외부 서비스 ────────────────────────────────
+    PRODUCT_SERVICE_ERROR("FUNDING-201", "상품 서비스 호출에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    STOCK_SERVICE_ERROR("FUNDING-202", "재고 서비스 호출에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    PAYMENT_SERVICE_ERROR("FUNDING-203", "결제 서비스 호출에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    STOCK_INSUFFICIENT("FUNDING-204", "재고가 부족합니다.", HttpStatus.CONFLICT),
+
+    // ─── 권한 ────────────────────────────────
+    UNAUTHORIZED_ACCESS("FUNDING-901", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
@@ -1,0 +1,33 @@
+package com.example.funding.repository;
+
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.entity.FundingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface FundingCampaignRepository extends JpaRepository<FundingCampaign, Long> {
+
+    Optional<FundingCampaign> findByItemId(Long itemId);
+
+    boolean existsByItemId(Long itemId);
+
+    @Query("SELECT c FROM FundingCampaign c WHERE c.status = :status AND c.endAt <= :now")
+    List<FundingCampaign> findExpiredCampaigns(@Param("status") FundingStatus status,
+                                                @Param("now") LocalDateTime now);
+
+    @Query("SELECT c FROM FundingCampaign c WHERE c.status = :status " +
+            "AND (:cursor IS NULL OR c.id < :cursor) ORDER BY c.id DESC")
+    List<FundingCampaign> findByStatusWithCursor(@Param("status") FundingStatus status,
+                                                  @Param("cursor") Long cursor,
+                                                  org.springframework.data.domain.Pageable pageable);
+
+    @Query("SELECT c FROM FundingCampaign c " +
+            "WHERE (:cursor IS NULL OR c.id < :cursor) ORDER BY c.id DESC")
+    List<FundingCampaign> findAllWithCursor(@Param("cursor") Long cursor,
+                                             org.springframework.data.domain.Pageable pageable);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/repository/FundingParticipationRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/FundingParticipationRepository.java
@@ -1,0 +1,27 @@
+package com.example.funding.repository;
+
+import com.example.funding.entity.FundingParticipation;
+import com.example.funding.entity.ParticipationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FundingParticipationRepository extends JpaRepository<FundingParticipation, Long> {
+
+    List<FundingParticipation> findByCampaignId(Long campaignId);
+
+    @Query("SELECT p FROM FundingParticipation p WHERE p.userId = :userId " +
+            "AND (:cursor IS NULL OR p.id < :cursor) ORDER BY p.id DESC")
+    List<FundingParticipation> findByUserIdWithCursor(@Param("userId") Long userId,
+                                                       @Param("cursor") Long cursor,
+                                                       org.springframework.data.domain.Pageable pageable);
+
+    long countByCampaignIdAndStatusIn(Long campaignId, List<ParticipationStatus> statuses);
+
+    Optional<FundingParticipation> findByReservationId(Long reservationId);
+
+    List<FundingParticipation> findByCampaignIdAndStatus(Long campaignId, ParticipationStatus status);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/repository/FundingStatusHistoryRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/FundingStatusHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.example.funding.repository;
+
+import com.example.funding.entity.FundingStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FundingStatusHistoryRepository extends JpaRepository<FundingStatusHistory, Long> {
+
+    List<FundingStatusHistory> findByCampaignIdOrderByCreatedAtDesc(Long campaignId);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/scheduler/FundingDeadlineScheduler.java
+++ b/servers/services/funding/src/main/java/com/example/funding/scheduler/FundingDeadlineScheduler.java
@@ -1,0 +1,74 @@
+package com.example.funding.scheduler;
+
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.entity.FundingStatus;
+import com.example.funding.entity.FundingStatusHistory;
+import com.example.funding.repository.FundingCampaignRepository;
+import com.example.funding.repository.FundingStatusHistoryRepository;
+import com.example.funding.service.CampaignCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FundingDeadlineScheduler {
+
+    private final FundingCampaignRepository campaignRepository;
+    private final FundingStatusHistoryRepository statusHistoryRepository;
+    private final CampaignCacheService campaignCacheService;
+
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void judgeExpiredCampaigns() {
+        List<FundingCampaign> expired = campaignRepository
+                .findExpiredCampaigns(FundingStatus.ACTIVE, LocalDateTime.now());
+
+        if (expired.isEmpty()) {
+            return;
+        }
+
+        log.info("만료된 펀딩 캠페인 {} 건 판정 시작", expired.size());
+
+        for (FundingCampaign campaign : expired) {
+            try {
+                judgeCampaign(campaign);
+            } catch (Exception e) {
+                log.error("캠페인 판정 실패: campaignId={}", campaign.getId(), e);
+            }
+        }
+    }
+
+    private void judgeCampaign(FundingCampaign campaign) {
+        FundingStatus previousStatus = campaign.getStatus();
+        FundingStatus newStatus;
+        String reason;
+
+        if (campaign.isGoalReached()) {
+            newStatus = FundingStatus.SUCCEEDED;
+            reason = String.format("목표 달성 (현재: %d원 / 목표: %d원)",
+                    campaign.getCurrentAmount(), campaign.getGoalAmount());
+        } else {
+            newStatus = FundingStatus.FAILED;
+            reason = String.format("목표 미달 (현재: %d원 / 목표: %d원)",
+                    campaign.getCurrentAmount(), campaign.getGoalAmount());
+        }
+
+        campaign.changeStatus(newStatus);
+
+        statusHistoryRepository.save(
+                FundingStatusHistory.create(campaign.getId(), previousStatus, newStatus, reason)
+        );
+
+        campaignCacheService.invalidateProgress(campaign.getId());
+
+        log.info("캠페인 판정 완료: campaignId={}, {} → {}",
+                campaign.getId(), previousStatus, newStatus);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/CampaignCacheService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/CampaignCacheService.java
@@ -1,0 +1,88 @@
+package com.example.funding.service;
+
+import com.example.funding.dto.campaign.response.ProgressResponse;
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.repository.FundingCampaignRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CampaignCacheService {
+
+    private static final String KEY_PREFIX = "funding:progress:";
+    private static final String FIELD_CURRENT_AMOUNT = "currentAmount";
+    private static final String FIELD_CURRENT_QUANTITY = "currentQuantity";
+    private static final Duration TTL = Duration.ofHours(1);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final FundingCampaignRepository campaignRepository;
+
+    public void cacheProgress(FundingCampaign campaign) {
+        String key = KEY_PREFIX + campaign.getId();
+        redisTemplate.opsForHash().putAll(key, Map.of(
+                FIELD_CURRENT_AMOUNT, campaign.getCurrentAmount(),
+                FIELD_CURRENT_QUANTITY, campaign.getCurrentQuantity()
+        ));
+        redisTemplate.expire(key, TTL);
+    }
+
+    public void incrementProgress(Long campaignId, Long amount, int quantity) {
+        String key = KEY_PREFIX + campaignId;
+        try {
+            redisTemplate.opsForHash().increment(key, FIELD_CURRENT_AMOUNT, amount);
+            redisTemplate.opsForHash().increment(key, FIELD_CURRENT_QUANTITY, quantity);
+            redisTemplate.expire(key, TTL);
+        } catch (Exception e) {
+            log.warn("Redis increment failed for campaign {}, will rely on DB", campaignId, e);
+        }
+    }
+
+    public void decrementProgress(Long campaignId, Long amount, int quantity) {
+        incrementProgress(campaignId, -amount, -quantity);
+    }
+
+    public ProgressResponse getProgress(Long campaignId) {
+        String key = KEY_PREFIX + campaignId;
+
+        try {
+            Object amountObj = redisTemplate.opsForHash().get(key, FIELD_CURRENT_AMOUNT);
+            Object quantityObj = redisTemplate.opsForHash().get(key, FIELD_CURRENT_QUANTITY);
+
+            if (amountObj != null && quantityObj != null) {
+                FundingCampaign campaign = campaignRepository.findById(campaignId).orElse(null);
+                if (campaign == null) return null;
+
+                long currentAmount = ((Number) amountObj).longValue();
+                int currentQuantity = ((Number) quantityObj).intValue();
+
+                return ProgressResponse.of(campaignId, currentAmount, campaign.getGoalAmount(),
+                        currentQuantity, campaign.getGoalQuantity());
+            }
+        } catch (Exception e) {
+            log.warn("Redis get failed for campaign {}, falling back to DB", campaignId, e);
+        }
+
+        return getProgressFromDb(campaignId);
+    }
+
+    public void invalidateProgress(Long campaignId) {
+        redisTemplate.delete(KEY_PREFIX + campaignId);
+    }
+
+    private ProgressResponse getProgressFromDb(Long campaignId) {
+        return campaignRepository.findById(campaignId)
+                .map(c -> {
+                    cacheProgress(c);
+                    return ProgressResponse.of(campaignId, c.getCurrentAmount(), c.getGoalAmount(),
+                            c.getCurrentQuantity(), c.getGoalQuantity());
+                })
+                .orElse(null);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/command/ParticipationCommandService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/command/ParticipationCommandService.java
@@ -1,0 +1,106 @@
+package com.example.funding.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.funding.client.StockClient;
+import com.example.funding.dto.participation.request.ParticipateRequest;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.entity.FundingParticipation;
+import com.example.funding.entity.FundingType;
+import com.example.funding.exception.FundingErrorCode;
+import com.example.funding.repository.FundingCampaignRepository;
+import com.example.funding.repository.FundingParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParticipationCommandService {
+
+    private final FundingCampaignRepository campaignRepository;
+    private final FundingParticipationRepository participationRepository;
+    private final StockClient stockClient;
+
+    public ParticipationResponse participate(Long campaignId, ParticipateRequest request, Long userId) {
+        FundingCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+
+        if (!campaign.isActive()) {
+            throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_ACTIVE);
+        }
+
+        if (campaign.isExpired()) {
+            throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_ACTIVE);
+        }
+
+        if (campaign.getFundingType() == FundingType.AMOUNT_BASED) {
+            return participateAmountBased(campaign, request, userId);
+        } else {
+            return participateQuantityBased(campaign, request, userId);
+        }
+    }
+
+    public void refund(Long participationId, Long userId) {
+        FundingParticipation participation = participationRepository.findById(participationId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.PARTICIPATION_NOT_FOUND));
+
+        FundingCampaign campaign = campaignRepository.findById(participation.getCampaignId())
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+
+        if (!campaign.isActive()) {
+            throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_ACTIVE);
+        }
+
+        // Stock 예약 취소 (QUANTITY_BASED만)
+        if (participation.getReservationId() != null) {
+            stockClient.cancelReservation(participation.getReservationId());
+        }
+
+        participation.refund();
+        campaign.removeParticipation(participation.getAmount(), participation.getQuantity());
+    }
+
+    private ParticipationResponse participateAmountBased(FundingCampaign campaign,
+                                                          ParticipateRequest request, Long userId) {
+        // 최소 금액 검증
+        if (campaign.getMinAmount() != null && request.getAmount() < campaign.getMinAmount()) {
+            throw new BusinessException(FundingErrorCode.BELOW_MIN_AMOUNT);
+        }
+
+        FundingParticipation participation = FundingParticipation.create(
+                campaign.getId(), userId, request.getAmount(),
+                1, null, null, null
+        );
+
+        participationRepository.save(participation);
+        campaign.addParticipation(request.getAmount(), 1);
+
+        return ParticipationResponse.from(participation);
+    }
+
+    private ParticipationResponse participateQuantityBased(FundingCampaign campaign,
+                                                            ParticipateRequest request, Long userId) {
+        int quantity = request.getQuantity() != null ? request.getQuantity() : 1;
+        Long referenceId = request.getSeatGradeId() != null
+                ? request.getSeatGradeId()
+                : request.getItemOptionId();
+
+        // Stock TCC Reserve
+        Long stockItemId = stockClient.findStockItemId(campaign.getItemId(), referenceId);
+        Long reservationId = stockClient.reserveStock(stockItemId, userId, quantity);
+
+        FundingParticipation participation = FundingParticipation.create(
+                campaign.getId(), userId, request.getAmount(),
+                quantity, request.getSeatGradeId(), request.getItemOptionId(), reservationId
+        );
+
+        participationRepository.save(participation);
+        campaign.addParticipation(request.getAmount(), quantity);
+
+        return ParticipationResponse.from(participation);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/query/CampaignQueryService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/query/CampaignQueryService.java
@@ -1,0 +1,76 @@
+package com.example.funding.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.core.pagination.CursorResponse;
+import com.example.core.pagination.CursorUtils;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.dto.campaign.response.StatusHistoryResponse;
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.entity.FundingStatus;
+import com.example.funding.exception.FundingErrorCode;
+import com.example.funding.repository.FundingCampaignRepository;
+import com.example.funding.repository.FundingStatusHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CampaignQueryService {
+
+    private final FundingCampaignRepository campaignRepository;
+    private final FundingStatusHistoryRepository statusHistoryRepository;
+
+    public CampaignResponse findById(Long campaignId) {
+        FundingCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+        return CampaignResponse.from(campaign);
+    }
+
+    public CampaignResponse findByItemId(Long itemId) {
+        FundingCampaign campaign = campaignRepository.findByItemId(itemId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+        return CampaignResponse.from(campaign);
+    }
+
+    public CursorResponse<CampaignResponse> findList(String cursor, int size, String status) {
+        Long cursorId = CursorUtils.decodeLong(cursor);
+        PageRequest pageable = PageRequest.of(0, size + 1);
+
+        List<FundingCampaign> campaigns;
+        if (status != null && !status.isEmpty()) {
+            FundingStatus fundingStatus = FundingStatus.valueOf(status);
+            campaigns = campaignRepository.findByStatusWithCursor(fundingStatus, cursorId, pageable);
+        } else {
+            campaigns = campaignRepository.findAllWithCursor(cursorId, pageable);
+        }
+
+        boolean hasNext = campaigns.size() > size;
+        List<FundingCampaign> pageItems = hasNext ? campaigns.subList(0, size) : campaigns;
+
+        List<CampaignResponse> content = pageItems.stream()
+                .map(CampaignResponse::from)
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId())
+                : null;
+
+        return CursorResponse.of(content, nextCursor);
+    }
+
+    public List<StatusHistoryResponse> findStatusHistory(Long campaignId) {
+        if (!campaignRepository.existsById(campaignId)) {
+            throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND);
+        }
+
+        return statusHistoryRepository.findByCampaignIdOrderByCreatedAtDesc(campaignId)
+                .stream()
+                .map(StatusHistoryResponse::from)
+                .toList();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/query/InternalCampaignQueryService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/query/InternalCampaignQueryService.java
@@ -1,0 +1,38 @@
+package com.example.funding.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.funding.dto.campaign.response.CampaignResponse;
+import com.example.funding.entity.FundingCampaign;
+import com.example.funding.exception.FundingErrorCode;
+import com.example.funding.repository.FundingCampaignRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InternalCampaignQueryService {
+
+    private final FundingCampaignRepository campaignRepository;
+
+    public CampaignResponse findById(Long campaignId) {
+        FundingCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+        return CampaignResponse.from(campaign);
+    }
+
+    public CampaignResponse findByItemId(Long itemId) {
+        FundingCampaign campaign = campaignRepository.findByItemId(itemId)
+                .orElseThrow(() -> new BusinessException(FundingErrorCode.CAMPAIGN_NOT_FOUND));
+        return CampaignResponse.from(campaign);
+    }
+
+    public List<CampaignResponse> findByIds(List<Long> campaignIds) {
+        return campaignRepository.findAllById(campaignIds).stream()
+                .map(CampaignResponse::from)
+                .toList();
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/query/ParticipationQueryService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/query/ParticipationQueryService.java
@@ -1,0 +1,48 @@
+package com.example.funding.service.query;
+
+import com.example.core.pagination.CursorResponse;
+import com.example.core.pagination.CursorUtils;
+import com.example.funding.dto.participation.response.ParticipationResponse;
+import com.example.funding.entity.FundingParticipation;
+import com.example.funding.repository.FundingParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ParticipationQueryService {
+
+    private final FundingParticipationRepository participationRepository;
+
+    public CursorResponse<ParticipationResponse> findByUserId(Long userId, String cursor, int size) {
+        Long cursorId = CursorUtils.decodeLong(cursor);
+        PageRequest pageable = PageRequest.of(0, size + 1);
+
+        List<FundingParticipation> participations =
+                participationRepository.findByUserIdWithCursor(userId, cursorId, pageable);
+
+        boolean hasNext = participations.size() > size;
+        List<FundingParticipation> pageItems = hasNext ? participations.subList(0, size) : participations;
+
+        List<ParticipationResponse> content = pageItems.stream()
+                .map(ParticipationResponse::from)
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId())
+                : null;
+
+        return CursorResponse.of(content, nextCursor);
+    }
+
+    public List<ParticipationResponse> findByCampaignId(Long campaignId) {
+        return participationRepository.findByCampaignId(campaignId).stream()
+                .map(ParticipationResponse::from)
+                .toList();
+    }
+}

--- a/servers/services/funding/src/main/resources/application.yml
+++ b/servers/services/funding/src/main/resources/application.yml
@@ -45,6 +45,10 @@ app:
     datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
     worker-id: ${SNOWFLAKE_WORKER_ID:6}
 
+  # ─── Service URLs ────────────────────────────
+  service:
+    stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
+
   # ─── OpenAPI ──────────────────────────────────
   openapi:
     enabled: ${OPENAPI_ENABLED:true}

--- a/servers/services/funding/src/main/resources/application.yml
+++ b/servers/services/funding/src/main/resources/application.yml
@@ -1,0 +1,70 @@
+server:
+  port: ${SERVER_PORT:8086}
+
+spring:
+  application:
+    name: funding-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/funding_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: funding-service-group
+      auto-offset-reset: earliest
+
+# ─── Snowflake ID ────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:6}
+
+  # ─── OpenAPI ──────────────────────────────────
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Funding Service API"
+    version: "1.0.0"
+    description: |
+      펀딩 캠페인 생성, 참여, 목표 달성 판정, 정산 시스템
+
+# ─── Actuator ─────────────────────────────────
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+# ─── Logging ──────────────────────────────────
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ include("servers:services:auth")
 include("servers:services:user")
 include("servers:services:product")
 include("servers:services:stock")
+include("servers:services:funding")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## 개요

### 관련 이슈

**Epic**
- Closes #12

**Story**
- Closes #157
- Closes #165
- Closes #171
- Closes #183
- Closes #196
- Closes #203
- Closes #210
- Closes #216
- Closes #221
- Closes #228

**Task — 초기 셋업 (#157)**
- Closes #158
- Closes #159
- Closes #160
- Closes #161
- Closes #162
- Closes #163
- Closes #164

**Task — 엔티티/테이블 설계 (#165)**
- Closes #166
- Closes #167
- Closes #168
- Closes #169
- Closes #170

**Task — 캠페인 CRUD API (#171)**
- Closes #172
- Closes #173
- Closes #174
- Closes #175
- Closes #176
- Closes #177
- Closes #178
- Closes #179
- Closes #180
- Closes #181
- Closes #182

**Task — 펀딩 참여 기능 (#183)**
- Closes #184
- Closes #185
- Closes #187
- Closes #188
- Closes #189
- Closes #190
- Closes #191
- Closes #192
- Closes #193
- Closes #194
- Closes #195

**Task — 진행률 캐시 (#196)**
- Closes #197
- Closes #198
- Closes #199
- Closes #200
- Closes #201
- Closes #202

**Task — 마감 스케줄러 (#203)**
- Closes #204
- Closes #205
- Closes #206
- Closes #207
- Closes #208
- Closes #209

**Task — 이벤트 발행 (#210)**
- Closes #211
- Closes #212
- Closes #213
- Closes #214
- Closes #215

**Task — 참여 내역 조회 (#216)**
- Closes #217
- Closes #218
- Closes #219
- Closes #220

**Task — 외부 이벤트 소비 (#221)**
- Closes #222
- Closes #223
- Closes #224
- Closes #225
- Closes #226
- Closes #227

**Task — 내부 API (#228)**
- Closes #229
- Closes #230
- Closes #231

**Task — 추가 태스크**
- Closes #511
- Closes #512
- Closes #514

### 작업 / 변경 내용
- **Funding Service 전체 구현** (Epic #12)
- 프로젝트 초기 셋업 (port 8086, funding_db)
- 엔티티/테이블 설계: FundingCampaign, FundingParticipation, FundingStatusHistory
- 캠페인 CRUD API (CQRS 패턴, Swagger, 커서 페이징)
- 펀딩 참여: QUANTITY_BASED(Stock TCC Reserve) / AMOUNT_BASED(직접 참여) 분기
- 진행률 실시간 Redis Hash 캐시 (HINCRBY)
- 마감 판정 스케줄러 (@Scheduled 60초 주기)
- 도메인 이벤트 발행: FundingCreated/Succeeded/Failed → Outbox → Kafka
- 외부 이벤트 소비: PaymentEventConsumer (payment-events 토픽)
- 내부 API: /internal/v1/campaigns
- StockClient: WebClient 기반 TCC Reserve/Cancel 연동

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:funding:compileJava`)
- [x] 서비스 기동 확인 (actuator/health UP, port 8086)
- [x] Product(8084) × Stock(8085) × Funding(8086) 3개 서비스 연동 통합 테스트 완료
- [x] Kafka funding-events 토픽 이벤트 발행 확인

### 참고사항
- Story PR: #515 (feature/funding/157 → feature/funding-epic)
- 결제 서비스 미구현 상태, PaymentEventConsumer는 토픽 구독만 설정
- ShedLock은 추후 공통 모듈로 분리 예정