### PR TITLE
[BUGFIX] 외부 Stock 취소 실패 재시도 큐/백오프 스케줄러 추가

### DIFF
--- a/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetry.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetry.java
@@ -1,0 +1,98 @@
+package com.example.funding.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "funding_stock_cancel_retries",
+        indexes = {
+                @Index(name = "idx_funding_stock_cancel_retry_status_next", columnList = "status, nextRetryAt"),
+                @Index(name = "idx_funding_stock_cancel_retry_participation", columnList = "participationId"),
+                @Index(name = "idx_funding_stock_cancel_retry_reservation", columnList = "reservationId")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class StockCancelRetry extends BaseEntity {
+
+    private static final int MAX_ERROR_LENGTH = 500;
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(nullable = false)
+    private Long participationId;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StockCancelRetryStatus status;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false)
+    private LocalDateTime nextRetryAt;
+
+    @Column(length = MAX_ERROR_LENGTH)
+    private String lastError;
+
+    public static StockCancelRetry create(Long participationId, Long reservationId, String errorMessage) {
+        StockCancelRetry retry = new StockCancelRetry();
+        retry.participationId = participationId;
+        retry.reservationId = reservationId;
+        retry.status = StockCancelRetryStatus.PENDING;
+        retry.retryCount = 0;
+        retry.nextRetryAt = LocalDateTime.now();
+        retry.lastError = normalizeError(errorMessage);
+        return retry;
+    }
+
+    public void markProcessing() {
+        this.status = StockCancelRetryStatus.PROCESSING;
+    }
+
+    public void markCompleted() {
+        this.status = StockCancelRetryStatus.COMPLETED;
+        this.lastError = null;
+    }
+
+    public void scheduleNextRetry(String errorMessage, long delaySeconds) {
+        this.retryCount += 1;
+        this.status = StockCancelRetryStatus.PENDING;
+        this.nextRetryAt = LocalDateTime.now().plusSeconds(delaySeconds);
+        this.lastError = normalizeError(errorMessage);
+    }
+
+    public void markFailed(String errorMessage) {
+        this.retryCount += 1;
+        this.status = StockCancelRetryStatus.FAILED;
+        this.lastError = normalizeError(errorMessage);
+    }
+
+    private static String normalizeError(String errorMessage) {
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "Stock cancel retry failed";
+        }
+        if (errorMessage.length() <= MAX_ERROR_LENGTH) {
+            return errorMessage;
+        }
+        return errorMessage.substring(0, MAX_ERROR_LENGTH);
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetryStatus.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetryStatus.java
@@ -1,0 +1,8 @@
+package com.example.funding.entity;
+
+public enum StockCancelRetryStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/servers/services/funding/src/main/java/com/example/funding/repository/StockCancelRetryRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/StockCancelRetryRepository.java
@@ -1,0 +1,25 @@
+package com.example.funding.repository;
+
+import com.example.funding.entity.StockCancelRetry;
+import com.example.funding.entity.StockCancelRetryStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StockCancelRetryRepository extends JpaRepository<StockCancelRetry, Long> {
+
+    List<StockCancelRetry> findTop100ByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            StockCancelRetryStatus status, LocalDateTime now);
+
+    @Modifying
+    @Query("UPDATE StockCancelRetry r SET r.status = :processing " +
+            "WHERE r.id = :id AND r.status = :pending AND r.nextRetryAt <= :now")
+    int claimForProcessing(@Param("id") Long id,
+                           @Param("pending") StockCancelRetryStatus pending,
+                           @Param("processing") StockCancelRetryStatus processing,
+                           @Param("now") LocalDateTime now);
+}

--- a/servers/services/funding/src/main/java/com/example/funding/scheduler/StockCancelRetryScheduler.java
+++ b/servers/services/funding/src/main/java/com/example/funding/scheduler/StockCancelRetryScheduler.java
@@ -1,0 +1,24 @@
+package com.example.funding.scheduler;
+
+import com.example.funding.service.retry.StockCancelRetryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockCancelRetryScheduler {
+
+    private final StockCancelRetryService stockCancelRetryService;
+
+    @Scheduled(fixedDelay = 30000)
+    public void processRetries() {
+        try {
+            stockCancelRetryService.processDueRetries();
+        } catch (Exception e) {
+            log.error("Funding stock cancel retry scheduler failed", e);
+        }
+    }
+}

