### PR TITLE
[BUGFIX] Outbox stale SENDING 복구 및 상태 전이 가드 추가

### DIFF
--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxRepository.java
@@ -24,12 +24,16 @@ public interface OutboxRepository extends JpaRepository<OutboxMessage, Long> {
             @Param("limit") int limit);
 
     @Modifying
-    @Query("UPDATE OutboxMessage o SET o.status = :newStatus WHERE o.id = :id AND o.status = :currentStatus")
+    @Query("UPDATE OutboxMessage o SET o.status = :newStatus, o.updatedAt = CURRENT_TIMESTAMP " +
+            "WHERE o.id = :id AND o.status = :currentStatus")
     int updateStatusById(@Param("id") Long id,
                          @Param("currentStatus") OutboxStatus currentStatus,
                          @Param("newStatus") OutboxStatus newStatus);
 
     List<OutboxMessage> findByStatusOrderByCreatedAtAsc(OutboxStatus status);
+
+    List<OutboxMessage> findTop100ByStatusAndUpdatedAtLessThanEqualOrderByUpdatedAtAsc(
+            OutboxStatus status, LocalDateTime updatedAt);
 
     @Modifying
     @Query("DELETE FROM OutboxMessage o WHERE o.status = :status AND o.createdAt < :before")


### PR DESCRIPTION
## 개요
Outbox relay에서 `SENDING` 상태가 프로세스 장애로 고착될 수 있는 문제를 복구 가능한 구조로 보강했습니다.

### 관련 이슈
- Closes #581

### 작업 / 변경 내용
- `OutboxRelayScheduler`
  - stale `SENDING` 복구 루프 추가 (`updatedAt` 기반 lease timeout)
  - stale 메시지 복구 시 retryCount 증가 후 `PENDING` 재큐잉 또는 `FAILED` 전환
  - 늦게 도착한 publish callback이 비-`SENDING` 상태를 덮어쓰지 않도록 가드 추가
- `OutboxRepository`
  - 상태 전이 update 시 `updatedAt` 동시 갱신
  - stale `SENDING` 조회 메서드 추가

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :libs:event:outbox:compileJava`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :libs:event:outbox:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- `SENDING_STALE_THRESHOLD_SECONDS=120` 기본값으로 적용
