### PR TITLE
feat: Stock 서비스 — orderId 관통 키 적용

### DIFF
--- a/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/api/query/StockQueryApi.java
@@ -1,6 +1,7 @@
 package com.example.stock.controller.api.query;
 
 import com.example.api.response.ApiResponse;
+import com.example.stock.dto.response.ReservationResponse;
 import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
@@ -29,4 +30,8 @@ public interface StockQueryApi {
             @PathVariable Long stockItemId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "orderId 기반 예약 조회")
+    @GetMapping("/internal/v1/stock/reservations")
+    ApiResponse<List<ReservationResponse>> getReservationsByOrderId(@RequestParam Long orderId);
 }

--- a/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
+++ b/servers/services/stock/src/main/java/com/example/stock/controller/query/StockQueryController.java
@@ -2,6 +2,7 @@ package com.example.stock.controller.query;
 
 import com.example.api.response.ApiResponse;
 import com.example.stock.controller.api.query.StockQueryApi;
+import com.example.stock.dto.response.ReservationResponse;
 import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
@@ -35,5 +36,10 @@ public class StockQueryController implements StockQueryApi {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return ApiResponse.success(stockQueryService.getStockHistory(stockItemId, page, size));
+    }
+
+    @Override
+    public ApiResponse<List<ReservationResponse>> getReservationsByOrderId(@RequestParam Long orderId) {
+        return ApiResponse.success(stockQueryService.getReservationsByOrderId(orderId));
     }
 }

--- a/servers/services/stock/src/main/java/com/example/stock/dto/request/ReserveStockRequest.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/request/ReserveStockRequest.java
@@ -15,6 +15,8 @@ public class ReserveStockRequest {
     @NotNull
     private Long userId;
 
+    private Long orderId;
+
     @NotNull
     @Min(1)
     private Integer quantity;

--- a/servers/services/stock/src/main/java/com/example/stock/dto/response/ReservationResponse.java
+++ b/servers/services/stock/src/main/java/com/example/stock/dto/response/ReservationResponse.java
@@ -14,6 +14,7 @@ public class ReservationResponse {
     private Long id;
     private Long stockItemId;
     private Long userId;
+    private Long orderId;
     private int quantity;
     private ReservationStatus status;
     private LocalDateTime expiredAt;
@@ -23,6 +24,7 @@ public class ReservationResponse {
                 .id(reservation.getId())
                 .stockItemId(reservation.getStockItemId())
                 .userId(reservation.getUserId())
+                .orderId(reservation.getOrderId())
                 .quantity(reservation.getQuantity())
                 .status(reservation.getStatus())
                 .expiredAt(reservation.getExpiredAt())

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockReservation.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockReservation.java
@@ -15,7 +15,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "stock_reservations", indexes = {
         @Index(name = "idx_reservation_stock_item", columnList = "stockItemId"),
-        @Index(name = "idx_reservation_status_expired", columnList = "status, expiredAt")
+        @Index(name = "idx_reservation_status_expired", columnList = "status, expiredAt"),
+        @Index(name = "idx_reservation_order_id", columnList = "orderId")
 })
 @SQLRestriction("deleted_at IS NULL")
 @Getter
@@ -32,6 +33,8 @@ public class StockReservation extends BaseEntity {
     @Column(nullable = false)
     private Long userId;
 
+    private Long orderId;
+
     @Column(nullable = false)
     private int quantity;
 
@@ -42,10 +45,11 @@ public class StockReservation extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
-    public static StockReservation create(Long stockItemId, Long userId, int quantity, int ttlMinutes) {
+    public static StockReservation create(Long stockItemId, Long userId, Long orderId, int quantity, int ttlMinutes) {
         StockReservation reservation = new StockReservation();
         reservation.stockItemId = stockItemId;
         reservation.userId = userId;
+        reservation.orderId = orderId;
         reservation.quantity = quantity;
         reservation.status = ReservationStatus.RESERVED;
         reservation.expiredAt = LocalDateTime.now().plusMinutes(ttlMinutes);

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
@@ -15,4 +15,6 @@ public interface StockReservationRepository extends JpaRepository<StockReservati
     List<StockReservation> findExpiredReservations(@Param("status") ReservationStatus status, @Param("now") LocalDateTime now);
 
     List<StockReservation> findByStockItemIdAndStatus(Long stockItemId, ReservationStatus status);
+
+    List<StockReservation> findByOrderId(Long orderId);
 }

--- a/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
@@ -89,7 +89,7 @@ public class StockCommandService {
         stockItem.reserve(request.getQuantity());
 
         StockReservation reservation = StockReservation.create(
-                stockItem.getId(), request.getUserId(), request.getQuantity(), RESERVATION_TTL_MINUTES);
+                stockItem.getId(), request.getUserId(), request.getOrderId(), request.getQuantity(), RESERVATION_TTL_MINUTES);
         stockReservationRepository.save(reservation);
 
         stockHistoryRepository.save(StockHistory.create(

--- a/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/query/StockQueryService.java
@@ -1,6 +1,7 @@
 package com.example.stock.service.query;
 
 import com.example.core.exception.BusinessException;
+import com.example.stock.dto.response.ReservationResponse;
 import com.example.stock.dto.response.StockHistoryResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.dto.response.StockSummaryResponse;
@@ -8,6 +9,7 @@ import com.example.stock.entity.StockItem;
 import com.example.stock.exception.StockErrorCode;
 import com.example.stock.repository.StockHistoryRepository;
 import com.example.stock.repository.StockItemRepository;
+import com.example.stock.repository.StockReservationRepository;
 import com.example.stock.service.StockCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +26,7 @@ public class StockQueryService {
 
     private final StockItemRepository stockItemRepository;
     private final StockHistoryRepository stockHistoryRepository;
+    private final StockReservationRepository stockReservationRepository;
     private final StockCacheService stockCacheService;
 
     public StockResponse getStock(Long stockItemId) {
@@ -46,6 +49,12 @@ public class StockQueryService {
                         stockItemId, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")))
                 .stream()
                 .map(StockHistoryResponse::from)
+                .toList();
+    }
+
+    public List<ReservationResponse> getReservationsByOrderId(Long orderId) {
+        return stockReservationRepository.findByOrderId(orderId).stream()
+                .map(ReservationResponse::from)
                 .toList();
     }
 }


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #523
- Closes #524
- Closes #525
- Closes #526

### 작업 / 변경 내용
- StockReservation 엔티티에 orderId 컬럼 추가 (nullable, 인덱스)
- ReserveStockRequest에 orderId 필드 추가
- ReservationResponse에 orderId 필드 추가
- StockReservationRepository에 findByOrderId() 쿼리 추가
- Internal API: GET /internal/v1/stock/reservations?orderId= 엔드포인트 추가

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:stock:compileJava`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- orderId는 MSA 전체에서 주문/결제/환불을 추적하는 관통 키(correlation key)
- Stock 측은 orderId를 nullable로 처리 (기존 예약 호환)
- orderId로 예약 조회 API 추가하여 Order 서비스에서 조회 가능