--- a/servers/services/funding/src/main/java/com/example/funding/service/retry/StockCancelRetryService.java
+++ b/servers/services/funding/src/main/java/com/example/funding/service/retry/StockCancelRetryService.java
@@ -1,0 +1,109 @@
+package com.example.funding.service.retry;
+
+import com.example.funding.client.StockClient;
+import com.example.funding.entity.StockCancelRetry;
+import com.example.funding.entity.StockCancelRetryStatus;
+import com.example.funding.repository.StockCancelRetryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockCancelRetryService {
+
+    private static final int MAX_RETRY_COUNT = 5;
+    private static final long BASE_DELAY_SECONDS = 30;
+    private static final long MAX_DELAY_SECONDS = 600;
+
+    private final StockCancelRetryRepository retryRepository;
+    private final StockClient stockClient;
+    private final TransactionTemplate transactionTemplate;
+
+    public void enqueue(Long participationId, Long reservationId, String errorMessage) {
+        transactionTemplate.executeWithoutResult(status ->
+                retryRepository.save(StockCancelRetry.create(participationId, reservationId, errorMessage)));
+    }
+
+    public void processDueRetries() {
+        List<Long> retryIds = transactionTemplate.execute(status ->
+                retryRepository.findTop100ByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+                                StockCancelRetryStatus.PENDING, LocalDateTime.now())
+                        .stream()
+                        .map(StockCancelRetry::getId)
+                        .toList()
+        );
+
+        if (retryIds == null || retryIds.isEmpty()) {
+            return;
+        }
+
+        for (Long retryId : retryIds) {
+            processOneRetry(retryId);
+        }
+    }
+
+    private void processOneRetry(Long retryId) {
+        boolean claimed = Boolean.TRUE.equals(transactionTemplate.execute(status ->
+                retryRepository.claimForProcessing(
+                        retryId,
+                        StockCancelRetryStatus.PENDING,
+                        StockCancelRetryStatus.PROCESSING,
+                        LocalDateTime.now()
+                ) > 0
+        ));
+
+        if (!claimed) {
+            return;
+        }
+
+        StockCancelRetry retryTask = transactionTemplate.execute(status ->
+                retryRepository.findById(retryId).orElse(null));
+        if (retryTask == null) {
+            return;
+        }
+
+        try {
+            stockClient.cancelReservation(retryTask.getReservationId());
+
+            transactionTemplate.executeWithoutResult(status ->
+                    retryRepository.findById(retryId).ifPresent(task -> {
+                        if (task.getStatus() == StockCancelRetryStatus.PROCESSING) {
+                            task.markCompleted();
+                        }
+                    })
+            );
+
+            log.info("Stock cancel retry succeeded: retryId={}, participationId={}, reservationId={}, retryCount={}",
+                    retryId, retryTask.getParticipationId(), retryTask.getReservationId(), retryTask.getRetryCount());
+        } catch (Exception e) {
+            transactionTemplate.executeWithoutResult(status ->
+                    retryRepository.findById(retryId).ifPresent(task -> {
+                        if (task.getStatus() != StockCancelRetryStatus.PROCESSING) {
+                            return;
+                        }
+
+                        int nextRetryCount = task.getRetryCount() + 1;
+                        if (nextRetryCount >= MAX_RETRY_COUNT) {
+                            task.markFailed(e.getMessage());
+                        } else {
+                            task.scheduleNextRetry(e.getMessage(), computeDelaySeconds(nextRetryCount));
+                        }
+                    })
+            );
+
+            log.warn("Stock cancel retry failed: retryId={}, reservationId={}, error={}",
+                    retryId, retryTask.getReservationId(), e.getMessage());
+        }
+    }
+
+    private long computeDelaySeconds(int retryCount) {
+        long delaySeconds = BASE_DELAY_SECONDS * (1L << Math.max(0, retryCount - 1));
+        return Math.min(delaySeconds, MAX_DELAY_SECONDS);
+    }
+}

--- a/servers/services/sales/src/main/java/com/example/sales/client/StockClient.java
+++ b/servers/services/sales/src/main/java/com/example/sales/client/StockClient.java
@@ -64,9 +64,25 @@ public class StockClient {
                     .retrieve()
                     .bodyToMono(JsonNode.class)
                     .block();
+        } catch (WebClientResponseException e) {
+            if (isAlreadyReleasedReservation(e)) {
+                log.info("Reservation already released in stock service: reservationId={}, status={}",
+                        reservationId, e.getStatusCode().value());
+                return;
+            }
+            log.error("Stock cancel failed: reservationId={}, status={}", reservationId, e.getStatusCode().value(), e);
+            throw new BusinessException(SalesErrorCode.STOCK_SERVICE_ERROR);
         } catch (Exception e) {
             log.error("Stock cancel failed: reservationId={}", reservationId, e);
             throw new BusinessException(SalesErrorCode.STOCK_SERVICE_ERROR);
         }
+    }
+
+    private boolean isAlreadyReleasedReservation(WebClientResponseException e) {
+        if (!e.getStatusCode().is4xxClientError()) {
+            return false;
+        }
+        String body = e.getResponseBodyAsString();
+        return body.contains("STOCK-103") || body.contains("STOCK-104") || body.contains("STOCK-105");
     }
 }

