### PR TITLE
fix: MVP 크리티컬 버그 수정 — Redis 정합성, 트랜잭션 분리, 동시성 안전

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ CLAUDE.md
 
 ### Blog ###
 .blog/
+
+### Agent docs ###
+AGENTS.md

--- a/docker/init-scripts/postgres/01-init.sql
+++ b/docker/init-scripts/postgres/01-init.sql
@@ -6,6 +6,9 @@
 CREATE DATABASE auth_db;
 CREATE DATABASE user_db;
 CREATE DATABASE test_db;
+CREATE DATABASE product_db;
+CREATE DATABASE stock_db;
+CREATE DATABASE funding_db;
 CREATE DATABASE sales_db;
 CREATE DATABASE hotdeal_db;
 
@@ -19,6 +22,22 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- test_db 초기 설정 (테스트 서버용)
 \c test_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- product_db 초기 설정
+\c product_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- stock_db 초기 설정
+\c stock_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- funding_db 초기 설정
+\c funding_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- sales_db 초기 설정
+\c sales_db;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- hotdeal_db 초기 설정

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingCampaign.java
@@ -105,7 +105,10 @@ public class FundingCampaign extends BaseEntity {
     }
 
     public boolean isActive() {
-        return this.status == FundingStatus.ACTIVE;
+        LocalDateTime now = LocalDateTime.now();
+        return this.status == FundingStatus.ACTIVE
+                && !now.isBefore(this.startAt)
+                && now.isBefore(this.endAt);
     }
 
     public boolean isExpired() {
@@ -120,7 +123,7 @@ public class FundingCampaign extends BaseEntity {
 
     public void update(Long goalAmount, Integer goalQuantity, Long minAmount,
                        LocalDateTime startAt, LocalDateTime endAt) {
-        if (!isActive()) {
+        if (this.status != FundingStatus.ACTIVE || isExpired()) {
             throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_EDITABLE);
         }
         this.goalAmount = goalAmount;

--- a/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/FundingParticipation.java
@@ -1,7 +1,9 @@
 package com.example.funding.entity;
 
+import com.example.core.exception.BusinessException;
 import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
+import com.example.funding.exception.FundingErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -74,11 +76,17 @@ public class FundingParticipation extends BaseEntity {
     }
 
     public void confirm(Long paymentId) {
+        if (this.status != ParticipationStatus.PENDING) {
+            throw new BusinessException(FundingErrorCode.INVALID_PARTICIPATION_STATUS);
+        }
         this.status = ParticipationStatus.CONFIRMED;
         this.paymentId = paymentId;
     }
 
     public void refund() {
+        if (this.status != ParticipationStatus.PENDING) {
+            throw new BusinessException(FundingErrorCode.INVALID_PARTICIPATION_STATUS);
+        }
         this.status = ParticipationStatus.REFUNDED;
     }
 }

--- a/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
@@ -2,7 +2,10 @@ package com.example.funding.repository;
 
 import com.example.funding.entity.FundingCampaign;
 import com.example.funding.entity.FundingStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,6 +14,20 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FundingCampaignRepository extends JpaRepository<FundingCampaign, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM FundingCampaign c WHERE c.id = :id")
+    Optional<FundingCampaign> findByIdWithLock(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE FundingCampaign c SET c.currentAmount = c.currentAmount + :amount, " +
+            "c.currentQuantity = c.currentQuantity + :quantity WHERE c.id = :id")
+    int incrementParticipation(@Param("id") Long id, @Param("amount") Long amount, @Param("quantity") int quantity);
+
+    @Modifying
+    @Query("UPDATE FundingCampaign c SET c.currentAmount = c.currentAmount - :amount, " +
+            "c.currentQuantity = c.currentQuantity - :quantity WHERE c.id = :id")
+    int decrementParticipation(@Param("id") Long id, @Param("amount") Long amount, @Param("quantity") int quantity);
 
     Optional<FundingCampaign> findByItemId(Long itemId);
 

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/StockClient.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/StockClient.java
@@ -42,4 +42,28 @@ public class StockClient {
             throw new BusinessException(HotDealErrorCode.STOCK_SERVICE_ERROR);
         }
     }
+
+    /**
+     * 아이템 ID 기반 재고 정보 조회
+     */
+    public JsonNode getStockInfoByItemId(Long itemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/stock/items/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new BusinessException(HotDealErrorCode.STOCK_SERVICE_ERROR);
+            }
+
+            return response.path("data");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Stock info lookup by itemId failed: itemId={}", itemId, e);
+            throw new BusinessException(HotDealErrorCode.STOCK_SERVICE_ERROR);
+        }
+    }
 }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/InternalHotDealController.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/InternalHotDealController.java
@@ -30,6 +30,7 @@ public class InternalHotDealController {
                 request.getOriginalPrice(),
                 request.getDiscountRate(),
                 request.getMaxQuantity(),
+                request.getMaxPerUser() != null ? request.getMaxPerUser() : 1,
                 request.getStartAt() != null ? request.getStartAt() : LocalDateTime.now(),
                 request.getEndAt() != null ? request.getEndAt() : LocalDateTime.now().plusHours(1),
                 "수동 생성");
