### PR TITLE
fix: retry stale-scan index and threshold config

### DIFF
--- a/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetry.java
+++ b/servers/services/funding/src/main/java/com/example/funding/entity/StockCancelRetry.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 @Table(name = "funding_stock_cancel_retries",
         indexes = {
                 @Index(name = "idx_funding_stock_cancel_retry_status_next", columnList = "status, nextRetryAt"),
+                @Index(name = "idx_funding_stock_cancel_retry_status_updated", columnList = "status, updatedAt"),
                 @Index(name = "idx_funding_stock_cancel_retry_participation", columnList = "participationId"),
                 @Index(name = "idx_funding_stock_cancel_retry_reservation", columnList = "reservationId")
         })

--- a/servers/services/funding/src/main/resources/application.yml
+++ b/servers/services/funding/src/main/resources/application.yml
@@ -49,6 +49,9 @@ app:
   service:
     stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
 
+  stock-cancel-retry:
+    processing-stale-threshold-seconds: ${STOCK_CANCEL_RETRY_PROCESSING_STALE_THRESHOLD_SECONDS:120}
+
   # ─── OpenAPI ──────────────────────────────────
   openapi:
     enabled: ${OPENAPI_ENABLED:true}

--- a/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetry.java
+++ b/servers/services/sales/src/main/java/com/example/sales/entity/StockCancelRetry.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 @Table(name = "sales_stock_cancel_retries",
         indexes = {
                 @Index(name = "idx_sales_stock_cancel_retry_status_next", columnList = "status, nextRetryAt"),
+                @Index(name = "idx_sales_stock_cancel_retry_status_updated", columnList = "status, updatedAt"),
                 @Index(name = "idx_sales_stock_cancel_retry_purchase", columnList = "purchaseId"),
                 @Index(name = "idx_sales_stock_cancel_retry_reservation", columnList = "reservationId")
         })

--- a/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
+++ b/servers/services/sales/src/main/java/com/example/sales/service/retry/StockCancelRetryService.java
@@ -6,6 +6,7 @@ import com.example.sales.entity.StockCancelRetryStatus;
 import com.example.sales.repository.StockCancelRetryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -20,11 +21,13 @@ public class StockCancelRetryService {
     private static final int MAX_RETRY_COUNT = 5;
     private static final long BASE_DELAY_SECONDS = 30;
     private static final long MAX_DELAY_SECONDS = 600;
-    private static final long PROCESSING_STALE_THRESHOLD_SECONDS = 120;
 
     private final StockCancelRetryRepository retryRepository;
     private final StockClient stockClient;
     private final TransactionTemplate transactionTemplate;
+
+    @Value("${app.stock-cancel-retry.processing-stale-threshold-seconds:120}")
+    private long processingStaleThresholdSeconds;
 
     public void enqueue(Long purchaseId, Long reservationId, String errorMessage) {
         transactionTemplate.executeWithoutResult(status ->
@@ -52,7 +55,7 @@ public class StockCancelRetryService {
     }
 
     private void recoverStaleProcessingTasks() {
-        LocalDateTime staleBefore = LocalDateTime.now().minusSeconds(PROCESSING_STALE_THRESHOLD_SECONDS);
+        LocalDateTime staleBefore = LocalDateTime.now().minusSeconds(processingStaleThresholdSeconds);
         List<Long> staleIds = transactionTemplate.execute(status ->
                 retryRepository.findTop100ByStatusAndUpdatedAtLessThanEqualOrderByUpdatedAtAsc(
                                 StockCancelRetryStatus.PROCESSING, staleBefore)

--- a/servers/services/sales/src/main/resources/application.yml
+++ b/servers/services/sales/src/main/resources/application.yml
@@ -50,6 +50,9 @@ app:
     stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
     product-url: ${PRODUCT_SERVICE_URL:http://localhost:8084}
 
+  stock-cancel-retry:
+    processing-stale-threshold-seconds: ${STOCK_CANCEL_RETRY_PROCESSING_STALE_THRESHOLD_SECONDS:120}
+
   # ─── OpenAPI ──────────────────────────────────
   openapi:
     enabled: ${OPENAPI_ENABLED:true}


### PR DESCRIPTION
## 개요
Sales/Funding stock cancel retry stale 복구 경로의 성능/운영 유연성을 개선하기 위해 인덱스를 보강하고 threshold를 설정값으로 외부화했습니다.

### 관련 이슈
- Closes #586

### 작업 / 변경 내용
- sales/funding `StockCancelRetry`에 `status, updatedAt` 복합 인덱스 추가
- sales/funding `StockCancelRetryService`의 stale threshold 상수 제거
- `app.stock-cancel-retry.processing-stale-threshold-seconds` 프로퍼티 적용 (default: 120)
- sales/funding `application.yml`에 환경변수 override 항목 추가

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`./gradlew :servers:services:sales:compileJava :servers:services:funding:compileJava`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:sales:test :servers:services:funding:test`)
- [x] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 운영 DB가 `ddl-auto=update`가 아니라면 인덱스 DDL을 별도 반영해야 합니다.
