### PR TITLE
feat: ShedLock 공통 모듈 추가 (libs/config/shedlock)

### DIFF
--- a/libs/config/shedlock/build.gradle.kts
+++ b/libs/config/shedlock/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("java-library")
+    id("org.springframework.boot") apply false
+    id("io.spring.dependency-management")
+}
+
+tasks.bootJar {
+    enabled = false
+}
+
+tasks.jar {
+    enabled = true
+}
+
+dependencies {
+    // ShedLock
+    api("net.javacrumbs.shedlock:shedlock-spring:6.3.0")
+    api("net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.3.0")
+
+    // Redis (for RedisConnectionFactory)
+    compileOnly("org.springframework.boot:spring-boot-starter-data-redis")
+
+    // Spring Boot
+    compileOnly("org.springframework.boot:spring-boot-autoconfigure")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+}

--- a/libs/config/shedlock/src/main/java/com/example/config/shedlock/ShedLockAutoConfiguration.java
+++ b/libs/config/shedlock/src/main/java/com/example/config/shedlock/ShedLockAutoConfiguration.java
@@ -1,0 +1,24 @@
+package com.example.config.shedlock;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@AutoConfiguration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
+public class ShedLockAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(RedisConnectionFactory.class)
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/libs/config/shedlock/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/config/shedlock/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.example.config.shedlock.ShedLockAutoConfiguration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ include(":libs:config:redis")
 include(":libs:config:resilience")
 include(":libs:config:webclient")
 include(":libs:config:tracing")
+include(":libs:config:shedlock")
 
 // 이벤트 모듈
 include(":libs:event:domain")


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #513

### 작업 / 변경 내용
- `libs/config/shedlock` 공통 모듈 신규 생성
- Redis 기반 `LockProvider` 자동 설정 (`ShedLockAutoConfiguration`)
- `@EnableSchedulerLock` (defaultLockAtMostFor = 30초)
- 서비스에서 `implementation(project(":libs:config:shedlock"))` 추가만으로 `@SchedulerLock` 사용 가능
- `settings.gradle.kts`에 모듈 등록

### 사용 예시
```java
@Scheduled(fixedDelay = 60_000)
@SchedulerLock(name = "funding-deadline", lockAtMostFor = "PT55S", lockAtLeastFor = "PT30S")
public void closeExpiredCampaigns() { ... }
```

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :libs:config:shedlock:compileJava`)
- [ ] Funding Service에 적용하여 스케줄러 중복 실행 방지 확인

### 참고사항
- 기존 `@DistributedLock` (Redisson): 비즈니스 로직 동시성 제어용
- `@SchedulerLock` (ShedLock): 스케줄러 중복 실행 방지용
- 두 모듈은 용도가 다르므로 서비스에서 선택적으로 사용