### PR TITLE
feat: Funding 서비스 — orderId 관통 키 적용

### DIFF
--- a/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
+++ b/servers/services/funding/src/main/java/com/example/funding/client/StockClient.java
@@ -24,11 +24,12 @@ public class StockClient {
         this.webClient = webClientBuilder.baseUrl(stockUrl).build();
     }
 
-    public Long reserveStock(Long stockItemId, Long userId, int quantity) {
+    public Long reserveStock(Long stockItemId, Long userId, int quantity, Long orderId) {
         Map<String, Object> body = Map.of(
                 "stockItemId", stockItemId,
                 "userId", userId,
-                "quantity", quantity
+                "quantity", quantity,
+                "orderId", orderId
         );
 
         try {

--- a/servers/services/funding/src/main/java/com/example/funding/dto/participation/response/ParticipationResponse.java
+++ b/servers/services/funding/src/main/java/com/example/funding/dto/participation/response/ParticipationResponse.java
@@ -32,6 +32,9 @@ public class ParticipationResponse {
     private String status;
 
     @SnowflakeId
+    private Long orderId;
+
+    @SnowflakeId
     private Long reservationId;
 
     @SnowflakeId
@@ -50,6 +53,7 @@ public class ParticipationResponse {
                 .seatGradeId(p.getSeatGradeId())
                 .itemOptionId(p.getItemOptionId())
                 .status(p.getStatus().name())
+                .orderId(p.getOrderId())
                 .reservationId(p.getReservationId())
                 .paymentId(p.getPaymentId())
                 .createdAt(p.getCreatedAt())

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
@@ -13,7 +13,8 @@ import org.hibernate.annotations.SQLRestriction;
         indexes = {
                 @Index(name = "idx_participation_campaign_id", columnList = "campaignId"),
                 @Index(name = "idx_participation_user_id", columnList = "userId"),
-                @Index(name = "idx_participation_status", columnList = "status")
+                @Index(name = "idx_participation_status", columnList = "status"),
+                @Index(name = "idx_participation_order_id", columnList = "orderId")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -46,6 +47,9 @@ public class FundingParticipation extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private ParticipationStatus status;
 
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
     @Column(name = "reservation_id")
     private Long reservationId;
 
@@ -54,7 +58,8 @@ public class FundingParticipation extends BaseEntity {
 
     public static FundingParticipation create(Long campaignId, Long userId, Long amount,
                                                Integer quantity, Long seatGradeId,
-                                               Long itemOptionId, Long reservationId) {
+                                               Long itemOptionId, Long orderId,
+                                               Long reservationId) {
         FundingParticipation p = new FundingParticipation();
         p.campaignId = campaignId;
         p.userId = userId;
@@ -62,6 +67,7 @@ public class FundingParticipation extends BaseEntity {
         p.quantity = quantity;
         p.seatGradeId = seatGradeId;
         p.itemOptionId = itemOptionId;
+        p.orderId = orderId;
         p.reservationId = reservationId;
         p.status = ParticipationStatus.PENDING;
         return p;

--- a/servers/services/funding/src/main/java/com/example/funding/event/FundingParticipatedEvent.java
+++ b/servers/services/funding/src/main/java/com/example/funding/event/FundingParticipatedEvent.java
@@ -1,0 +1,50 @@
+package com.example.funding.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class FundingParticipatedEvent extends DomainEvent {
+
+    private final Long campaignId;
+    private final Long participationId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+    private final Integer quantity;
+    private final String fundingType;
+
+    public FundingParticipatedEvent(Long campaignId, Long participationId, Long orderId,
+                                     Long userId, Long amount, Integer quantity,
+                                     String fundingType) {
+        super("funding-events");
+        this.campaignId = campaignId;
+        this.participationId = participationId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+        this.quantity = quantity;
+        this.fundingType = fundingType;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "FUNDING_PARTICIPATED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("campaignId", campaignId);
+        payload.put("participationId", participationId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        payload.put("quantity", quantity);
+        payload.put("fundingType", fundingType);
+        return payload;
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/event/FundingRefundedEvent.java
+++ b/servers/services/funding/src/main/java/com/example/funding/event/FundingRefundedEvent.java
@@ -1,0 +1,43 @@
+package com.example.funding.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class FundingRefundedEvent extends DomainEvent {
+
+    private final Long campaignId;
+    private final Long participationId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+
+    public FundingRefundedEvent(Long campaignId, Long participationId, Long orderId,
+                                 Long userId, Long amount) {
+        super("funding-events");
+        this.campaignId = campaignId;
+        this.participationId = participationId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "FUNDING_REFUNDED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("campaignId", campaignId);
+        payload.put("participationId", participationId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        return payload;
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #518
- Closes #519
- Closes #520
- Closes #521
- Closes #522

### 작업 / 변경 내용
- FundingParticipation 엔티티에 orderId 컬럼 추가 (NOT NULL, 인덱스)
- ParticipationCommandService에서 Snowflake로 orderId 사전 발급
- StockClient.reserveStock()에 orderId 파라미터 추가
- ParticipationResponse에 orderId 필드 추가
- FundingParticipatedEvent, FundingRefundedEvent에 orderId 포함

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:funding:compileJava`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- orderId는 MSA 전체에서 주문/결제/환불을 추적하는 관통 키(correlation key)
- Snowflake로 발급하여 중복 없이 글로벌 유일성 보장
- AMOUNT_BASED는 Stock을 거치지 않으므로 reservationId = null