### PR TITLE
[BUGFIX] Funding Amount-based 업데이트 가드 강화

### DIFF
--- a/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/FundingCampaignRepository.java
@@ -21,8 +21,18 @@ public interface FundingCampaignRepository extends JpaRepository<FundingCampaign
 
     @Modifying
     @Query("UPDATE FundingCampaign c SET c.currentAmount = c.currentAmount + :amount, " +
-            "c.currentQuantity = c.currentQuantity + :quantity WHERE c.id = :id")
-    int incrementParticipation(@Param("id") Long id, @Param("amount") Long amount, @Param("quantity") int quantity);
+            "c.currentQuantity = c.currentQuantity + :quantity " +
+            "WHERE c.id = :id " +
+            "AND c.status = :status " +
+            "AND c.startAt <= :now " +
+            "AND c.endAt > :now " +
+            "AND (c.goalAmount IS NULL OR c.currentAmount + :amount <= c.goalAmount) " +
+            "AND (c.goalQuantity IS NULL OR c.currentQuantity + :quantity <= c.goalQuantity)")
+    int incrementParticipationIfAvailable(@Param("id") Long id,
+                                          @Param("amount") Long amount,
+                                          @Param("quantity") int quantity,
+                                          @Param("status") FundingStatus status,
+                                          @Param("now") LocalDateTime now);
 
     @Modifying
     @Query("UPDATE FundingCampaign c SET c.currentAmount = c.currentAmount - :amount, " +

--- a/servers/services/funding/src/main/java/com/example/funding/service/command/ParticipationCommandService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/command/ParticipationCommandService.java
@@ -9,6 +9,7 @@ import com.example.funding.dto.participation.request.ParticipateRequest;
 import com.example.funding.dto.participation.response.ParticipationResponse;
 import com.example.funding.entity.FundingCampaign;
 import com.example.funding.entity.FundingParticipation;
+import com.example.funding.entity.FundingStatus;
 import com.example.funding.entity.FundingType;
 import com.example.funding.event.FundingParticipatedEvent;
 import com.example.funding.event.FundingRefundedEvent;
@@ -20,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -114,7 +117,13 @@ public class ParticipationCommandService {
         );
 
         participationRepository.save(participation);
-        int updated = campaignRepository.incrementParticipation(campaign.getId(), request.getAmount(), 1);
+        int updated = campaignRepository.incrementParticipationIfAvailable(
+                campaign.getId(),
+                request.getAmount(),
+                1,
+                FundingStatus.ACTIVE,
+                LocalDateTime.now()
+        );
         if (updated == 0) {
             throw new BusinessException(FundingErrorCode.CAMPAIGN_NOT_ACTIVE);
         }


### PR DESCRIPTION
## 개요
Funding Amount-based 참여 누적 시 DB update에 비즈니스 가드를 추가해 동시성 상황에서도 상태/기간/목표 조건을 DB 레벨에서 강제합니다.

### 관련 이슈
- Closes #574

### 작업 / 변경 내용
- `FundingCampaignRepository`에 guarded update 쿼리(`incrementParticipationIfAvailable`) 추가
- 가드 조건 추가:
  - `status = ACTIVE`
  - `startAt <= now < endAt`
  - `currentAmount + amount <= goalAmount`
  - `currentQuantity + quantity <= goalQuantity`
- `ParticipationCommandService`에서 기존 `incrementParticipation` 대신 guarded update 호출로 변경

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:funding:compileJava`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 영향 행(`updated`)이 0인 경우 기존과 동일하게 `CAMPAIGN_NOT_ACTIVE` 예외로 처리됩니다.