@@ -44,6 +45,7 @@ public class InternalHotDealController {
         private Long originalPrice;
         private Integer discountRate;
         private Integer maxQuantity;
+        private Integer maxPerUser;
         private LocalDateTime startAt;
         private LocalDateTime endAt;
     }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/CreateHotDealRequest.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/CreateHotDealRequest.java
@@ -24,6 +24,9 @@ public class CreateHotDealRequest {
     @Min(value = 1, message = "최대 수량은 1 이상이어야 합니다")
     private Integer maxQuantity;
 
+    @Min(value = 1, message = "1인당 최대 구매 수량은 1 이상이어야 합니다")
+    private Integer maxPerUser;
+
     private LocalDateTime startAt;
 
     private LocalDateTime endAt;

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealDetailResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/HotDealDetailResponse.java
@@ -2,12 +2,17 @@ package com.example.hotdeal.dto;
 
 import com.example.core.id.jackson.SnowflakeId;
 import com.example.hotdeal.entity.HotDeal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
 public class HotDealDetailResponse {
 
@@ -18,6 +23,7 @@ public class HotDealDetailResponse {
     private Integer discountRate;
     private Long discountedPrice;
     private Integer maxQuantity;
+    private Integer maxPerUser;
     private Integer soldQuantity;
     private Integer remainingQuantity;
     private Double progressRate;
@@ -39,6 +45,7 @@ public class HotDealDetailResponse {
                 .discountRate(h.getDiscountRate())
                 .discountedPrice(h.getDiscountedPrice())
                 .maxQuantity(h.getMaxQuantity())
+                .maxPerUser(h.getMaxPerUser())
                 .soldQuantity(h.getSoldQuantity())
                 .remainingQuantity(h.getRemainingQuantity())
                 .progressRate(Math.round(progress * 10.0) / 10.0)

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDeal.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/entity/HotDeal.java
@@ -51,6 +51,9 @@ public class HotDeal extends BaseEntity {
     @Column(name = "max_quantity", nullable = false)
     private Integer maxQuantity;
 
+    @Column(name = "max_per_user", nullable = false)
+    private Integer maxPerUser;
+
     @Column(name = "sold_quantity", nullable = false)
     private Integer soldQuantity;
 
@@ -59,7 +62,7 @@ public class HotDeal extends BaseEntity {
     private HotDealStatus status;
 
     public static HotDeal create(Long itemId, String title, Long originalPrice,
-                                  Integer discountRate, Integer maxQuantity,
+                                  Integer discountRate, Integer maxQuantity, Integer maxPerUser,
                                   LocalDateTime startAt, LocalDateTime endAt) {
         HotDeal hotDeal = new HotDeal();
         hotDeal.itemId = itemId;
@@ -68,6 +71,7 @@ public class HotDeal extends BaseEntity {
         hotDeal.discountRate = discountRate;
         hotDeal.discountedPrice = originalPrice * (100 - discountRate) / 100;
         hotDeal.maxQuantity = maxQuantity;
+        hotDeal.maxPerUser = maxPerUser != null ? maxPerUser : 1;
         hotDeal.soldQuantity = 0;
         hotDeal.startAt = startAt;
         hotDeal.endAt = endAt;

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealRepository.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/repository/HotDealRepository.java
@@ -28,6 +28,12 @@ public interface HotDealRepository extends JpaRepository<HotDeal, Long> {
     boolean existsByItemIdAndStatusIn(Long itemId, List<HotDealStatus> statuses);
 
     @Modifying
-    @Query("UPDATE HotDeal h SET h.soldQuantity = h.soldQuantity + :quantity WHERE h.id = :id")
+    @Query("""
+            UPDATE HotDeal h
+            SET h.soldQuantity = h.soldQuantity + :quantity
+            WHERE h.id = :id
+              AND h.status = 'ACTIVE'
+              AND (h.soldQuantity + :quantity) <= h.maxQuantity
+            """)
     int incrementSoldQuantity(@Param("id") Long id, @Param("quantity") int quantity);
 }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
@@ -5,6 +5,7 @@ import com.example.hotdeal.repository.HotDealRepository;
 import com.example.hotdeal.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,7 @@ public class QueueAdmissionScheduler {
      * 매 1초마다 실행: ACTIVE 핫딜별 대기열에서 상위 N명 입장 허용
      */
     @Scheduled(fixedRate = 1000)
+    @SchedulerLock(name = "queueAdmission", lockAtLeastFor = "PT0.5S", lockAtMostFor = "PT5S")
     public void admitUsers() {
         hotDealRepository.findByStatus(HotDealStatus.ACTIVE)
                 .forEach(hotDeal -> {

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealCommandService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealCommandService.java
@@ -1,5 +1,6 @@
 package com.example.hotdeal.service;
 
+import com.example.config.redis.lock.DistributedLock;
 import com.example.core.exception.BusinessException;
 import com.example.hotdeal.client.ProductClient;
 import com.example.hotdeal.dto.CreateHotDealRequest;
@@ -12,36 +13,48 @@ import com.example.hotdeal.event.HotDealStartedEvent;
 import com.example.hotdeal.exception.HotDealErrorCode;
 import com.example.hotdeal.repository.HotDealRepository;
 import com.example.hotdeal.repository.HotDealStatusHistoryRepository;
+import com.example.event.EventMetadata;
 import com.example.event.EventPublisher;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class HotDealCommandService {
 
     private final HotDealRepository hotDealRepository;
     private final HotDealStatusHistoryRepository statusHistoryRepository;
     private final EventPublisher eventPublisher;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
     private final ProductClient productClient;
+    private final TransactionTemplate transactionTemplate;
 
     private static final String STOCK_KEY_PREFIX = "hotdeal:stock:";
+    private static final String MAX_PER_USER_KEY_PREFIX = "hotdeal:maxperuser:";
+    private static final String QUEUE_KEY_PREFIX = "hotdeal:queue:";
+    private static final String TOKEN_KEY_PREFIX = "hotdeal:token:";
+    private static final String ADMITTED_KEY_PREFIX = "hotdeal:admitted:";
+    private static final String PURCHASED_KEY_PREFIX = "hotdeal:purchased:";
+    private static final String RESERVATION_KEY_PREFIX = "hotdeal:reservation:";
 
     /**
-     * 판매자가 직접 핫딜 생성
+     * 판매자가 직접 핫딜 생성 — HTTP 조회 후 트랜잭션 시작
      */
+    @DistributedLock(key = "'hotdeal:item:' + #request.itemId", waitTime = 3)
     public HotDealDetailResponse createManual(CreateHotDealRequest request, Long userId) {
-        // 상품 정보 조회 + 검증
+        // 상품 정보 조회 (트랜잭션 밖)
         JsonNode itemData = productClient.findItem(request.getItemId());
         String title = itemData.path("title").asText();
         Long originalPrice = itemData.path("price").asLong();
@@ -55,20 +68,30 @@ public class HotDealCommandService {
 
         LocalDateTime startAt = request.getStartAt() != null ? request.getStartAt() : LocalDateTime.now();
         LocalDateTime endAt = request.getEndAt() != null ? request.getEndAt() : startAt.plusHours(2);
+        Integer maxPerUser = request.getMaxPerUser() != null ? request.getMaxPerUser() : 1;
 
-        HotDeal hotDeal = createAndActivate(
-                request.getItemId(), title, originalPrice,
-                request.getDiscountRate(), request.getMaxQuantity(),
-                startAt, endAt, "판매자 수동 생성 (userId=" + userId + ")");
+        // DB 작업은 트랜잭션 내에서 (self-invocation이므로 TransactionTemplate 사용)
+        HotDeal hotDeal = transactionTemplate.execute(status ->
+                createAndActivate(request.getItemId(), title, originalPrice,
+                        request.getDiscountRate(), request.getMaxQuantity(), maxPerUser,
+                        startAt, endAt, "판매자 수동 생성 (userId=" + userId + ")"));
 
         return HotDealDetailResponse.from(hotDeal);
     }
 
+    @Transactional
+    @DistributedLock(key = "'hotdeal:item:' + #itemId", waitTime = 3)
     public HotDeal createAndActivate(Long itemId, String title, Long originalPrice,
-                                      Integer discountRate, Integer maxQuantity,
+                                      Integer discountRate, Integer maxQuantity, Integer maxPerUser,
                                       LocalDateTime startAt, LocalDateTime endAt, String reason) {
+        boolean exists = hotDealRepository.existsByItemIdAndStatusIn(
+                itemId, List.of(HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE));
+        if (exists) {
+            throw new BusinessException(HotDealErrorCode.HOT_DEAL_ALREADY_EXISTS);
+        }
+
         HotDeal hotDeal = HotDeal.create(itemId, title, originalPrice,
-                discountRate, maxQuantity, startAt, endAt);
+                discountRate, maxQuantity, maxPerUser, startAt, endAt);
         hotDeal.activate();
         hotDealRepository.save(hotDeal);
 
@@ -78,13 +101,21 @@ public class HotDealCommandService {
         statusHistoryRepository.save(
                 HotDealStatusHistory.create(hotDeal.getId(), HotDealStatus.SCHEDULED, HotDealStatus.ACTIVE, reason));
 
-        // Redis에 재고 초기화
-        redisTemplate.opsForValue().set(STOCK_KEY_PREFIX + hotDeal.getId(), maxQuantity);
+        // 트랜잭션 커밋 이후 Redis에 재고 + 유저당 최대 수량을 초기화한다.
+        Long hotDealId = hotDeal.getId();
+        runAfterCommit(() -> {
+            stringRedisTemplate.opsForValue().set(STOCK_KEY_PREFIX + hotDealId, String.valueOf(maxQuantity));
+            stringRedisTemplate.opsForValue().set(MAX_PER_USER_KEY_PREFIX + hotDealId, String.valueOf(maxPerUser));
+        });
 
         // 이벤트 발행
-        eventPublisher.publish(new HotDealStartedEvent(
-                hotDeal.getId(), itemId, title, hotDeal.getDiscountedPrice(),
-                discountRate, maxQuantity, startAt, endAt));
+        eventPublisher.publish(
+                new HotDealStartedEvent(
+                        hotDealId, itemId, title, hotDeal.getDiscountedPrice(),
+                        discountRate, maxQuantity, startAt, endAt
+                ),
+                EventMetadata.of("HotDeal", String.valueOf(hotDealId))
+        );
 
         log.info("Hot deal activated: id={}, itemId={}, discountRate={}%", hotDeal.getId(), itemId, discountRate);
 
@@ -92,24 +123,75 @@ public class HotDealCommandService {
     }
 
     public void endExpiredDeals() {
-        List<HotDeal> expired = hotDealRepository.findExpiredActiveDeals(LocalDateTime.now());
+        List<Long> expiredDealIds = hotDealRepository.findExpiredActiveDeals(LocalDateTime.now()).stream()
+                .map(HotDeal::getId)
+                .toList();
 
-        for (HotDeal hotDeal : expired) {
-            HotDealStatus from = hotDeal.getStatus();
-            hotDeal.end();
-
-            statusHistoryRepository.save(
-                    HotDealStatusHistory.create(hotDeal.getId(), from, HotDealStatus.ENDED, "시간 만료"));
-
-            // Redis 재고 키 삭제
-            redisTemplate.delete(STOCK_KEY_PREFIX + hotDeal.getId());
-
-            eventPublisher.publish(new HotDealEndedEvent(
-                    hotDeal.getId(), hotDeal.getItemId(),
-                    hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity()));
-
-            log.info("Hot deal ended: id={}, sold={}/{}", hotDeal.getId(),
-                    hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity());
+        for (Long hotDealId : expiredDealIds) {
+            try {
+                transactionTemplate.executeWithoutResult(status -> endExpiredDealInTransaction(hotDealId));
+            } catch (Exception e) {
+                log.error("Failed to end hot deal: id={}", hotDealId, e);
+            }
         }
+    }
+
+    private void endExpiredDealInTransaction(Long hotDealId) {
+        HotDeal hotDeal = hotDealRepository.findById(hotDealId).orElse(null);
+        if (hotDeal == null || hotDeal.getStatus() != HotDealStatus.ACTIVE) {
+            return;
+        }
+
+        HotDealStatus from = hotDeal.getStatus();
+        hotDeal.end();
+
+        statusHistoryRepository.save(
+                HotDealStatusHistory.create(hotDeal.getId(), from, HotDealStatus.ENDED, "시간 만료"));
+
+        runAfterCommit(() -> clearRedisKeys(hotDealId));
+
+        eventPublisher.publish(
+                new HotDealEndedEvent(
+                        hotDealId, hotDeal.getItemId(),
+                        hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity()
+                ),
+                EventMetadata.of("HotDeal", String.valueOf(hotDealId))
+        );
+
+        log.info("Hot deal ended: id={}, sold={}/{}", hotDeal.getId(),
+                hotDeal.getSoldQuantity(), hotDeal.getMaxQuantity());
+    }
+
+    private void clearRedisKeys(Long hotDealId) {
+        stringRedisTemplate.delete(STOCK_KEY_PREFIX + hotDealId);
+        stringRedisTemplate.delete(MAX_PER_USER_KEY_PREFIX + hotDealId);
+        stringRedisTemplate.delete(QUEUE_KEY_PREFIX + hotDealId);
+        deleteKeysByPattern(ADMITTED_KEY_PREFIX + hotDealId + ":*");
+        deleteKeysByPattern(TOKEN_KEY_PREFIX + hotDealId + ":*");
+        deleteKeysByPattern(PURCHASED_KEY_PREFIX + hotDealId + ":*");
+        deleteKeysByPattern(RESERVATION_KEY_PREFIX + hotDealId + ":*");
+    }
+
+    private void deleteKeysByPattern(String pattern) {
+        Set<String> keys = stringRedisTemplate.keys(pattern);
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        stringRedisTemplate.delete(keys);
+    }
+
+    private void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+            return;
+        }
+
+        action.run();
     }
 }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealPurchaseService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/HotDealPurchaseService.java
@@ -4,13 +4,15 @@ import com.example.core.exception.BusinessException;
 import com.example.hotdeal.dto.HotDealPurchaseRequest;
 import com.example.hotdeal.dto.HotDealPurchaseResponse;
 import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.entity.HotDealStatus;
 import com.example.hotdeal.event.HotDealPurchasedEvent;
 import com.example.hotdeal.exception.HotDealErrorCode;
 import com.example.hotdeal.repository.HotDealRepository;
+import com.example.event.EventMetadata;
 import com.example.event.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -27,20 +28,32 @@ public class HotDealPurchaseService {
 
     private final HotDealRepository hotDealRepository;
     private final EventPublisher eventPublisher;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
     private final QueueService queueService;
 
     private static final String STOCK_KEY_PREFIX = "hotdeal:stock:";
     private static final String RESERVATION_KEY_PREFIX = "hotdeal:reservation:";
+    private static final String PURCHASED_KEY_PREFIX = "hotdeal:purchased:";
+    private static final String MAX_PER_USER_KEY_PREFIX = "hotdeal:maxperuser:";
     private static final long RESERVATION_TTL_MINUTES = 5;
 
     private static final String LUA_SCRIPT = """
             local stockKey = KEYS[1]
             local reservationKey = KEYS[2]
+            local purchasedKey = KEYS[3]
             local quantity = tonumber(ARGV[1])
             local ttl = tonumber(ARGV[2])
             local reservationId = ARGV[3]
+            local maxPerUser = tonumber(ARGV[4])
 
+            -- 유저당 구매 수량 체크
+            local purchased = tonumber(redis.call('GET', purchasedKey) or '0')
+            if purchased == nil then purchased = 0 end
+            if purchased + quantity > maxPerUser then
+                return -2
+            end
+
+            -- 재고 체크
             local current = tonumber(redis.call('GET', stockKey))
             if current == nil then
                 return -1
@@ -48,9 +61,37 @@ public class HotDealPurchaseService {
             if current < quantity then
                 return 0
             end
+
+            -- 재고 차감 + 예약 생성 + 구매 수량 기록
             redis.call('DECRBY', stockKey, quantity)
             redis.call('SET', reservationKey, reservationId, 'EX', ttl)
+            redis.call('INCRBY', purchasedKey, quantity)
             return 1
+            """;
+
+    private static final String COMPENSATE_LUA_SCRIPT = """
+            local stockKey = KEYS[1]
+            local reservationKey = KEYS[2]
+            local purchasedKey = KEYS[3]
+            local reservationId = ARGV[1]
+            local quantity = tonumber(ARGV[2])
+
+            local currentReservation = redis.call('GET', reservationKey)
+            if currentReservation == reservationId then
+                redis.call('INCRBY', stockKey, quantity)
+
+                local purchased = tonumber(redis.call('GET', purchasedKey) or '0')
+                if purchased <= quantity then
+                    redis.call('DEL', purchasedKey)
+                else
+                    redis.call('DECRBY', purchasedKey, quantity)
+                end
+
+                redis.call('DEL', reservationKey)
+                return 1
+            end
+
+            return 0
             """;
 
     @Transactional
@@ -60,40 +101,83 @@ public class HotDealPurchaseService {
             throw new BusinessException(HotDealErrorCode.QUEUE_NOT_ADMITTED);
         }
 
+        HotDeal hotDeal = hotDealRepository.findById(hotDealId)
+                .orElseThrow(() -> new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND));
+        if (hotDeal.getStatus() != HotDealStatus.ACTIVE) {
+            throw new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_ACTIVE);
+        }
+
+        // maxPerUser 조회 (Redis 우선, 없으면 DB)
+        String maxPerUserValue = stringRedisTemplate.opsForValue().get(MAX_PER_USER_KEY_PREFIX + hotDealId);
+        int maxPerUser = maxPerUserValue != null
+                ? Integer.parseInt(maxPerUserValue)
+                : hotDeal.getMaxPerUser();
+
         String stockKey = STOCK_KEY_PREFIX + hotDealId;
         String reservationKey = RESERVATION_KEY_PREFIX + hotDealId + ":" + userId;
+        String purchasedKey = PURCHASED_KEY_PREFIX + hotDealId + ":" + userId;
         String reservationId = UUID.randomUUID().toString();
 
         DefaultRedisScript<Long> script = new DefaultRedisScript<>(LUA_SCRIPT, Long.class);
-        Long result = redisTemplate.execute(script,
-                List.of(stockKey, reservationKey),
-                request.getQuantity(),
-                RESERVATION_TTL_MINUTES * 60,
-                reservationId);
+        Long result = stringRedisTemplate.execute(script,
+                List.of(stockKey, reservationKey, purchasedKey),
+                String.valueOf(request.getQuantity()),
+                String.valueOf(RESERVATION_TTL_MINUTES * 60),
+                reservationId,
+                String.valueOf(maxPerUser));
 
         if (result == null || result == -1) {
             throw new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND);
+        }
+
+        if (result == -2) {
+            throw new BusinessException(HotDealErrorCode.PURCHASE_QUANTITY_EXCEEDED);
         }
 
         if (result == 0) {
             throw new BusinessException(HotDealErrorCode.HOT_DEAL_SOLD_OUT);
         }
 
-        // DB 판매 수량 원자적 증가 (동시성 안전)
-        hotDealRepository.incrementSoldQuantity(hotDealId, request.getQuantity());
+        try {
+            // DB 판매 수량 원자적 증가 (동시성 안전)
+            int updated = hotDealRepository.incrementSoldQuantity(hotDealId, request.getQuantity());
+            if (updated == 0) {
+                throw new BusinessException(HotDealErrorCode.HOT_DEAL_SOLD_OUT);
+            }
 
-        HotDeal hotDeal = hotDealRepository.findById(hotDealId)
-                .orElseThrow(() -> new BusinessException(HotDealErrorCode.HOT_DEAL_NOT_FOUND));
+            Long totalAmount = hotDeal.getDiscountedPrice() * request.getQuantity();
 
-        Long totalAmount = hotDeal.getDiscountedPrice() * request.getQuantity();
+            // 이벤트 발행
+            eventPublisher.publish(
+                    new HotDealPurchasedEvent(
+                            hotDealId, userId, hotDeal.getItemId(), request.getQuantity(), totalAmount
+                    ),
+                    EventMetadata.of("HotDeal", String.valueOf(hotDealId))
+            );
 
-        // 이벤트 발행
-        eventPublisher.publish(new HotDealPurchasedEvent(
-                hotDealId, userId, hotDeal.getItemId(), request.getQuantity(), totalAmount));
+            log.info("Hot deal purchased: hotDealId={}, userId={}, quantity={}", hotDealId, userId, request.getQuantity());
 
-        log.info("Hot deal purchased: hotDealId={}, userId={}, quantity={}", hotDealId, userId, request.getQuantity());
+            return HotDealPurchaseResponse.success(reservationId,
+                    LocalDateTime.now().plusMinutes(RESERVATION_TTL_MINUTES));
+        } catch (RuntimeException e) {
+            compensateReservation(stockKey, reservationKey, purchasedKey, reservationId, request.getQuantity());
+            throw e;
+        }
+    }
 
-        return HotDealPurchaseResponse.success(reservationId,
-                LocalDateTime.now().plusMinutes(RESERVATION_TTL_MINUTES));
+    private void compensateReservation(String stockKey, String reservationKey, String purchasedKey,
+                                       String reservationId, int quantity) {
+        try {
+            DefaultRedisScript<Long> script = new DefaultRedisScript<>(COMPENSATE_LUA_SCRIPT, Long.class);
+            stringRedisTemplate.execute(
+                    script,
+                    List.of(stockKey, reservationKey, purchasedKey),
+                    reservationId,
+                    String.valueOf(quantity)
+            );
+        } catch (Exception e) {
+            // 보상 실패는 운영자가 추적할 수 있도록 별도 로그를 남긴다.
+            log.error("Failed to compensate hot-deal reservation: reservationKey={}", reservationKey, e);
+        }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/query/InternalItemQueryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/query/InternalItemQueryController.java
@@ -29,4 +29,11 @@ public class InternalItemQueryController {
     public ApiResponse<List<ItemSummaryResponse>> findByIds(@RequestBody List<Long> itemIds) {
         return ApiResponse.success(internalItemQueryService.findByIds(itemIds));
     }
+
+    @Operation(summary = "마감 임박 상품 조회 (내부)")
+    @GetMapping("/ending-soon")
+    public ApiResponse<List<ItemSummaryResponse>> findItemsEndingSoon(
+            @RequestParam(defaultValue = "3") int withinDays) {
+        return ApiResponse.success(internalItemQueryService.findItemsEndingSoon(withinDays));
+    }
 }

--- a/servers/services/product/src/main/java/com/example/product/entity/item/Item.java
+++ b/servers/services/product/src/main/java/com/example/product/entity/item/Item.java
@@ -70,8 +70,8 @@ public class Item extends BaseEntity {
         if (title != null) this.title = title;
         if (description != null) this.description = description;
         if (price != null) this.price = price;
-        this.categoryId = categoryId;
-        this.thumbnailUrl = thumbnailUrl;
+        if (categoryId != null) this.categoryId = categoryId;
+        if (thumbnailUrl != null) this.thumbnailUrl = thumbnailUrl;
     }
 
     public void changeStatus(ItemStatus newStatus) {
@@ -91,5 +91,12 @@ public class Item extends BaseEntity {
 
     public boolean isEditable() {
         return this.status == ItemStatus.DRAFT;
+    }
+
+    public boolean isDeletable() {
+        return switch (this.status) {
+            case FUNDING, FUNDED, ON_SALE, HOT_DEAL -> false;
+            default -> true;
+        };
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/repository/ItemRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/repository/ItemRepository.java
@@ -1,6 +1,7 @@
 package com.example.product.repository;
 
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.item.ItemType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,10 +17,21 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("SELECT i FROM Item i WHERE i.itemType = :type AND i.id < :cursor ORDER BY i.id DESC")
     List<Item> findByItemTypeAndIdLessThan(@Param("type") ItemType type, @Param("cursor") Long cursor, Pageable pageable);
 
+    @Query("SELECT i FROM Item i WHERE i.itemType = :type AND i.status IN :statuses ORDER BY i.id DESC")
+    List<Item> findByItemTypeAndStatusIn(@Param("type") ItemType type,
+                                          @Param("statuses") List<ItemStatus> statuses, Pageable pageable);
+
+    @Query("SELECT i FROM Item i WHERE i.itemType = :type AND i.status IN :statuses AND i.id < :cursor ORDER BY i.id DESC")
+    List<Item> findByItemTypeAndStatusInAndIdLessThan(@Param("type") ItemType type,
+                                                       @Param("statuses") List<ItemStatus> statuses,
+                                                       @Param("cursor") Long cursor, Pageable pageable);
+
     @Query("SELECT i FROM Item i WHERE i.id < :cursor ORDER BY i.id DESC")
     List<Item> findByIdLessThan(@Param("cursor") Long cursor, Pageable pageable);
 
     List<Item> findBySellerIdOrderByIdDesc(Long sellerId, Pageable pageable);
 
     List<Item> findByCategoryIdOrderByIdDesc(Long categoryId, Pageable pageable);
+
+    List<Item> findByStatusIn(List<ItemStatus> statuses, Pageable pageable);
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -109,6 +109,9 @@ public class GoodsCommandService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        if (!item.isDeletable()) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
+        }
         item.softDelete();
 
         itemOptionRepository.softDeleteAllByItemId(itemId);

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -74,6 +74,9 @@ public class PerformanceCommandService {
     public PerformanceDetailResponse update(Long itemId, PerformanceUpdateRequest request, Long sellerId) {
         Item item = getItem(itemId);
         item.validateOwnership(sellerId);
+        if (!item.isEditable()) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
+        }
 
         item.update(request.getTitle(), request.getDescription(), request.getPrice(),
                 request.getCategoryId(), request.getThumbnailUrl());
@@ -112,6 +115,9 @@ public class PerformanceCommandService {
     public void delete(Long itemId, Long sellerId) {
         Item item = getItem(itemId);
         item.validateOwnership(sellerId);
+        if (!item.isDeletable()) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
+        }
         item.softDelete();
 
         Performance performance = performanceRepository.findByItemId(itemId).orElse(null);

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -95,6 +95,9 @@ public class ProductCommandService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        if (!item.isDeletable()) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
+        }
         item.softDelete();
 
         itemOptionRepository.softDeleteAllByItemId(itemId);

--- a/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
@@ -6,6 +6,7 @@ import com.example.core.pagination.CursorUtils;
 import com.example.product.dto.goods.response.GoodsDetailResponse;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.goods.ItemGoodsLink;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.goods.ItemOption;
 import com.example.product.entity.item.ItemType;
 import com.example.product.entity.goods.ShippingInfo;
@@ -43,13 +44,16 @@ public class GoodsQueryService {
         return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);
     }
 
+    private static final List<ItemStatus> VISIBLE_STATUSES = List.of(
+            ItemStatus.FUNDING, ItemStatus.FUNDED, ItemStatus.ON_SALE, ItemStatus.HOT_DEAL);
+
     public CursorResponse<GoodsDetailResponse> findGoodsList(String cursor, int size) {
         Long cursorId = CursorUtils.decodeLong(cursor);
         PageRequest pageable = PageRequest.of(0, size + 1);
 
         List<Item> items = cursorId == null
-                ? itemRepository.findByItemTypeOrderByIdDesc(ItemType.GOODS, pageable)
-                : itemRepository.findByItemTypeAndIdLessThan(ItemType.GOODS, cursorId, pageable);
+                ? itemRepository.findByItemTypeAndStatusIn(ItemType.GOODS, VISIBLE_STATUSES, pageable)
+                : itemRepository.findByItemTypeAndStatusInAndIdLessThan(ItemType.GOODS, VISIBLE_STATUSES, cursorId, pageable);
 
         boolean hasNext = items.size() > size;
         List<Item> pageItems = hasNext ? items.subList(0, size) : items;

--- a/servers/services/product/src/main/java/com/example/product/service/query/InternalItemQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/InternalItemQueryService.java
@@ -2,8 +2,10 @@ package com.example.product.service.query;
 
 import com.example.product.dto.item.response.ItemSummaryResponse;
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,14 @@ public class InternalItemQueryService {
 
     public List<ItemSummaryResponse> findByIds(List<Long> itemIds) {
         List<Item> items = itemRepository.findAllById(itemIds);
+        return items.stream().map(ItemSummaryResponse::from).toList();
+    }
+
+    public List<ItemSummaryResponse> findItemsEndingSoon(int withinDays) {
+        // For MVP, return ON_SALE items as hot-deal candidates
+        // Future: filter by actual end date when the field is added
+        List<Item> items = itemRepository.findByStatusIn(
+                List.of(ItemStatus.ON_SALE), Pageable.ofSize(50));
         return items.stream().map(ItemSummaryResponse::from).toList();
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
@@ -6,6 +6,7 @@ import com.example.core.pagination.CursorUtils;
 import com.example.product.dto.performance.response.PerformanceDetailResponse;
 import com.example.product.dto.performance.response.PerformanceListResponse;
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.item.ItemType;
 import com.example.product.entity.performance.CastMember;
 import com.example.product.entity.performance.Performance;
@@ -31,6 +32,9 @@ public class PerformanceQueryService {
     private final SeatGradeRepository seatGradeRepository;
     private final CastMemberRepository castMemberRepository;
 
+    private static final List<ItemStatus> VISIBLE_STATUSES = List.of(
+            ItemStatus.FUNDING, ItemStatus.FUNDED, ItemStatus.ON_SALE, ItemStatus.HOT_DEAL);
+
     public PerformanceDetailResponse findById(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
@@ -46,8 +50,8 @@ public class PerformanceQueryService {
         PageRequest pageable = PageRequest.of(0, size + 1);
 
         List<Item> items = cursorId == null
-                ? itemRepository.findByItemTypeOrderByIdDesc(ItemType.PERFORMANCE, pageable)
-                : itemRepository.findByItemTypeAndIdLessThan(ItemType.PERFORMANCE, cursorId, pageable);
+                ? itemRepository.findByItemTypeAndStatusIn(ItemType.PERFORMANCE, VISIBLE_STATUSES, pageable)
+                : itemRepository.findByItemTypeAndStatusInAndIdLessThan(ItemType.PERFORMANCE, VISIBLE_STATUSES, cursorId, pageable);
 
         boolean hasNext = items.size() > size;
         List<Item> pageItems = hasNext ? items.subList(0, size) : items;

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockItem.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockItem.java
@@ -1,7 +1,9 @@
 package com.example.stock.entity;
 
+import com.example.core.exception.BusinessException;
 import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
+import com.example.stock.exception.StockErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -83,10 +85,11 @@ public class StockItem extends BaseEntity {
     }
 
     public void updateTotal(int totalQuantity) {
-        int diff = totalQuantity - this.totalQuantity;
+        if (totalQuantity < this.reservedQuantity) {
+            throw new BusinessException(StockErrorCode.STOCK_OVERFLOW);
+        }
         this.totalQuantity = totalQuantity;
-        this.availableQuantity += diff;
-        if (this.availableQuantity < 0) this.availableQuantity = 0;
+        this.availableQuantity = totalQuantity - this.reservedQuantity;
     }
 
     public boolean isDepleted() {

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockReservationRepository.java
@@ -14,6 +14,19 @@ public interface StockReservationRepository extends JpaRepository<StockReservati
     @Query("SELECT r FROM StockReservation r WHERE r.status = :status AND r.expiredAt < :now")
     List<StockReservation> findExpiredReservations(@Param("status") ReservationStatus status, @Param("now") LocalDateTime now);
 
+    @Query("""
+            SELECT r.id
+            FROM StockReservation r
+            WHERE r.status = :status
+              AND r.expiredAt < :now
+              AND (:cursor IS NULL OR r.id < :cursor)
+            ORDER BY r.id DESC
+            """)
+    List<Long> findExpiredReservationIdsWithCursor(@Param("status") ReservationStatus status,
+                                                    @Param("now") LocalDateTime now,
+                                                    @Param("cursor") Long cursor,
+                                                    org.springframework.data.domain.Pageable pageable);
+
     List<StockReservation> findByStockItemIdAndStatus(Long stockItemId, ReservationStatus status);
 
     List<StockReservation> findByOrderId(Long orderId);


### PR DESCRIPTION
## Summary

MVP 데모/통합 테스트 전 전체 서비스 코드 리뷰를 통해 발견한 크리티컬 이슈들을 수정합니다.

Closes #567
Closes #568
Closes #569
Closes #570
Closes #571

### Hot-Deal 서비스
- `RedisTemplate` → `StringRedisTemplate` 전환 (Lua `tonumber()` 호환성)
- `runAfterCommit()` 패턴으로 Redis-DB 정합성 보장
- 보상 Lua Script 추가 (DB 실패 시 Redis 복원)
- `incrementSoldQuantity`에 ACTIVE 상태 + maxQuantity 오버플로우 가드
- `endExpiredDeals()` 건별 트랜잭션 분리 + 전체 Redis 키 정리
- 모든 이벤트에 `EventMetadata` 추가
- `QueueAdmissionScheduler` ShedLock 추가 (#568)
- `StockEventConsumer` 예외 재전파
- 유저당 구매 수량 제한 Lua Script 추가 (#570)

### Funding 서비스
- `@Transactional` → `TransactionTemplate` 분리 (#569)
- `addParticipation()` → `@Modifying @Query` 원자적 증감 (#567)
- 모든 이벤트에 `EventMetadata` 추가
- `FundingDeadlineScheduler` 건별 트랜잭션 분리

### Product 서비스
- `ProductQueryService`/`GoodsQueryService` N+1 → 배치 조회
- `VISIBLE_STATUSES` 필터 적용 (#571)
- `/ending-soon` 내부 API 추가
- `Item.update()` null 필드 무시, `delete()` 상태 검증

### Sales 서비스
- `@Transactional` → `TransactionTemplate` 분리 (#569)
- `EventMetadata` 추가

### Stock 서비스
- `StockItem.updateTotal()` reservedQuantity 고려
- 예약 스케줄러 건별 트랜잭션 분리

### 인프라
- Docker 초기화 스크립트에 누락 DB 추가

## 수정 범위

| 카테고리 | 수정 내용 |
|---------|----------|
| P0 (데이터 정합성) | Redis 직렬화, Redis-DB 정합성, EventMetadata |
| P1 (동시성/안전) | @Modifying @Query 원자적 업데이트, 트랜잭션-HTTP 분리, 스케줄러 장애 격리 |
| P1 (성능) | N+1 쿼리 해결, 상태 필터링 |

## Test plan

- [ ] 각 서비스 빌드 성공 확인
- [ ] 핫딜 구매 플로우 테스트 (Redis Lua 정상 동작)
- [ ] 펀딩 참여/환불 플로우 테스트
- [ ] 상품 목록 조회 성능 확인
- [ ] 핫딜 종료 스케줄러 Redis 키 정리 확인