### PR TITLE
fix: recover stale PROCESSING stock cancel retries

### DIFF
--- a/servers/services/funding/src/main/java/com/example/funding/repository/StockCancelRetryRepository.java
+++ b/servers/services/funding/src/main/java/com/example/funding/repository/StockCancelRetryRepository.java
@@ -16,10 +16,13 @@ public interface StockCancelRetryRepository extends JpaRepository<StockCancelRet
             StockCancelRetryStatus status, LocalDateTime now);
 
     @Modifying
-    @Query("UPDATE StockCancelRetry r SET r.status = :processing " +
+    @Query("UPDATE StockCancelRetry r SET r.status = :processing, r.updatedAt = CURRENT_TIMESTAMP " +
             "WHERE r.id = :id AND r.status = :pending AND r.nextRetryAt <= :now")
     int claimForProcessing(@Param("id") Long id,
                            @Param("pending") StockCancelRetryStatus pending,
                            @Param("processing") StockCancelRetryStatus processing,
                            @Param("now") LocalDateTime now);
+
+    List<StockCancelRetry> findTop100ByStatusAndUpdatedAtLessThanEqualOrderByUpdatedAtAsc(
+            StockCancelRetryStatus status, LocalDateTime updatedAt);
 }

--- a/servers/services/sales/src/main/java/com/example/sales/repository/StockCancelRetryRepository.java
+++ b/servers/services/sales/src/main/java/com/example/sales/repository/StockCancelRetryRepository.java
@@ -16,10 +16,13 @@ public interface StockCancelRetryRepository extends JpaRepository<StockCancelRet
             StockCancelRetryStatus status, LocalDateTime now);
 
     @Modifying
-    @Query("UPDATE StockCancelRetry r SET r.status = :processing " +
+    @Query("UPDATE StockCancelRetry r SET r.status = :processing, r.updatedAt = CURRENT_TIMESTAMP " +
             "WHERE r.id = :id AND r.status = :pending AND r.nextRetryAt <= :now")
     int claimForProcessing(@Param("id") Long id,
                            @Param("pending") StockCancelRetryStatus pending,
                            @Param("processing") StockCancelRetryStatus processing,
                            @Param("now") LocalDateTime now);
+
+    List<StockCancelRetry> findTop100ByStatusAndUpdatedAtLessThanEqualOrderByUpdatedAtAsc(
+            StockCancelRetryStatus status, LocalDateTime updatedAt);
 }

--- a/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
+++ b/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
@@ -20,6 +20,7 @@ public class StockCancelRetryService {
     private static final int MAX_RETRY_COUNT = 5;
     private static final long BASE_DELAY_SECONDS = 30;
     private static final long MAX_DELAY_SECONDS = 600;
+    private static final long PROCESSING_STALE_THRESHOLD_SECONDS = 120;
 
     private final StockCancelRetryRepository retryRepository;
     private final StockClient stockClient;
@@ -31,6 +32,8 @@ public class StockCancelRetryService {
     }
 
     public void processDueRetries() {
+        recoverStaleProcessingTasks();
+
         List<Long> retryIds = transactionTemplate.execute(status ->
                 retryRepository.findTop100ByStatusAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(
                                 StockCancelRetryStatus.PENDING, LocalDateTime.now())
@@ -46,6 +49,46 @@ public class StockCancelRetryService {
         for (Long retryId : retryIds) {
             processOneRetry(retryId);
         }
+    }
+
+    private void recoverStaleProcessingTasks() {
+        LocalDateTime staleBefore = LocalDateTime.now().minusSeconds(PROCESSING_STALE_THRESHOLD_SECONDS);
+        List<Long> staleIds = transactionTemplate.execute(status ->
+                retryRepository.findTop100ByStatusAndUpdatedAtLessThanEqualOrderByUpdatedAtAsc(
+                                StockCancelRetryStatus.PROCESSING, staleBefore)
+                        .stream()
+                        .map(StockCancelRetry::getId)
+                        .toList()
+        );
+
+        if (staleIds == null || staleIds.isEmpty()) {
+            return;
+        }
+
+        for (Long staleId : staleIds) {
+            recoverStaleProcessingTask(staleId);
+        }
+    }
+
+    private void recoverStaleProcessingTask(Long retryId) {
+        transactionTemplate.executeWithoutResult(status ->
+                retryRepository.findById(retryId).ifPresent(task -> {
+                    if (task.getStatus() != StockCancelRetryStatus.PROCESSING) {
+                        return;
+                    }
+
+                    int nextRetryCount = task.getRetryCount() + 1;
+                    if (nextRetryCount >= MAX_RETRY_COUNT) {
+                        task.markFailed("Recovered stale PROCESSING and exceeded max retries");
+                        log.error("Sales retry moved stale PROCESSING to FAILED: retryId={}, reservationId={}, retry={}",
+                                retryId, task.getReservationId(), task.getRetryCount());
+                    } else {
+                        task.scheduleNextRetry("Recovered stale PROCESSING task", computeDelaySeconds(nextRetryCount));
+                        log.warn("Sales retry recovered stale PROCESSING to PENDING: retryId={}, reservationId={}, retry={}",
+                                retryId, task.getReservationId(), task.getRetryCount());
+                    }
+                })
+        );
     }
 
     private void processOneRetry(Long retryId) {


### PR DESCRIPTION
## 개요
Stock cancel retry 워커가 `PROCESSING` 상태에서 크래시될 때 보상 작업이 영구 중단되는 문제를 복구 가능하도록 개선했습니다.

### 관련 이슈
- Closes #582

### 작업 / 변경 내용
- sales/funding `StockCancelRetryRepository.claimForProcessing()`에서 claim 시 `updatedAt`도 갱신하도록 수정
- sales/funding에 `PROCESSING + updatedAt <= now-threshold` 조회 메서드 추가
- sales/funding `StockCancelRetryService.processDueRetries()` 시작 시 stale `PROCESSING` 작업을 선복구하도록 추가
- stale 복구 시 재시도 횟수/백오프를 적용해 `PENDING`으로 되돌리거나, 최대 횟수 초과 시 `FAILED`로 종료

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:sales:compileJava :servers:services:funding:compileJava`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:sales:test :servers:services:funding:test`)
- [x] 스키마/마이그레이션 변경 없음

### 참고사항
- threshold는 우선 120초 상수로 두었고, 운영값 튜닝이 필요하면 프로퍼티화 가능합니다.
