### PR TITLE
feat: 핫딜 서비스 전체 구현 (#362)

### DIFF
--- a/docker/init-scripts/postgres/01-init.sql
+++ b/docker/init-scripts/postgres/01-init.sql
@@ -7,6 +7,7 @@ CREATE DATABASE auth_db;
 CREATE DATABASE user_db;
 CREATE DATABASE test_db;
 CREATE DATABASE sales_db;
+CREATE DATABASE hotdeal_db;
 
 -- auth_db 초기 설정
 \c auth_db;
@@ -18,4 +19,8 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- test_db 초기 설정 (테스트 서버용)
 \c test_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- hotdeal_db 초기 설정
+\c hotdeal_db;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/servers/services/hot-deal/build.gradle.kts
+++ b/servers/services/hot-deal/build.gradle.kts
@@ -1,0 +1,50 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+    implementation(project(":libs:config:webclient"))
+    implementation(project(":libs:config:shedlock"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/HotDealApplication.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/HotDealApplication.java
@@ -1,0 +1,16 @@
+package com.example.hotdeal;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(scanBasePackages = "com.example")
+@EnableAsync
+@EnableScheduling
+public class HotDealApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(HotDealApplication.class, args);
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/ProductClient.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/ProductClient.java
@@ -1,0 +1,66 @@
+package com.example.hotdeal.client;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class ProductClient {
+
+    private final WebClient webClient;
+
+    public ProductClient(WebClient.Builder webClientBuilder,
+                         @Value("${app.service.product-url}") String productUrl) {
+        this.webClient = webClientBuilder.baseUrl(productUrl).build();
+    }
+
+    public JsonNode findItem(Long itemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/items/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(HotDealErrorCode.PRODUCT_SERVICE_ERROR);
+            }
+
+            return response.path("data");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Product lookup failed: itemId={}", itemId, e);
+            throw new BusinessException(HotDealErrorCode.PRODUCT_SERVICE_ERROR);
+        }
+    }
+
+    /**
+     * D-3 이내 마감 예정 상품 목록 조회
+     */
+    public JsonNode findItemsEndingSoon(int withinDays) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/items/ending-soon?withinDays={days}", withinDays)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(HotDealErrorCode.PRODUCT_SERVICE_ERROR);
+            }
+
+            return response.path("data");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Product ending-soon lookup failed: withinDays={}", withinDays, e);
+            throw new BusinessException(HotDealErrorCode.PRODUCT_SERVICE_ERROR);
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/StockClient.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/StockClient.java
@@ -1,0 +1,45 @@
+package com.example.hotdeal.client;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class StockClient {
+
+    private final WebClient webClient;
+
+    public StockClient(WebClient.Builder webClientBuilder,
+                       @Value("${app.service.stock-url}") String stockUrl) {
+        this.webClient = webClientBuilder.baseUrl(stockUrl).build();
+    }
+
+    /**
+     * 재고 정보 조회 (잔여율 계산용)
+     */
+    public JsonNode getStockInfo(Long stockItemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/stock/{stockItemId}", stockItemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(HotDealErrorCode.STOCK_SERVICE_ERROR);
+            }
+
+            return response.path("data");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Stock info lookup failed: stockItemId={}", stockItemId, e);
+            throw new BusinessException(HotDealErrorCode.STOCK_SERVICE_ERROR);
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/config/JpaConfig.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.example.hotdeal.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example.hotdeal.repository")
+public class JpaConfig {
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/consumer/StockEventConsumer.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/consumer/StockEventConsumer.java
@@ -1,0 +1,98 @@
+package com.example.hotdeal.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.hotdeal.client.ProductClient;
+import com.example.hotdeal.client.StockClient;
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.service.HotDealCommandService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventConsumer {
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final HotDealRepository hotDealRepository;
+    private final HotDealCommandService hotDealCommandService;
+    private final ProductClient productClient;
+    private final StockClient stockClient;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "stock-events", groupId = "hot-deal-service-group")
+    public void consume(String message) {
+        try {
+            JsonNode event = objectMapper.readTree(message);
+            String eventType = event.path("eventType").asText();
+            String eventId = event.path("eventId").asText();
+
+            if (!"STOCK_THRESHOLD".equals(eventType)) {
+                return;
+            }
+
+            idempotentConsumerService.executeIdempotent(eventId, "STOCK_EVENT", () -> {
+                handleStockThreshold(event.path("payload"));
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("Stock event consumption failed", e);
+        }
+    }
+
+    private void handleStockThreshold(JsonNode payload) {
+        Long itemId = payload.path("itemId").asLong();
+        Long stockItemId = payload.path("stockItemId").asLong();
+        int totalQuantity = payload.path("totalQuantity").asInt();
+        int availableQuantity = payload.path("availableQuantity").asInt();
+
+        if (totalQuantity == 0) {
+            return;
+        }
+
+        // 이미 핫딜로 등록된 상품인지 확인
+        boolean exists = hotDealRepository.existsByItemIdAndStatusIn(
+                itemId, List.of(HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE));
+        if (exists) {
+            return;
+        }
+
+        double remainingRate = (double) availableQuantity / totalQuantity * 100;
+
+        // 잔여율 20% 미만이면 스킵
+        if (remainingRate < 20) {
+            return;
+        }
+
+        // 상품 정보 조회
+        JsonNode itemData = productClient.findItem(itemId);
+        String title = itemData.path("title").asText();
+        Long price = itemData.path("price").asLong();
+
+        // 할인율 계산
+        int discountRate;
+        if (remainingRate >= 50) {
+            discountRate = 10;
+        } else if (remainingRate >= 30) {
+            discountRate = 20;
+        } else {
+            discountRate = 30;
+        }
+
+        hotDealCommandService.createAndActivate(
+                itemId, title, price, discountRate, availableQuantity,
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                "재고 임계값 이벤트 — 잔여율 " + String.format("%.1f", remainingRate) + "%");
+
+        log.info("Hot deal created from stock threshold: itemId={}, remainingRate={:.1f}%",
+                itemId, remainingRate);
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealCommandController.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealCommandController.java
@@ -1,0 +1,43 @@
+package com.example.hotdeal.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.hotdeal.controller.api.HotDealCommandApi;
+import com.example.hotdeal.dto.*;
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.service.HotDealCommandService;
+import com.example.hotdeal.service.HotDealPurchaseService;
+import com.example.hotdeal.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/hot-deals")
+@RequiredArgsConstructor
+public class HotDealCommandController implements HotDealCommandApi {
+
+    private final HotDealCommandService hotDealCommandService;
+    private final HotDealPurchaseService hotDealPurchaseService;
+    private final QueueService queueService;
+
+    @Override
+    public ApiResponse<HotDealDetailResponse> createHotDeal(CreateHotDealRequest request, Long userId) {
+        return ApiResponse.success(hotDealCommandService.createManual(request, userId));
+    }
+
+    @Override
+    public ApiResponse<HotDealPurchaseResponse> purchase(Long hotDealId,
+                                                          HotDealPurchaseRequest request, Long userId) {
+        return ApiResponse.success(hotDealPurchaseService.purchase(hotDealId, request, userId));
+    }
+
+    @Override
+    public ApiResponse<QueueEnterResponse> enterQueue(Long hotDealId, Long userId) {
+        return ApiResponse.success(queueService.enter(hotDealId, userId));
+    }
+
+    @Override
+    public ApiResponse<QueueStatusResponse> getQueueStatus(Long hotDealId, Long userId) {
+        return ApiResponse.success(queueService.getStatus(hotDealId, userId));
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealQueryController.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealQueryController.java
@@ -1,0 +1,30 @@
+package com.example.hotdeal.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.hotdeal.controller.api.HotDealQueryApi;
+import com.example.hotdeal.dto.HotDealDetailResponse;
+import com.example.hotdeal.dto.HotDealListResponse;
+import com.example.hotdeal.service.HotDealQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/hot-deals")
+@RequiredArgsConstructor
+public class HotDealQueryController implements HotDealQueryApi {
+
+    private final HotDealQueryService hotDealQueryService;
+
+    @Override
+    public ApiResponse<List<HotDealListResponse>> getActiveDeals(Long cursor, int size) {
+        return ApiResponse.success(hotDealQueryService.getActiveDeals(cursor, size));
+    }
+
+    @Override
+    public ApiResponse<HotDealDetailResponse> getDetail(Long hotDealId) {
+        return ApiResponse.success(hotDealQueryService.getDetail(hotDealId));
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/InternalHotDealController.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/InternalHotDealController.java
@@ -1,0 +1,50 @@
+package com.example.hotdeal.controller;
+
+import com.example.api.response.ApiResponse;
+import com.example.hotdeal.dto.HotDealDetailResponse;
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.service.HotDealCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "Internal", description = "내부 서비스 간 호출 / 테스트용 API")
+@RestController
+@RequestMapping("/internal/v1/hot-deals")
+@RequiredArgsConstructor
+public class InternalHotDealController {
+
+    private final HotDealCommandService hotDealCommandService;
+
+    @Operation(summary = "핫딜 수동 생성 (내부/테스트용)")
+    @PostMapping
+    public ApiResponse<HotDealDetailResponse> createHotDeal(@RequestBody CreateHotDealRequest request) {
+        HotDeal hotDeal = hotDealCommandService.createAndActivate(
+                request.getItemId(),
+                request.getTitle(),
+                request.getOriginalPrice(),
+                request.getDiscountRate(),
+                request.getMaxQuantity(),
+                request.getStartAt() != null ? request.getStartAt() : LocalDateTime.now(),
+                request.getEndAt() != null ? request.getEndAt() : LocalDateTime.now().plusHours(1),
+                "수동 생성");
+        return ApiResponse.success(HotDealDetailResponse.from(hotDeal));
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateHotDealRequest {
+        private Long itemId;
+        private String title;
+        private Long originalPrice;
+        private Integer discountRate;
+        private Integer maxQuantity;
+        private LocalDateTime startAt;
+        private LocalDateTime endAt;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealCommandApi.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealCommandApi.java
@@ -1,0 +1,38 @@
+package com.example.hotdeal.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.hotdeal.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Hot-Deal Command", description = "핫딜 구매/대기열 API")
+public interface HotDealCommandApi {
+
+    @Operation(summary = "핫딜 수동 생성 (판매자)")
+    @PostMapping
+    ApiResponse<HotDealDetailResponse> createHotDeal(
+            @Valid @RequestBody CreateHotDealRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "선착순 구매")
+    @PostMapping("/{hotDealId}/purchase")
+    ApiResponse<HotDealPurchaseResponse> purchase(
+            @PathVariable Long hotDealId,
+            @Valid @RequestBody HotDealPurchaseRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "대기열 진입")
+    @PostMapping("/{hotDealId}/queue/enter")
+    ApiResponse<QueueEnterResponse> enterQueue(
+            @PathVariable Long hotDealId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "대기열 상태 조회")
+    @GetMapping("/{hotDealId}/queue")
+    ApiResponse<QueueStatusResponse> getQueueStatus(
+            @PathVariable Long hotDealId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealQueryApi.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealQueryApi.java
@@ -1,0 +1,27 @@
+package com.example.hotdeal.controller.api;
+
+import com.example.api.response.ApiResponse;
+import com.example.hotdeal.dto.HotDealDetailResponse;
+import com.example.hotdeal.dto.HotDealListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Hot-Deal Query", description = "핫딜 조회 API")
+public interface HotDealQueryApi {
+
+    @Operation(summary = "핫딜 목록 조회 (ACTIVE)")
+    @GetMapping
+    ApiResponse<List<HotDealListResponse>> getActiveDeals(
+            @Parameter(description = "커서 ID") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size);
+
+    @Operation(summary = "핫딜 상세 조회")
+    @GetMapping("/{hotDealId}")
+    ApiResponse<HotDealDetailResponse> getDetail(@PathVariable Long hotDealId);
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/CreateHotDealRequest.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/CreateHotDealRequest.java
@@ -1,0 +1,30 @@
+package com.example.hotdeal.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CreateHotDealRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다")
+    private Long itemId;
+
+    @NotNull(message = "할인율은 필수입니다")
+    @Min(value = 1, message = "할인율은 1% 이상이어야 합니다")
+    @Max(value = 90, message = "할인율은 90% 이하여야 합니다")
+    private Integer discountRate;
+
+    @NotNull(message = "최대 수량은 필수입니다")
+    @Min(value = 1, message = "최대 수량은 1 이상이어야 합니다")
+    private Integer maxQuantity;
+
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealDetailResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealDetailResponse.java
@@ -1,0 +1,51 @@
+package com.example.hotdeal.dto;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.hotdeal.entity.HotDeal;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class HotDealDetailResponse {
+
+    @SnowflakeId private Long id;
+    @SnowflakeId private Long itemId;
+    private String title;
+    private Long originalPrice;
+    private Integer discountRate;
+    private Long discountedPrice;
+    private Integer maxQuantity;
+    private Integer soldQuantity;
+    private Integer remainingQuantity;
+    private Double progressRate;
+    private String status;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private LocalDateTime createdAt;
+
+    public static HotDealDetailResponse from(HotDeal h) {
+        double progress = h.getMaxQuantity() > 0
+                ? (double) h.getSoldQuantity() / h.getMaxQuantity() * 100
+                : 0.0;
+
+        return HotDealDetailResponse.builder()
+                .id(h.getId())
+                .itemId(h.getItemId())
+                .title(h.getTitle())
+                .originalPrice(h.getOriginalPrice())
+                .discountRate(h.getDiscountRate())
+                .discountedPrice(h.getDiscountedPrice())
+                .maxQuantity(h.getMaxQuantity())
+                .soldQuantity(h.getSoldQuantity())
+                .remainingQuantity(h.getRemainingQuantity())
+                .progressRate(Math.round(progress * 10.0) / 10.0)
+                .status(h.getStatus().name())
+                .startAt(h.getStartAt())
+                .endAt(h.getEndAt())
+                .createdAt(h.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealListResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealListResponse.java
@@ -1,0 +1,33 @@
+package com.example.hotdeal.dto;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.hotdeal.entity.HotDeal;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class HotDealListResponse {
+
+    @SnowflakeId private Long id;
+    private String title;
+    private Integer discountRate;
+    private Long discountedPrice;
+    private Integer soldQuantity;
+    private Integer maxQuantity;
+    private LocalDateTime endAt;
+
+    public static HotDealListResponse from(HotDeal h) {
+        return HotDealListResponse.builder()
+                .id(h.getId())
+                .title(h.getTitle())
+                .discountRate(h.getDiscountRate())
+                .discountedPrice(h.getDiscountedPrice())
+                .soldQuantity(h.getSoldQuantity())
+                .maxQuantity(h.getMaxQuantity())
+                .endAt(h.getEndAt())
+                .build();
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealPurchaseRequest.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealPurchaseRequest.java
@@ -1,0 +1,15 @@
+package com.example.hotdeal.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HotDealPurchaseRequest {
+
+    @NotNull(message = "수량은 필수입니다")
+    @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+    private Integer quantity;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealPurchaseResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealPurchaseResponse.java
@@ -1,0 +1,29 @@
+package com.example.hotdeal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class HotDealPurchaseResponse {
+
+    private boolean success;
+    private String reservationId;
+    private LocalDateTime expiresAt;
+
+    public static HotDealPurchaseResponse success(String reservationId, LocalDateTime expiresAt) {
+        return HotDealPurchaseResponse.builder()
+                .success(true)
+                .reservationId(reservationId)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public static HotDealPurchaseResponse fail() {
+        return HotDealPurchaseResponse.builder()
+                .success(false)
+                .build();
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueEnterResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueEnterResponse.java
@@ -1,0 +1,13 @@
+package com.example.hotdeal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueEnterResponse {
+
+    private String token;
+    private Long position;
+    private Long estimatedWaitSeconds;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueStatusResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueStatusResponse.java
@@ -1,0 +1,12 @@
+package com.example.hotdeal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueStatusResponse {
+
+    private Long position;
+    private boolean canPurchase;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDeal.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDeal.java
@@ -1,0 +1,106 @@
+package com.example.hotdeal.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "hot_deals",
+        indexes = {
+                @Index(name = "idx_hot_deal_item_id", columnList = "itemId"),
+                @Index(name = "idx_hot_deal_status", columnList = "status"),
+                @Index(name = "idx_hot_deal_start_at", columnList = "startAt"),
+                @Index(name = "idx_hot_deal_end_at", columnList = "endAt")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class HotDeal extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "original_price", nullable = false)
+    private Long originalPrice;
+
+    @Column(name = "discount_rate", nullable = false)
+    private Integer discountRate;
+
+    @Column(name = "discounted_price", nullable = false)
+    private Long discountedPrice;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Column(name = "max_quantity", nullable = false)
+    private Integer maxQuantity;
+
+    @Column(name = "sold_quantity", nullable = false)
+    private Integer soldQuantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private HotDealStatus status;
+
+    public static HotDeal create(Long itemId, String title, Long originalPrice,
+                                  Integer discountRate, Integer maxQuantity,
+                                  LocalDateTime startAt, LocalDateTime endAt) {
+        HotDeal hotDeal = new HotDeal();
+        hotDeal.itemId = itemId;
+        hotDeal.title = title;
+        hotDeal.originalPrice = originalPrice;
+        hotDeal.discountRate = discountRate;
+        hotDeal.discountedPrice = originalPrice * (100 - discountRate) / 100;
+        hotDeal.maxQuantity = maxQuantity;
+        hotDeal.soldQuantity = 0;
+        hotDeal.startAt = startAt;
+        hotDeal.endAt = endAt;
+        hotDeal.status = HotDealStatus.SCHEDULED;
+        return hotDeal;
+    }
+
+    public void changeStatus(HotDealStatus newStatus) {
+        this.status.validateTransitionTo(newStatus);
+        this.status = newStatus;
+    }
+
+    public void activate() {
+        changeStatus(HotDealStatus.ACTIVE);
+    }
+
+    public void end() {
+        changeStatus(HotDealStatus.ENDED);
+    }
+
+    public void cancel() {
+        changeStatus(HotDealStatus.CANCELLED);
+    }
+
+    public void incrementSoldQuantity(int quantity) {
+        this.soldQuantity += quantity;
+    }
+
+    public int getRemainingQuantity() {
+        return maxQuantity - soldQuantity;
+    }
+
+    public boolean isSoldOut() {
+        return soldQuantity >= maxQuantity;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDealStatus.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDealStatus.java
@@ -1,0 +1,32 @@
+package com.example.hotdeal.entity;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.exception.HotDealErrorCode;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum HotDealStatus {
+
+    SCHEDULED,
+    ACTIVE,
+    ENDED,
+    CANCELLED;
+
+    private static final Map<HotDealStatus, Set<HotDealStatus>> TRANSITIONS = Map.of(
+            SCHEDULED, Set.of(ACTIVE, CANCELLED),
+            ACTIVE, Set.of(ENDED, CANCELLED),
+            ENDED, Set.of(),
+            CANCELLED, Set.of()
+    );
+
+    public void validateTransitionTo(HotDealStatus target) {
+        if (!canTransitionTo(target)) {
+            throw new BusinessException(HotDealErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
+
+    public boolean canTransitionTo(HotDealStatus target) {
+        return TRANSITIONS.getOrDefault(this, Set.of()).contains(target);
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDealStatusHistory.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDealStatusHistory.java
@@ -1,0 +1,46 @@
+package com.example.hotdeal.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hot_deal_status_histories",
+        indexes = {
+                @Index(name = "idx_history_hot_deal_id", columnList = "hotDealId")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HotDealStatusHistory extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "hot_deal_id", nullable = false)
+    private Long hotDealId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_status", length = 20)
+    private HotDealStatus fromStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_status", nullable = false, length = 20)
+    private HotDealStatus toStatus;
+
+    @Column(name = "reason")
+    private String reason;
+
+    public static HotDealStatusHistory create(Long hotDealId, HotDealStatus fromStatus,
+                                               HotDealStatus toStatus, String reason) {
+        HotDealStatusHistory history = new HotDealStatusHistory();
+        history.hotDealId = hotDealId;
+        history.fromStatus = fromStatus;
+        history.toStatus = toStatus;
+        history.reason = reason;
+        return history;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealEndedEvent.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealEndedEvent.java
@@ -1,0 +1,40 @@
+package com.example.hotdeal.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class HotDealEndedEvent extends DomainEvent {
+
+    private final Long hotDealId;
+    private final Long itemId;
+    private final Integer soldQuantity;
+    private final Integer maxQuantity;
+
+    public HotDealEndedEvent(Long hotDealId, Long itemId,
+                              Integer soldQuantity, Integer maxQuantity) {
+        super("hotdeal-events");
+        this.hotDealId = hotDealId;
+        this.itemId = itemId;
+        this.soldQuantity = soldQuantity;
+        this.maxQuantity = maxQuantity;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "HOT_DEAL_ENDED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("hotDealId", hotDealId);
+        payload.put("itemId", itemId);
+        payload.put("soldQuantity", soldQuantity);
+        payload.put("maxQuantity", maxQuantity);
+        return payload;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealPurchasedEvent.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealPurchasedEvent.java
@@ -1,0 +1,43 @@
+package com.example.hotdeal.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class HotDealPurchasedEvent extends DomainEvent {
+
+    private final Long hotDealId;
+    private final Long userId;
+    private final Long itemId;
+    private final Integer quantity;
+    private final Long totalAmount;
+
+    public HotDealPurchasedEvent(Long hotDealId, Long userId, Long itemId,
+                                  Integer quantity, Long totalAmount) {
+        super("hotdeal-events");
+        this.hotDealId = hotDealId;
+        this.userId = userId;
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.totalAmount = totalAmount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "HOT_DEAL_PURCHASED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("hotDealId", hotDealId);
+        payload.put("userId", userId);
+        payload.put("itemId", itemId);
+        payload.put("quantity", quantity);
+        payload.put("totalAmount", totalAmount);
+        return payload;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealStartedEvent.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/event/HotDealStartedEvent.java
@@ -1,0 +1,54 @@
+package com.example.hotdeal.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class HotDealStartedEvent extends DomainEvent {
+
+    private final Long hotDealId;
+    private final Long itemId;
+    private final String title;
+    private final Long discountedPrice;
+    private final Integer discountRate;
+    private final Integer maxQuantity;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+
+    public HotDealStartedEvent(Long hotDealId, Long itemId, String title,
+                                Long discountedPrice, Integer discountRate,
+                                Integer maxQuantity, LocalDateTime startAt, LocalDateTime endAt) {
+        super("hotdeal-events");
+        this.hotDealId = hotDealId;
+        this.itemId = itemId;
+        this.title = title;
+        this.discountedPrice = discountedPrice;
+        this.discountRate = discountRate;
+        this.maxQuantity = maxQuantity;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "HOT_DEAL_STARTED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("hotDealId", hotDealId);
+        payload.put("itemId", itemId);
+        payload.put("title", title);
+        payload.put("discountedPrice", discountedPrice);
+        payload.put("discountRate", discountRate);
+        payload.put("maxQuantity", maxQuantity);
+        payload.put("startAt", startAt.toString());
+        payload.put("endAt", endAt.toString());
+        return payload;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/exception/HotDealErrorCode.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/exception/HotDealErrorCode.java
@@ -1,0 +1,39 @@
+package com.example.hotdeal.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HotDealErrorCode implements DomainErrorCode {
+
+    // ─── 핫딜 ────────────────────────────────
+    HOT_DEAL_NOT_FOUND("HOTDEAL-001", "핫딜 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    HOT_DEAL_NOT_ACTIVE("HOTDEAL-002", "현재 진행 중인 핫딜이 아닙니다.", HttpStatus.BAD_REQUEST),
+    HOT_DEAL_ALREADY_EXISTS("HOTDEAL-003", "이미 등록된 핫딜입니다.", HttpStatus.CONFLICT),
+    INVALID_STATUS_TRANSITION("HOTDEAL-004", "유효하지 않은 상태 전이입니다.", HttpStatus.BAD_REQUEST),
+    HOT_DEAL_SOLD_OUT("HOTDEAL-005", "핫딜 수량이 모두 소진되었습니다.", HttpStatus.CONFLICT),
+
+    // ─── 선착순 구매 ────────────────────────────
+    PURCHASE_QUANTITY_EXCEEDED("HOTDEAL-101", "구매 가능 수량을 초과했습니다.", HttpStatus.BAD_REQUEST),
+    PURCHASE_ALREADY_EXISTS("HOTDEAL-102", "이미 구매한 핫딜입니다.", HttpStatus.CONFLICT),
+    RESERVATION_EXPIRED("HOTDEAL-103", "임시 예약이 만료되었습니다.", HttpStatus.CONFLICT),
+
+    // ─── 대기열 ────────────────────────────────
+    QUEUE_ALREADY_ENTERED("HOTDEAL-201", "이미 대기열에 등록되어 있습니다.", HttpStatus.CONFLICT),
+    QUEUE_TOKEN_INVALID("HOTDEAL-202", "유효하지 않은 대기열 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    QUEUE_NOT_ADMITTED("HOTDEAL-203", "아직 입장이 허용되지 않았습니다.", HttpStatus.FORBIDDEN),
+
+    // ─── 외부 서비스 ────────────────────────────
+    PRODUCT_SERVICE_ERROR("HOTDEAL-301", "상품 서비스 호출 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    STOCK_SERVICE_ERROR("HOTDEAL-302", "재고 서비스 호출 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+
+    // ─── 분산 락 ────────────────────────────────
+    LOCK_ACQUISITION_FAILED("HOTDEAL-401", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealRepository.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealRepository.java
@@ -1,0 +1,33 @@
+package com.example.hotdeal.repository;
+
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.entity.HotDealStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface HotDealRepository extends JpaRepository<HotDeal, Long> {
+
+    List<HotDeal> findByStatus(HotDealStatus status);
+
+    Optional<HotDeal> findByItemIdAndStatusIn(Long itemId, List<HotDealStatus> statuses);
+
+    @Query("SELECT h FROM HotDeal h WHERE h.status = :status AND h.id < :cursor ORDER BY h.id DESC")
+    List<HotDeal> findByStatusWithCursor(@Param("status") HotDealStatus status,
+                                          @Param("cursor") Long cursor,
+                                          org.springframework.data.domain.Pageable pageable);
+
+    @Query("SELECT h FROM HotDeal h WHERE h.status = 'ACTIVE' AND h.endAt < :now")
+    List<HotDeal> findExpiredActiveDeals(@Param("now") LocalDateTime now);
+
+    boolean existsByItemIdAndStatusIn(Long itemId, List<HotDealStatus> statuses);
+
+    @Modifying
+    @Query("UPDATE HotDeal h SET h.soldQuantity = h.soldQuantity + :quantity WHERE h.id = :id")
+    int incrementSoldQuantity(@Param("id") Long id, @Param("quantity") int quantity);
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealStatusHistoryRepository.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealStatusHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.example.hotdeal.repository;
+
+import com.example.hotdeal.entity.HotDealStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HotDealStatusHistoryRepository extends JpaRepository<HotDealStatusHistory, Long> {
+
+    List<HotDealStatusHistory> findByHotDealIdOrderByCreatedAtDesc(Long hotDealId);
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealEndScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealEndScheduler.java
@@ -1,0 +1,29 @@
+package com.example.hotdeal.scheduler;
+
+import com.example.hotdeal.service.HotDealCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotDealEndScheduler {
+
+    private final HotDealCommandService hotDealCommandService;
+
+    /**
+     * 매 1분마다 실행: 종료 시간이 지난 ACTIVE 핫딜을 ENDED로 전환
+     */
+    @Scheduled(fixedRate = 60000)
+    @SchedulerLock(name = "hotDealEnd", lockAtLeastFor = "PT30S", lockAtMostFor = "PT5M")
+    public void endExpiredDeals() {
+        try {
+            hotDealCommandService.endExpiredDeals();
+        } catch (Exception e) {
+            log.error("Hot deal end scheduler failed", e);
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealSelectionScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealSelectionScheduler.java
@@ -1,0 +1,113 @@
+package com.example.hotdeal.scheduler;
+
+import com.example.hotdeal.client.ProductClient;
+import com.example.hotdeal.client.StockClient;
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.service.HotDealCommandService;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotDealSelectionScheduler {
+
+    private final ProductClient productClient;
+    private final StockClient stockClient;
+    private final HotDealRepository hotDealRepository;
+    private final HotDealCommandService hotDealCommandService;
+
+    /**
+     * 매일 자정에 실행: D-3 이내 마감 예정 상품 중 잔여율 조건에 맞는 상품을 핫딜로 전환
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(name = "hotDealSelection", lockAtLeastFor = "PT5M", lockAtMostFor = "PT30M")
+    public void selectHotDeals() {
+        log.info("Hot deal selection scheduler started");
+
+        try {
+            JsonNode items = productClient.findItemsEndingSoon(3);
+
+            if (items == null || !items.isArray()) {
+                log.info("No items ending soon found");
+                return;
+            }
+
+            int selectedCount = 0;
+
+            for (JsonNode item : items) {
+                Long itemId = item.path("itemId").asLong();
+                String title = item.path("title").asText();
+                Long price = item.path("price").asLong();
+                Long stockItemId = item.path("stockItemId").asLong();
+
+                // 이미 핫딜로 등록된 상품인지 확인
+                boolean exists = hotDealRepository.existsByItemIdAndStatusIn(
+                        itemId, List.of(HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE));
+                if (exists) {
+                    continue;
+                }
+
+                // 재고 정보 조회
+                JsonNode stockInfo = stockClient.getStockInfo(stockItemId);
+                int totalQuantity = stockInfo.path("totalQuantity").asInt();
+                int availableQuantity = stockInfo.path("availableQuantity").asInt();
+
+                if (totalQuantity == 0) {
+                    continue;
+                }
+
+                double remainingRate = (double) availableQuantity / totalQuantity * 100;
+
+                // 잔여율 20% 미만이면 스킵 (이미 잘 팔리는 상품)
+                if (remainingRate < 20) {
+                    continue;
+                }
+
+                // 할인율 계산
+                int discountRate = calculateDiscountRate(remainingRate);
+
+                // 핫딜 생성 및 활성화
+                hotDealCommandService.createAndActivate(
+                        itemId, title, price, discountRate, availableQuantity,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+                        "자동 선정 — 잔여율 " + String.format("%.1f", remainingRate) + "%");
+
+                selectedCount++;
+                log.info("Hot deal selected: itemId={}, title={}, remainingRate={:.1f}%, discountRate={}%",
+                        itemId, title, remainingRate, discountRate);
+            }
+
+            log.info("Hot deal selection completed: {} deals created", selectedCount);
+        } catch (Exception e) {
+            log.error("Hot deal selection scheduler failed", e);
+        }
+    }
+
+    /**
+     * 잔여율 기반 할인율 계산
+     * - 50% 이상 → 10%
+     * - 30~50% → 20%
+     * - 20~30% → 30%
+     * - 20% 미만 → 40%
+     */
+    private int calculateDiscountRate(double remainingRate) {
+        if (remainingRate >= 50) {
+            return 10;
+        } else if (remainingRate >= 30) {
+            return 20;
+        } else if (remainingRate >= 20) {
+            return 30;
+        } else {
+            return 40;
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
@@ -1,0 +1,35 @@
+package com.example.hotdeal.scheduler;
+
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueAdmissionScheduler {
+
+    private final QueueService queueService;
+    private final HotDealRepository hotDealRepository;
+
+    private static final int ADMIT_COUNT = 10;
+
+    /**
+     * 매 1초마다 실행: ACTIVE 핫딜별 대기열에서 상위 N명 입장 허용
+     */
+    @Scheduled(fixedRate = 1000)
+    public void admitUsers() {
+        hotDealRepository.findByStatus(HotDealStatus.ACTIVE)
+                .forEach(hotDeal -> {
+                    try {
+                        queueService.admitUsers(hotDeal.getId(), ADMIT_COUNT);
+                    } catch (Exception e) {
+                        log.error("Queue admission failed: hotDealId={}", hotDeal.getId(), e);
+                    }
+                });
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealCommandService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealCommandService.java
@@ -1,0 +1,115 @@
+package com.example.hotdeal.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.client.ProductClient;
+import com.example.hotdeal.dto.CreateHotDealRequest;
+import com.example.hotdeal.dto.HotDealDetailResponse;
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.entity.HotDealStatusHistory;
+import com.example.hotdeal.event.HotDealEndedEvent;
+import com.example.hotdeal.event.HotDealStartedEvent;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.repository.HotDealStatusHistoryRepository;
+import com.example.event.EventPublisher;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HotDealCommandService {
+
+    private final HotDealRepository hotDealRepository;
+    private final HotDealStatusHistoryRepository statusHistoryRepository;
+    private final EventPublisher eventPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductClient productClient;
+
+    private static final String STOCK_KEY_PREFIX = "hotdeal:stock:";
+
+    /**
+     * 판매자가 직접 핫딜 생성
+     */
+    public HotDealDetailResponse createManual(CreateHotDealRequest request, Long userId) {
+        // 상품 정보 조회 + 검증
+        JsonNode itemData = productClient.findItem(request.getItemId());
+        String title = itemData.path("title").asText();
+        Long originalPrice = itemData.path("price").asLong();
+
+        // 이미 핫딜로 등록된 상품인지 확인
+        boolean exists = hotDealRepository.existsByItemIdAndStatusIn(
+                request.getItemId(), List.of(HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE));
+        if (exists) {
+            throw new BusinessException(HotDealErrorCode.HOT_DEAL_ALREADY_EXISTS);
+        }
+
+        LocalDateTime startAt = request.getStartAt() != null ? request.getStartAt() : LocalDateTime.now();
+        LocalDateTime endAt = request.getEndAt() != null ? request.getEndAt() : startAt.plusHours(2);
+
+        HotDeal hotDeal = createAndActivate(
+                request.getItemId(), title, originalPrice,
+                request.getDiscountRate(), request.getMaxQuantity(),
+                startAt, endAt, "판매자 수동 생성 (userId=" + userId + ")");
+
+        return HotDealDetailResponse.from(hotDeal);
+    }
+
+    public HotDeal createAndActivate(Long itemId, String title, Long originalPrice,
+                                      Integer discountRate, Integer maxQuantity,
+                                      LocalDateTime startAt, LocalDateTime endAt, String reason) {
+        HotDeal hotDeal = HotDeal.create(itemId, title, originalPrice,
+                discountRate, maxQuantity, startAt, endAt);
+        hotDeal.activate();
+        hotDealRepository.save(hotDeal);
+
+        // 상태 이력
+        statusHistoryRepository.save(
+                HotDealStatusHistory.create(hotDeal.getId(), null, HotDealStatus.SCHEDULED, "핫딜 생성"));
+        statusHistoryRepository.save(
+                HotDealStatusHistory.create(hotDeal.getId(), HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE, reason));
+
+        // Redis에 재고 초기화
+        redisTemplate.opsForValue().set(STOCK_KEY_PREFIX + hotDeal.getId(), maxQuantity);
+
+        // 이벤트 발행
+        eventPublisher.publish(new HotDealStartedEvent(
+                hotDeal.getId(), itemId, title, hotDeal.getDiscountedPrice(),
+                discountRate, maxQuantity, startAt, endAt));
+
+        log.info("Hot deal activated: id={}, itemId={}, discountRate={}%", hotDeal.getId(), itemId, discountRate);
+
+        return hotDeal;
+    }
+
+    public void endExpiredDeals() {
+        List<HotDeal> expired = hotDealRepository.findExpiredActiveDeals(LocalDateTime.now());
+
+        for (HotDeal hotDeal : expired) {
+            HotDealStatus from = hotDeal.getStatus();
+            hotDeal.end();
+
+            statusHistoryRepository.save(
+                    HotDealStatusHistory.create(hotDeal.getId(), from, HotDealStatus.ENDED, "시간 만료"));
+
+            // Redis 재고 키 삭제
+            redisTemplate.delete(STOCK_KEY_PREFIX + hotDeal.getId());
+
+            eventPublisher.publish(new HotDealEndedEvent(
+                    hotDeal.getId(), hotDeal.getItemId(),
+                    hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity()));
+
+            log.info("Hot deal ended: id={}, sold={}/{}", hotDeal.getId(),
+                    hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity());
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealPurchaseService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealPurchaseService.java
@@ -1,0 +1,99 @@
+package com.example.hotdeal.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.dto.HotDealPurchaseRequest;
+import com.example.hotdeal.dto.HotDealPurchaseResponse;
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.event.HotDealPurchasedEvent;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.event.EventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HotDealPurchaseService {
+
+    private final HotDealRepository hotDealRepository;
+    private final EventPublisher eventPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final QueueService queueService;
+
+    private static final String STOCK_KEY_PREFIX = "hotdeal:stock:";
+    private static final String RESERVATION_KEY_PREFIX = "hotdeal:reservation:";
+    private static final long RESERVATION_TTL_MINUTES = 5;
+
+    private static final String LUA_SCRIPT = """
+            local stockKey = KEYS[1]
+            local reservationKey = KEYS[2]
+            local quantity = tonumber(ARGV[1])
+            local ttl = tonumber(ARGV[2])
+            local reservationId = ARGV[3]
+
+            local current = tonumber(redis.call('GET', stockKey))
+            if current == nil then
+                return -1
+            end
+            if current < quantity then
+                return 0
+            end
+            redis.call('DECRBY', stockKey, quantity)
+            redis.call('SET', reservationKey, reservationId, 'EX', ttl)
+            return 1
+            """;
+
+    @Transactional
+    public HotDealPurchaseResponse purchase(Long hotDealId, HotDealPurchaseRequest request, Long userId) {
+        // 대기열 토큰 검증
+        if (!queueService.isAdmitted(hotDealId, userId)) {
+            throw new BusinessException(HotDealErrorCode.QUEUE_NOT_ADMITTED);
+        }
+
+        String stockKey = STOCK_KEY_PREFIX + hotDealId;
+        String reservationKey = RESERVATION_KEY_PREFIX + hotDealId + ":" + userId;
+        String reservationId = UUID.randomUUID().toString();
+
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>(LUA_SCRIPT, Long.class);
+        Long result = redisTemplate.execute(script,
+                List.of(stockKey, reservationKey),
+                request.getQuantity(),
+                RESERVATION_TTL_MINUTES * 60,
+                reservationId);
+
+        if (result == null || result == -1) {
+            throw new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND);
+        }
+
+        if (result == 0) {
+            throw new BusinessException(HotDealErrorCode.HOT_DEAL_SOLD_OUT);
+        }
+
+        // DB 판매 수량 원자적 증가 (동시성 안전)
+        hotDealRepository.incrementSoldQuantity(hotDealId, request.getQuantity());
+
+        HotDeal hotDeal = hotDealRepository.findById(hotDealId)
+                .orElseThrow(() -> new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND));
+
+        Long totalAmount = hotDeal.getDiscountedPrice() * request.getQuantity();
+
+        // 이벤트 발행
+        eventPublisher.publish(new HotDealPurchasedEvent(
+                hotDealId, userId, hotDeal.getItemId(), request.getQuantity(), totalAmount));
+
+        log.info("Hot deal purchased: hotDealId={}, userId={}, quantity={}", hotDealId, userId, request.getQuantity());
+
+        return HotDealPurchaseResponse.success(reservationId,
+                LocalDateTime.now().plusMinutes(RESERVATION_TTL_MINUTES));
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealQueryService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealQueryService.java
@@ -1,0 +1,59 @@
+package com.example.hotdeal.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.dto.HotDealDetailResponse;
+import com.example.hotdeal.dto.HotDealListResponse;
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import com.example.hotdeal.repository.HotDealRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HotDealQueryService {
+
+    private final HotDealRepository hotDealRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String CACHE_KEY_PREFIX = "hotdeal:detail:";
+    private static final long CACHE_TTL_SECONDS = 10;
+
+    public List<HotDealListResponse> getActiveDeals(Long cursor, int size) {
+        if (cursor == null || cursor == 0) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        return hotDealRepository.findByStatusWithCursor(
+                        HotDealStatus.ACTIVE, cursor, PageRequest.of(0, size))
+                .stream()
+                .map(HotDealListResponse::from)
+                .toList();
+    }
+
+    public HotDealDetailResponse getDetail(Long hotDealId) {
+        String cacheKey = CACHE_KEY_PREFIX + hotDealId;
+
+        Object cached = redisTemplate.opsForValue().get(cacheKey);
+        if (cached instanceof HotDealDetailResponse response) {
+            return response;
+        }
+
+        HotDeal hotDeal = hotDealRepository.findById(hotDealId)
+                .orElseThrow(() -> new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND));
+
+        HotDealDetailResponse response = HotDealDetailResponse.from(hotDeal);
+
+        redisTemplate.opsForValue().set(cacheKey, response, CACHE_TTL_SECONDS, TimeUnit.SECONDS);
+
+        return response;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
@@ -1,0 +1,115 @@
+package com.example.hotdeal.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.dto.QueueEnterResponse;
+import com.example.hotdeal.dto.QueueStatusResponse;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String QUEUE_KEY_PREFIX = "hotdeal:queue:";
+    private static final String TOKEN_KEY_PREFIX = "hotdeal:token:";
+    private static final String ADMITTED_KEY_PREFIX = "hotdeal:admitted:";
+    private static final long TOKEN_TTL_MINUTES = 30;
+    private static final long ADMITTED_TTL_MINUTES = 10;
+    private static final long ESTIMATED_PROCESS_SECONDS_PER_USER = 2;
+
+    public QueueEnterResponse enter(Long hotDealId, Long userId) {
+        String queueKey = QUEUE_KEY_PREFIX + hotDealId;
+        String memberKey = userId.toString();
+
+        // 이미 대기열에 있는지 확인
+        Long existingRank = redisTemplate.opsForZSet().rank(queueKey, memberKey);
+        if (existingRank != null) {
+            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+        }
+
+        // 이미 입장 허용된 사용자인지 확인
+        if (isAdmitted(hotDealId, userId)) {
+            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+        }
+
+        // ZADD (score = timestamp)
+        double score = System.currentTimeMillis();
+        redisTemplate.opsForZSet().add(queueKey, memberKey, score);
+
+        // 토큰 생성
+        String token = UUID.randomUUID().toString();
+        String tokenKey = TOKEN_KEY_PREFIX + hotDealId + ":" + userId;
+        redisTemplate.opsForValue().set(tokenKey, token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+
+        Long position = redisTemplate.opsForZSet().rank(queueKey, memberKey);
+        long pos = position != null ? position + 1 : 1;
+
+        return QueueEnterResponse.builder()
+                .token(token)
+                .position(pos)
+                .estimatedWaitSeconds(pos * ESTIMATED_PROCESS_SECONDS_PER_USER)
+                .build();
+    }
+
+    public QueueStatusResponse getStatus(Long hotDealId, Long userId) {
+        // 이미 입장 허용됐는지 확인
+        if (isAdmitted(hotDealId, userId)) {
+            return QueueStatusResponse.builder()
+                    .position(0L)
+                    .canPurchase(true)
+                    .build();
+        }
+
+        String queueKey = QUEUE_KEY_PREFIX + hotDealId;
+        String memberKey = userId.toString();
+
+        Long rank = redisTemplate.opsForZSet().rank(queueKey, memberKey);
+        if (rank == null) {
+            throw new BusinessException(HotDealErrorCode.QUEUE_TOKEN_INVALID);
+        }
+
+        return QueueStatusResponse.builder()
+                .position(rank + 1)
+                .canPurchase(false)
+                .build();
+    }
+
+    /**
+     * 상위 N명 입장 허용 (스케줄러에서 호출)
+     */
+    public void admitUsers(Long hotDealId, int count) {
+        String queueKey = QUEUE_KEY_PREFIX + hotDealId;
+
+        Set<ZSetOperations.TypedTuple<Object>> topUsers =
+                redisTemplate.opsForZSet().popMin(queueKey, count);
+
+        if (topUsers == null || topUsers.isEmpty()) {
+            return;
+        }
+
+        for (ZSetOperations.TypedTuple<Object> user : topUsers) {
+            Object value = user.getValue();
+            if (value != null) {
+                String admittedKey = ADMITTED_KEY_PREFIX + hotDealId + ":" + value;
+                redisTemplate.opsForValue().set(admittedKey, "true", ADMITTED_TTL_MINUTES, TimeUnit.MINUTES);
+                log.debug("User admitted: hotDealId={}, userId={}", hotDealId, value);
+            }
+        }
+    }
+
+    public boolean isAdmitted(Long hotDealId, Long userId) {
+        String admittedKey = ADMITTED_KEY_PREFIX + hotDealId + ":" + userId;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(admittedKey));
+    }
+}

--- a/servers/services/hot-deal/src/main/resources/application.yml
+++ b/servers/services/hot-deal/src/main/resources/application.yml
@@ -1,0 +1,75 @@
+server:
+  port: ${SERVER_PORT:8089}
+
+spring:
+  application:
+    name: hot-deal-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/hotdeal_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: hot-deal-service-group
+      auto-offset-reset: earliest
+
+# ─── Snowflake ID ────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:8}
+
+  # ─── Service URLs ──────────────────────────────
+  service:
+    product-url: ${PRODUCT_SERVICE_URL:http://localhost:8084}
+    stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
+
+  # ─── OpenAPI ──────────────────────────────────
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Hot-Deal Service API"
+    version: "1.0.0"
+    description: |
+      핫딜 자동 전환, 선착순 구매, 대기열 시스템
+
+# ─── Actuator ─────────────────────────────────
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+# ─── Logging ──────────────────────────────────
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/servers/services/hot-deal/src/test/k6/load-test.js
+++ b/servers/services/hot-deal/src/test/k6/load-test.js
@@ -1,0 +1,125 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+// ─── 설정 ─────────────────────────────────
+const HOT_DEAL_ID = '280227607700733952';
+const BASE_URL = 'http://localhost:8089';
+
+// ─── 커스텀 메트릭 ──────────────────────────
+const purchaseSuccess = new Counter('purchase_success');
+const purchaseFail = new Counter('purchase_fail');
+const queueEnterSuccess = new Counter('queue_enter_success');
+const purchaseRate = new Rate('purchase_success_rate');
+const purchaseDuration = new Trend('purchase_duration');
+
+// ─── 시나리오 ────────────────────────────────
+// 100명 동시 접속 → 대기열 진입 → 입장 대기 → 구매 시도
+export const options = {
+    scenarios: {
+        rush: {
+            executor: 'shared-iterations',
+            vus: 100,
+            iterations: 100,
+            maxDuration: '60s',
+        },
+    },
+    thresholds: {
+        http_req_duration: ['p(95)<2000'],
+        purchase_success_rate: ['rate>0'],
+    },
+};
+
+export default function () {
+    const userId = __VU;
+    const headers = {
+        'Content-Type': 'application/json',
+        'X-User-Id': String(userId),
+    };
+
+    // 1. 대기열 진입
+    const enterRes = http.post(
+        `${BASE_URL}/api/v1/hot-deals/${HOT_DEAL_ID}/queue/enter`,
+        null,
+        { headers }
+    );
+
+    const enterOk = check(enterRes, {
+        'queue enter status 200': (r) => r.status === 200,
+    });
+
+    if (enterOk) {
+        queueEnterSuccess.add(1);
+    }
+
+    // 2. 입장 대기 (폴링)
+    let admitted = false;
+    for (let i = 0; i < 30; i++) {
+        sleep(1);
+
+        const statusRes = http.get(
+            `${BASE_URL}/api/v1/hot-deals/${HOT_DEAL_ID}/queue`,
+            { headers }
+        );
+
+        if (statusRes.status === 200) {
+            const body = JSON.parse(statusRes.body);
+            if (body.data && body.data.canPurchase) {
+                admitted = true;
+                break;
+            }
+        }
+    }
+
+    if (!admitted) {
+        purchaseFail.add(1);
+        purchaseRate.add(false);
+        return;
+    }
+
+    // 3. 구매 시도
+    const start = Date.now();
+    const purchaseRes = http.post(
+        `${BASE_URL}/api/v1/hot-deals/${HOT_DEAL_ID}/purchase`,
+        JSON.stringify({ quantity: 1 }),
+        { headers }
+    );
+    purchaseDuration.add(Date.now() - start);
+
+    const purchaseOk = check(purchaseRes, {
+        'purchase status 200': (r) => r.status === 200,
+    });
+
+    if (purchaseOk) {
+        const body = JSON.parse(purchaseRes.body);
+        if (body.data && body.data.success) {
+            purchaseSuccess.add(1);
+            purchaseRate.add(true);
+        } else {
+            purchaseFail.add(1);
+            purchaseRate.add(false);
+        }
+    } else {
+        purchaseFail.add(1);
+        purchaseRate.add(false);
+    }
+}
+
+export function handleSummary(data) {
+    const success = data.metrics.purchase_success ? data.metrics.purchase_success.values.count : 0;
+    const fail = data.metrics.purchase_fail ? data.metrics.purchase_fail.values.count : 0;
+    const total = success + fail;
+
+    console.log('\n=== 부하 테스트 결과 ===');
+    console.log(`총 시도: ${total}`);
+    console.log(`구매 성공: ${success}`);
+    console.log(`구매 실패: ${fail} (재고 소진 포함)`);
+    console.log(`성공률: ${total > 0 ? ((success / total) * 100).toFixed(1) : 0}%`);
+
+    if (data.metrics.purchase_duration) {
+        const dur = data.metrics.purchase_duration.values;
+        console.log(`구매 응답시간 p50: ${dur.med?.toFixed(0)}ms, p95: ${dur['p(95)']?.toFixed(0)}ms`);
+    }
+
+    return {};
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include("servers:services:product")
 include("servers:services:stock")
 include("servers:services:funding")
 include("servers:services:sales")
+include("servers:services:hot-deal")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## Summary
- HotDeal 엔티티 및 상태 머신 (SCHEDULED → ACTIVE → ENDED/CANCELLED)
- Redis Sorted Set 기반 대기열 시스템 (진입/입장/상태조회)
- Lua Script 원자적 재고 차감 + 구매 처리
- 자동 핫딜 선정 스케줄러 (매일 자정, ShedLock)
- 핫딜 종료/대기열 입장 스케줄러
- 판매자 수동 핫딜 생성 API
- Product/Stock 서비스 연동 (WebClient)
- StockThreshold 카프카 이벤트 소비
- 핫딜 이벤트 발행 (Started, Ended, Purchased)
- k6 부하 테스트 스크립트 (100 VU 동시 접속)
- DB 동시성 버그 수정 (JPA → 원자적 UPDATE 쿼리)

## Changes
- 38 files changed, 1832 insertions

## Test Plan
- [x] E2E 테스트: 핫딜 생성 → 대기열 진입 → 입장 → 구매 → 종료 전체 흐름
- [x] k6 부하 테스트: 100 VU 동시 구매 시나리오
- [x] 동시성 버그 재현 및 수정 검증

Closes #362