--- a/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetry.java
+++ b/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetry.java
@@ -1,0 +1,98 @@
+package com.example.sales.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "sales_stock_cancel_retries",
+        indexes = {
+                @Index(name = "idx_sales_stock_cancel_retry_status_next", columnList = "status, nextRetryAt"),
+                @Index(name = "idx_sales_stock_cancel_retry_purchase", columnList = "purchaseId"),
+                @Index(name = "idx_sales_stock_cancel_retry_reservation", columnList = "reservationId")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class StockCancelRetry extends BaseEntity {
+
+    private static final int MAX_ERROR_LENGTH = 500;
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(nullable = false)
+    private Long purchaseId;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private StockCancelRetryStatus status;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false)
+    private LocalDateTime nextRetryAt;
+
+    @Column(length = MAX_ERROR_LENGTH)
+    private String lastError;
+
+    public static StockCancelRetry create(Long purchaseId, Long reservationId, String errorMessage) {
+        StockCancelRetry retry = new StockCancelRetry();
+        retry.purchaseId = purchaseId;
+        retry.reservationId = reservationId;
+        retry.status = StockCancelRetryStatus.PENDING;
+        retry.retryCount = 0;
+        retry.nextRetryAt = LocalDateTime.now();
+        retry.lastError = normalizeError(errorMessage);
+        return retry;
+    }
+
+    public void markProcessing() {
+        this.status = StockCancelRetryStatus.PROCESSING;
+    }
+
+    public void markCompleted() {
+        this.status = StockCancelRetryStatus.COMPLETED;
+        this.lastError = null;
+    }
+
+    public void scheduleNextRetry(String errorMessage, long delaySeconds) {
+        this.retryCount += 1;
+        this.status = StockCancelRetryStatus.PENDING;
+        this.nextRetryAt = LocalDateTime.now().plusSeconds(delaySeconds);
+        this.lastError = normalizeError(errorMessage);
+    }
+
+    public void markFailed(String errorMessage) {
+        this.retryCount += 1;
+        this.status = StockCancelRetryStatus.FAILED;
+        this.lastError = normalizeError(errorMessage);
+    }
+
+    private static String normalizeError(String errorMessage) {
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "Stock cancel retry failed";
+        }
+        if (errorMessage.length() <= MAX_ERROR_LENGTH) {
+            return errorMessage;
+        }
+        return errorMessage.substring(0, MAX_ERROR_LENGTH);
+    }
+}

--- a/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetryStatus.java
+++ b/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetryStatus.java
@@ -1,0 +1,8 @@
+package com.example.sales.entity;
+
+public enum StockCancelRetryStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/servers/services/sales/src/main/java/com/example/sales/repository/StockCancelRetryRepository.java
+++ b/servers/services/sales/src/main/java/com/example/sales/repository/StockCancelRetryRepository.java
@@ -1,0 +1,25 @@
+package com.example.sales.repository;
+
+import com.example.sales.entity.StockCancelRetry;
+import com.example.sales.entity.StockCancelRetryStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StockCancelRetryRepository extends JpaRepository<StockCancelRetry, Long> {
+
+    List<StockCancelRetry> findTop100ByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+            StockCancelRetryStatus status, LocalDateTime now);
+
+    @Modifying
+    @Query("UPDATE StockCancelRetry r SET r.status = :processing " +
+            "WHERE r.id = :id AND r.status = :pending AND r.nextRetryAt <= :now")
+    int claimForProcessing(@Param("id") Long id,
+                           @Param("pending") StockCancelRetryStatus pending,
+                           @Param("processing") StockCancelRetryStatus processing,
+                           @Param("now") LocalDateTime now);
+}

--- a/servers/services/sales/src/main/java/com/example/sales/scheduler/StockCancelRetryScheduler.java
+++ b/servers/services/sales/src/main/java/com/example/sales/scheduler/StockCancelRetryScheduler.java
@@ -1,0 +1,24 @@
+package com.example.sales.scheduler;
+
+import com.example.sales.service.retry.StockCancelRetryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockCancelRetryScheduler {
+
+    private final StockCancelRetryService stockCancelRetryService;
+
+    @Scheduled(fixedDelay = 30000)
+    public void processRetries() {
+        try {
+            stockCancelRetryService.processDueRetries();
+        } catch (Exception e) {
+            log.error("Sales stock cancel retry scheduler failed", e);
+        }
+    }
+}

--- a/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
+++ b/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
@@ -1,0 +1,109 @@
+package com.example.sales.service.retry;
+
+import com.example.sales.client.StockClient;
+import com.example.sales.entity.StockCancelRetry;
+import com.example.sales.entity.StockCancelRetryStatus;
+import com.example.sales.repository.StockCancelRetryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockCancelRetryService {
+
+    private static final int MAX_RETRY_COUNT = 5;
+    private static final long BASE_DELAY_SECONDS = 30;
+    private static final long MAX_DELAY_SECONDS = 600;
+
+    private final StockCancelRetryRepository retryRepository;
+    private final StockClient stockClient;
+    private final TransactionTemplate transactionTemplate;
+
+    public void enqueue(Long purchaseId, Long reservationId, String errorMessage) {
+        transactionTemplate.executeWithoutResult(status ->
+                retryRepository.save(StockCancelRetry.create(purchaseId, reservationId, errorMessage)));
+    }
+
+    public void processDueRetries() {
+        List<Long> retryIds = transactionTemplate.execute(status ->
+                retryRepository.findTop100ByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
+                                StockCancelRetryStatus.PENDING, LocalDateTime.now())
+                        .stream()
+                        .map(StockCancelRetry::getId)
+                        .toList()
+        );
+
+        if (retryIds == null || retryIds.isEmpty()) {
+            return;
+        }
+
+        for (Long retryId : retryIds) {
+            processOneRetry(retryId);
+        }
+    }
+
+    private void processOneRetry(Long retryId) {
+        boolean claimed = Boolean.TRUE.equals(transactionTemplate.execute(status ->
+                retryRepository.claimForProcessing(
+                        retryId,
+                        StockCancelRetryStatus.PENDING,
+                        StockCancelRetryStatus.PROCESSING,
+                        LocalDateTime.now()
+                ) > 0
+        ));
+
+        if (!claimed) {
+            return;
+        }
+
+        StockCancelRetry retryTask = transactionTemplate.execute(status ->
+                retryRepository.findById(retryId).orElse(null));
+        if (retryTask == null) {
+            return;
+        }
+
+        try {
+            stockClient.cancelReservation(retryTask.getReservationId());
+
+            transactionTemplate.executeWithoutResult(status ->
+                    retryRepository.findById(retryId).ifPresent(task -> {
+                        if (task.getStatus() == StockCancelRetryStatus.PROCESSING) {
+                            task.markCompleted();
+                        }
+                    })
+            );
+
+            log.info("Stock cancel retry succeeded: retryId={}, purchaseId={}, reservationId={}, retryCount={}",
+                    retryId, retryTask.getPurchaseId(), retryTask.getReservationId(), retryTask.getRetryCount());
+        } catch (Exception e) {
+            transactionTemplate.executeWithoutResult(status ->
+                    retryRepository.findById(retryId).ifPresent(task -> {
+                        if (task.getStatus() != StockCancelRetryStatus.PROCESSING) {
+                            return;
+                        }
+
+                        int nextRetryCount = task.getRetryCount() + 1;
+                        if (nextRetryCount >= MAX_RETRY_COUNT) {
+                            task.markFailed(e.getMessage());
+                        } else {
+                            task.scheduleNextRetry(e.getMessage(), computeDelaySeconds(nextRetryCount));
+                        }
+                    })
+            );
+
+            log.warn("Stock cancel retry failed: retryId={}, reservationId={}, error={}",
+                    retryId, retryTask.getReservationId(), e.getMessage());
+        }
+    }
+
+    private long computeDelaySeconds(int retryCount) {
+        long delaySeconds = BASE_DELAY_SECONDS * (1L << Math.max(0, retryCount - 1));
+        return Math.min(delaySeconds, MAX_DELAY_SECONDS);
+    }
+}


### PR DESCRIPTION
## 개요
sales/funding 취소·환불 후 Stock 예약 취소가 실패할 때 로그만 남기고 종료되던 경로에
영속 retry queue + 백오프 스케줄러를 추가해 eventual consistency 복구 경로를 구현했습니다.

### 관련 이슈
- Closes #579

### 작업 / 변경 내용
- sales/funding 각각에 `StockCancelRetry` 엔티티 및 상태(`PENDING/PROCESSING/COMPLETED/FAILED`) 추가
- 실패 건 enqueue 로직 추가
  - `PurchaseCommandService.cancelReservationAfterCommit()`
  - `ParticipationCommandService.cancelReservationAfterCommit()`
- 재시도 스케줄러 추가 (`fixedDelay=30s`)
  - due 건 조회 -> `claimForProcessing`(CAS) -> 외부 취소 -> 성공/실패 상태 전이
  - 실패 시 지수 백오프(30s base, max 10m), 최대 5회 후 FAILED
- StockClient 보강
  - `STOCK-103/104/105`는 이미 해제된 예약으로 간주해 성공 처리(준-멱등)

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:sales:compileJava :servers:services:funding:compileJava`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:sales:test :servers:services:funding:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 신규 테이블은 JPA `ddl-auto` 정책에 따라 생성됩니다.
- `.blog` 초안은 로컬 문서 디렉토리에 별도로 작성했습니다.
