### PR TITLE
feat(notification): notification service MVP bootstrap

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -100,6 +100,21 @@ services:
     networks:
       - project03-network
 
+  # ─── MailHog (Local SMTP) ────────────────────────────────
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: project03-mailhog
+    ports:
+      - "${MAIL_PORT:-1025}:1025"
+      - "${MAIL_WEB_PORT:-8025}:8025"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8025 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - project03-network
+
 volumes:
   postgres-data:
   redis-data:

--- a/servers/services/notification/build.gradle.kts
+++ b/servers/services/notification/build.gradle.kts
@@ -1,0 +1,55 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+    implementation(project(":libs:config:webclient"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+    implementation(project(":libs:security:context"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Mail
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation(platform("software.amazon.awssdk:bom:2.31.77"))
+    implementation("software.amazon.awssdk:ses")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/notification/src/main/java/com/example/notification/NotificationApplication.java
+++ b/servers/services/notification/src/main/java/com/example/notification/NotificationApplication.java
@@ -1,0 +1,16 @@
+package com.example.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(scanBasePackages = "com.example")
+@EnableAsync
+@EnableScheduling
+public class NotificationApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationApplication.class, args);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/client/ProductClient.java
+++ b/servers/services/notification/src/main/java/com/example/notification/client/ProductClient.java
@@ -1,0 +1,64 @@
+package com.example.notification.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class ProductClient {
+
+    private final WebClient webClient;
+
+    public ProductClient(WebClient.Builder webClientBuilder,
+                         @Value("${app.service.product-url:http://localhost:8084}") String productUrl) {
+        this.webClient = webClientBuilder.baseUrl(productUrl).build();
+    }
+
+    public ProductItemSummary findItemSummary(Long itemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/items/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                return null;
+            }
+
+            JsonNode data = response.path("data");
+            if (data.isMissingNode() || data.isNull()) {
+                return null;
+            }
+
+            return new ProductItemSummary(
+                    (data.path("id").isMissingNode() || data.path("id").isNull()) ? null : data.path("id").asLong(),
+                    (data.path("sellerId").isMissingNode() || data.path("sellerId").isNull())
+                            ? null
+                            : data.path("sellerId").asLong(),
+                    nullableText(data.path("title"))
+            );
+        } catch (Exception e) {
+            log.warn("Product lookup failed. itemId={}", itemId, e);
+            return null;
+        }
+    }
+
+    private String nullableText(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        String text = node.asText();
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    public record ProductItemSummary(
+            Long itemId,
+            Long sellerId,
+            String title
+    ) {
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/EmailProviderConfig.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/EmailProviderConfig.java
@@ -1,0 +1,19 @@
+package com.example.notification.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+
+@Configuration
+@EnableConfigurationProperties(NotificationEmailProperties.class)
+public class EmailProviderConfig {
+
+    @Bean
+    public SesClient sesClient(NotificationEmailProperties properties) {
+        return SesClient.builder()
+                .region(Region.of(properties.getSesRegion()))
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/GatewayHeaderValidationFilter.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/GatewayHeaderValidationFilter.java
@@ -1,0 +1,122 @@
+package com.example.notification.config;
+
+import com.example.security.context.AuthContext;
+import com.example.security.context.AuthContextHolder;
+import com.example.security.context.HeaderSecurityException;
+import com.example.security.context.SignedHeaderParser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Slf4j
+@RequiredArgsConstructor
+public class GatewayHeaderValidationFilter extends OncePerRequestFilter {
+
+    private static final String API_PREFIX = "/api/v1/notifications";
+
+    private final NotificationSecurityProperties properties;
+    private final SignedHeaderParser signedHeaderParser;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (properties.isGatewayAuthEnabled()) {
+            if (!validateGatewayAuth(request)) {
+                writeUnauthorized(response, "NOTIFICATION-AUTH-001", "gateway authentication failed");
+                return;
+            }
+        }
+
+        if (!validateUserContext(request)) {
+            writeUnauthorized(response, "NOTIFICATION-AUTH-002", "invalid user header");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (uri == null) {
+            return true;
+        }
+        if (uri.startsWith("/actuator") || uri.startsWith("/v3/api-docs") || uri.startsWith("/swagger-ui")) {
+            return true;
+        }
+        return !uri.startsWith(API_PREFIX);
+    }
+
+    private boolean validateGatewayAuth(HttpServletRequest request) {
+        String token = properties.getInternalAuthToken();
+        if (!StringUtils.hasText(token)) {
+            return signedHeaderParser != null;
+        }
+        String provided = request.getHeader(properties.getInternalAuthHeader());
+        return token.equals(provided);
+    }
+
+    private boolean validateUserContext(HttpServletRequest request) {
+        if (signedHeaderParser != null) {
+            return validateSignedHeaders(request);
+        }
+
+        return validateLegacyUserHeader(request);
+    }
+
+    private boolean validateSignedHeaders(HttpServletRequest request) {
+        try {
+            AuthContext authContext = signedHeaderParser.parse(request::getHeader);
+            if (!isPositiveLong(authContext.getUserId())) {
+                return false;
+            }
+            AuthContextHolder.setContext(authContext);
+            return true;
+        } catch (HeaderSecurityException e) {
+            log.debug("Signed header validation failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean validateLegacyUserHeader(HttpServletRequest request) {
+        String userIdRaw = request.getHeader(properties.getUserIdHeader());
+        return isPositiveLong(userIdRaw);
+    }
+
+    private boolean isPositiveLong(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return false;
+        }
+        try {
+            return Long.parseLong(raw) > 0;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
+    }
+
+    private void writeUnauthorized(HttpServletResponse response, String code, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("""
+                {
+                  "success": false,
+                  "error": {
+                    "code": "%s",
+                    "message": "%s"
+                  },
+                  "timestamp": "%s"
+                }
+                """.formatted(code, message, Instant.now()));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/JpaConfig.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.example.notification.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example.notification.repository")
+public class JpaConfig {
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/NotificationDeliveryProperties.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/NotificationDeliveryProperties.java
@@ -1,0 +1,62 @@
+package com.example.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "notification.delivery")
+public class NotificationDeliveryProperties {
+
+    private int maxAttempts = 3;
+    private int initialBackoffSeconds = 10;
+    private int backoffMultiplier = 2;
+    private int retryBatchSize = 100;
+    private long retryFixedDelayMs = 5000L;
+    private int claimLeaseSeconds = 30;
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public int getInitialBackoffSeconds() {
+        return initialBackoffSeconds;
+    }
+
+    public void setInitialBackoffSeconds(int initialBackoffSeconds) {
+        this.initialBackoffSeconds = initialBackoffSeconds;
+    }
+
+    public int getBackoffMultiplier() {
+        return backoffMultiplier;
+    }
+
+    public void setBackoffMultiplier(int backoffMultiplier) {
+        this.backoffMultiplier = backoffMultiplier;
+    }
+
+    public int getRetryBatchSize() {
+        return retryBatchSize;
+    }
+
+    public void setRetryBatchSize(int retryBatchSize) {
+        this.retryBatchSize = retryBatchSize;
+    }
+
+    public long getRetryFixedDelayMs() {
+        return retryFixedDelayMs;
+    }
+
+    public void setRetryFixedDelayMs(long retryFixedDelayMs) {
+        this.retryFixedDelayMs = retryFixedDelayMs;
+    }
+
+    public int getClaimLeaseSeconds() {
+        return claimLeaseSeconds;
+    }
+
+    public void setClaimLeaseSeconds(int claimLeaseSeconds) {
+        this.claimLeaseSeconds = claimLeaseSeconds;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/NotificationEmailProperties.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/NotificationEmailProperties.java
@@ -1,0 +1,63 @@
+package com.example.notification.config;
+
+import com.example.notification.service.email.EmailProviderType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "notification.email")
+public class NotificationEmailProperties {
+
+    private EmailProviderType provider = EmailProviderType.SMTP;
+    private boolean fallbackEnabled = false;
+    private EmailProviderType fallbackProvider = EmailProviderType.SMTP;
+    private String fromAddress = "no-reply@example.com";
+    private String sesRegion = "ap-northeast-2";
+    private String configurationSet;
+
+    public EmailProviderType getProvider() {
+        return provider;
+    }
+
+    public void setProvider(EmailProviderType provider) {
+        this.provider = provider;
+    }
+
+    public boolean isFallbackEnabled() {
+        return fallbackEnabled;
+    }
+
+    public void setFallbackEnabled(boolean fallbackEnabled) {
+        this.fallbackEnabled = fallbackEnabled;
+    }
+
+    public EmailProviderType getFallbackProvider() {
+        return fallbackProvider;
+    }
+
+    public void setFallbackProvider(EmailProviderType fallbackProvider) {
+        this.fallbackProvider = fallbackProvider;
+    }
+
+    public String getFromAddress() {
+        return fromAddress;
+    }
+
+    public void setFromAddress(String fromAddress) {
+        this.fromAddress = fromAddress;
+    }
+
+    public String getSesRegion() {
+        return sesRegion;
+    }
+
+    public void setSesRegion(String sesRegion) {
+        this.sesRegion = sesRegion;
+    }
+
+    public String getConfigurationSet() {
+        return configurationSet;
+    }
+
+    public void setConfigurationSet(String configurationSet) {
+        this.configurationSet = configurationSet;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/NotificationSecurityProperties.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/NotificationSecurityProperties.java
@@ -1,0 +1,44 @@
+package com.example.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "notification.security")
+public class NotificationSecurityProperties {
+
+    private boolean gatewayAuthEnabled = true;
+    private String internalAuthHeader = "X-Internal-Auth";
+    private String internalAuthToken = "";
+    private String userIdHeader = "X-User-Id";
+
+    public boolean isGatewayAuthEnabled() {
+        return gatewayAuthEnabled;
+    }
+
+    public void setGatewayAuthEnabled(boolean gatewayAuthEnabled) {
+        this.gatewayAuthEnabled = gatewayAuthEnabled;
+    }
+
+    public String getInternalAuthHeader() {
+        return internalAuthHeader;
+    }
+
+    public void setInternalAuthHeader(String internalAuthHeader) {
+        this.internalAuthHeader = internalAuthHeader;
+    }
+
+    public String getInternalAuthToken() {
+        return internalAuthToken;
+    }
+
+    public void setInternalAuthToken(String internalAuthToken) {
+        this.internalAuthToken = internalAuthToken;
+    }
+
+    public String getUserIdHeader() {
+        return userIdHeader;
+    }
+
+    public void setUserIdHeader(String userIdHeader) {
+        this.userIdHeader = userIdHeader;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/NotificationSseProperties.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/NotificationSseProperties.java
@@ -1,0 +1,35 @@
+package com.example.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "notification.sse")
+public class NotificationSseProperties {
+
+    private long heartbeatMs = 10_000L;
+    private int maxConnectionsPerUser = 3;
+    private int maxTotalConnections = 5_000;
+
+    public long getHeartbeatMs() {
+        return heartbeatMs;
+    }
+
+    public void setHeartbeatMs(long heartbeatMs) {
+        this.heartbeatMs = heartbeatMs;
+    }
+
+    public int getMaxConnectionsPerUser() {
+        return maxConnectionsPerUser;
+    }
+
+    public void setMaxConnectionsPerUser(int maxConnectionsPerUser) {
+        this.maxConnectionsPerUser = maxConnectionsPerUser;
+    }
+
+    public int getMaxTotalConnections() {
+        return maxTotalConnections;
+    }
+
+    public void setMaxTotalConnections(int maxTotalConnections) {
+        this.maxTotalConnections = maxTotalConnections;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/SecurityConfig.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.example.notification.config;
+
+import com.example.security.context.SignedHeaderParser;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.ObjectProvider;
+
+@Configuration
+@EnableConfigurationProperties({
+        NotificationSecurityProperties.class,
+        NotificationDeliveryProperties.class,
+        NotificationSseProperties.class
+})
+public class SecurityConfig {
+
+    @Bean
+    public FilterRegistrationBean<GatewayHeaderValidationFilter> gatewayHeaderValidationFilter(
+            NotificationSecurityProperties properties,
+            ObjectProvider<SignedHeaderParser> signedHeaderParserProvider) {
+        FilterRegistrationBean<GatewayHeaderValidationFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new GatewayHeaderValidationFilter(properties, signedHeaderParserProvider.getIfAvailable()));
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/config/SseRedisConfig.java
+++ b/servers/services/notification/src/main/java/com/example/notification/config/SseRedisConfig.java
@@ -1,0 +1,30 @@
+package com.example.notification.config;
+
+import com.example.notification.service.realtime.SseRedisSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class SseRedisConfig {
+
+    @Bean
+    public ChannelTopic sseNotificationTopic(
+            @Value("${notification.sse.topic:sse-notifications}") String topicName) {
+        return new ChannelTopic(topicName);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer sseMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            ChannelTopic sseNotificationTopic,
+            SseRedisSubscriber sseRedisSubscriber) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(sseRedisSubscriber, sseNotificationTopic);
+        return container;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/FundingEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/FundingEventMessage.java
@@ -1,0 +1,19 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FundingEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long campaignId;
+    private Long itemId;
+    private Long sellerId;
+    private String fundingType;
+    private Long goalAmount;
+    private Long currentAmount;
+    private Integer currentQuantity;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/HotDealEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/HotDealEventMessage.java
@@ -1,0 +1,19 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HotDealEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long hotDealId;
+    private Long itemId;
+    private String title;
+    private Long discountedPrice;
+    private Integer discountRate;
+    private Integer maxQuantity;
+    private Long sellerId;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationDeliveryEventConsumer.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationDeliveryEventConsumer.java
@@ -1,0 +1,149 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationDeliveryStatus;
+import com.example.notification.entity.NotificationStatus;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.delivery.NotificationDeliveryCommand;
+import com.example.notification.service.delivery.NotificationDeliveryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationDeliveryEventConsumer {
+
+    private static final String EVENT_TYPE = "NOTIFICATION_DELIVERY_REQUESTED";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final NotificationRepository notificationRepository;
+    private final NotificationDeliveryRepository notificationDeliveryRepository;
+    private final NotificationDeliveryService notificationDeliveryService;
+
+    @KafkaListener(topics = "notification-delivery-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumeDispatchRequest(String message) {
+        NotificationDeliveryEventMessage event = JsonUtils.fromJson(message, NotificationDeliveryEventMessage.class);
+        if (!hasRequiredEnvelope(event)) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), EVENT_TYPE, () -> {
+            if (!EVENT_TYPE.equals(normalizeEventType(event.getEventType()))) {
+                log.debug("Ignore delivery event type: {}", event.getEventType());
+                return null;
+            }
+            handleDeliveryRequested(event);
+            return null;
+        });
+    }
+
+    private void handleDeliveryRequested(NotificationDeliveryEventMessage event) {
+        if (event.getNotificationId() == null) {
+            throw new IllegalArgumentException("notificationId is required");
+        }
+
+        Notification notification = notificationRepository.findById(event.getNotificationId()).orElse(null);
+        if (notification == null) {
+            throw new IllegalStateException("notification not found. notificationId=" + event.getNotificationId());
+        }
+
+        NotificationChannel channel = resolveChannel(event.getChannel());
+        if (channel == null) {
+            throw new IllegalArgumentException(
+                    "invalid channel. eventId=" + event.getEventId() + ", channel=" + event.getChannel()
+            );
+        }
+
+        notificationDeliveryService.deliver(
+                notification,
+                channel,
+                NotificationDeliveryCommand.builder()
+                        .userId(notification.getRecipientId())
+                        .type(notification.getType())
+                        .title(notification.getTitle())
+                        .message(notification.getMessage())
+                        .emailTo(event.getEmailTo())
+                        .build()
+        );
+
+        refreshNotificationStatus(notification.getId());
+    }
+
+    private void refreshNotificationStatus(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId).orElse(null);
+        if (notification == null) {
+            return;
+        }
+
+        List<NotificationDelivery> deliveries = notificationDeliveryRepository.findByNotificationIdOrderByIdAsc(notificationId);
+        if (deliveries.isEmpty()) {
+            return;
+        }
+
+        boolean anyDelivered = deliveries.stream()
+                .anyMatch(delivery -> delivery.getStatus() == NotificationDeliveryStatus.DELIVERED);
+
+        if (anyDelivered) {
+            if (notification.getStatus() == NotificationStatus.CREATED
+                    || notification.getStatus() == NotificationStatus.FAILED) {
+                notification.markAsDispatched();
+                notificationRepository.save(notification);
+            }
+            return;
+        }
+
+        boolean allFailed = deliveries.stream().allMatch(this::isFinalFailure);
+        if (allFailed && notification.getStatus() == NotificationStatus.CREATED) {
+            notification.markAsFailed();
+            notificationRepository.save(notification);
+        }
+    }
+
+    private NotificationChannel resolveChannel(String rawChannel) {
+        if (rawChannel == null || rawChannel.isBlank()) {
+            return null;
+        }
+        try {
+            return NotificationChannel.valueOf(rawChannel.toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private boolean isFinalFailure(NotificationDelivery delivery) {
+        NotificationDeliveryStatus status = delivery.getStatus();
+        return status == NotificationDeliveryStatus.FAILED
+                || status == NotificationDeliveryStatus.DROPPED
+                || status == NotificationDeliveryStatus.BOUNCED;
+    }
+
+    private boolean hasRequiredEnvelope(NotificationDeliveryEventMessage event) {
+        if (event == null) {
+            log.warn("Skip invalid delivery event. payload is null");
+            return false;
+        }
+        if (event.getEventId() == null || event.getEventType() == null) {
+            log.warn("Skip invalid delivery event. eventId={}, eventType={}",
+                    event.getEventId(), event.getEventType());
+            return false;
+        }
+        return true;
+    }
+
+    private String normalizeEventType(String eventType) {
+        return eventType == null ? "" : eventType.toUpperCase(Locale.ROOT);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationDeliveryEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationDeliveryEventMessage.java
@@ -1,0 +1,15 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationDeliveryEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long notificationId;
+    private String channel;
+    private String emailTo;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationEventConsumer.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/NotificationEventConsumer.java
@@ -1,0 +1,303 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import com.example.notification.client.ProductClient;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.service.command.NotificationCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventConsumer {
+
+    private static final List<String> DEFAULT_CHANNELS = List.of(NotificationChannel.IN_APP.name());
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final NotificationCommandService notificationCommandService;
+    private final ProductClient productClient;
+
+    @KafkaListener(topics = "funding-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumeFunding(String message) {
+        FundingEventMessage event = JsonUtils.fromJson(message, FundingEventMessage.class);
+        if (!isValid(event.getEventId(), event.getEventType(), "funding-events")) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), "FUNDING_EVENT", () -> {
+            switch (normalizeEventType(event.getEventType())) {
+                case "FUNDING_SUCCEEDED" -> handleFundingSucceeded(event);
+                case "FUNDING_FAILED" -> handleFundingFailed(event);
+                default -> log.debug("Ignore funding event type: {}", event.getEventType());
+            }
+            return null;
+        });
+    }
+
+    @KafkaListener(topics = "payment-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumePayment(String message) {
+        PaymentEventMessage event = JsonUtils.fromJson(message, PaymentEventMessage.class);
+        if (!isValid(event.getEventId(), event.getEventType(), "payment-events")) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), "PAYMENT_EVENT", () -> {
+            if ("PAYMENT_COMPLETED".equals(normalizeEventType(event.getEventType()))) {
+                handlePaymentCompleted(event);
+            } else {
+                log.debug("Ignore payment event type: {}", event.getEventType());
+            }
+            return null;
+        });
+    }
+
+    @KafkaListener(topics = "hotdeal-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumeHotDeal(String message) {
+        HotDealEventMessage event = JsonUtils.fromJson(message, HotDealEventMessage.class);
+        if (!isValid(event.getEventId(), event.getEventType(), "hotdeal-events")) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), "HOTDEAL_EVENT", () -> {
+            if ("HOT_DEAL_STARTED".equals(normalizeEventType(event.getEventType()))) {
+                handleHotDealStarted(event);
+            } else {
+                log.debug("Ignore hotdeal event type: {}", event.getEventType());
+            }
+            return null;
+        });
+    }
+
+    @KafkaListener(topics = "stock-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumeStock(String message) {
+        StockEventMessage event = JsonUtils.fromJson(message, StockEventMessage.class);
+        if (!isValid(event.getEventId(), event.getEventType(), "stock-events")) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), "STOCK_EVENT", () -> {
+            if ("STOCK_DEPLETED".equals(normalizeEventType(event.getEventType()))) {
+                handleStockDepleted(event);
+            } else {
+                log.debug("Ignore stock event type: {}", event.getEventType());
+            }
+            return null;
+        });
+    }
+
+    private void handleFundingSucceeded(FundingEventMessage event) {
+        if (event.getSellerId() == null) {
+            log.warn("Skip FUNDING_SUCCEEDED notification. sellerId is null. campaignId={}", event.getCampaignId());
+            return;
+        }
+
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("campaignId", event.getCampaignId());
+        variables.put("itemId", event.getItemId());
+        variables.put("goalAmount", event.getGoalAmount());
+        variables.put("currentAmount", event.getCurrentAmount());
+        variables.put("currentQuantity", event.getCurrentQuantity());
+        variables.put("fundingType", event.getFundingType());
+
+        dispatchNotification(
+                event.getSellerId(),
+                NotificationType.FUNDING_SUCCESS,
+                "CAMPAIGN",
+                event.getCampaignId(),
+                event.getEventId(),
+                "펀딩이 성공적으로 마감되었어요",
+                "캠페인 #" + safeValue(event.getCampaignId()) + "이(가) 목표를 달성했습니다.",
+                variables
+        );
+    }
+
+    private void handleFundingFailed(FundingEventMessage event) {
+        if (event.getSellerId() == null) {
+            log.warn("Skip FUNDING_FAILED notification. sellerId is null. campaignId={}", event.getCampaignId());
+            return;
+        }
+
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("campaignId", event.getCampaignId());
+        variables.put("itemId", event.getItemId());
+        variables.put("goalAmount", event.getGoalAmount());
+        variables.put("currentAmount", event.getCurrentAmount());
+        variables.put("currentQuantity", event.getCurrentQuantity());
+        variables.put("fundingType", event.getFundingType());
+
+        dispatchNotification(
+                event.getSellerId(),
+                NotificationType.FUNDING_FAIL,
+                "CAMPAIGN",
+                event.getCampaignId(),
+                event.getEventId(),
+                "펀딩이 목표를 달성하지 못했어요",
+                "캠페인 #" + safeValue(event.getCampaignId()) + "이(가) 마감되었지만 목표 달성에 실패했습니다.",
+                variables
+        );
+    }
+
+    private void handlePaymentCompleted(PaymentEventMessage event) {
+        if (event.getUserId() == null) {
+            log.warn("Skip PAYMENT_COMPLETED notification. userId is null. paymentId={}", event.getPaymentId());
+            return;
+        }
+
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("paymentId", event.getPaymentId());
+        variables.put("purchaseId", event.getPurchaseId());
+        variables.put("orderId", event.getOrderId());
+        variables.put("itemId", event.getItemId());
+        variables.put("totalAmount", event.getTotalAmount());
+        variables.put("quantity", event.getQuantity());
+
+        dispatchNotification(
+                event.getUserId(),
+                NotificationType.PAYMENT,
+                "PURCHASE",
+                event.getPurchaseId(),
+                event.getEventId(),
+                "결제가 완료되었습니다",
+                "결제 건 #" + safeValue(event.getPaymentId()) + "이(가) 정상 처리되었습니다.",
+                variables
+        );
+    }
+
+    private void handleHotDealStarted(HotDealEventMessage event) {
+        ResolvedRecipient resolved = resolveRecipient(event.getItemId(), event.getSellerId(), event.getTitle());
+        if (resolved.recipientId() == null) {
+            log.warn("Skip HOT_DEAL_STARTED notification. recipient unresolved. itemId={}", event.getItemId());
+            return;
+        }
+
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("hotDealId", event.getHotDealId());
+        variables.put("itemId", event.getItemId());
+        variables.put("title", resolved.title());
+        variables.put("discountedPrice", event.getDiscountedPrice());
+        variables.put("discountRate", event.getDiscountRate());
+        variables.put("maxQuantity", event.getMaxQuantity());
+
+        dispatchNotification(
+                resolved.recipientId(),
+                NotificationType.HOTDEAL,
+                "HOT_DEAL",
+                event.getHotDealId(),
+                event.getEventId(),
+                "핫딜이 시작되었습니다",
+                safeValue(resolved.title()) + " 상품의 핫딜이 시작되었습니다.",
+                variables
+        );
+    }
+
+    private void handleStockDepleted(StockEventMessage event) {
+        ResolvedRecipient resolved = resolveRecipient(event.getItemId(), event.getSellerId(), event.getTitle());
+        if (resolved.recipientId() == null) {
+            log.warn("Skip STOCK_DEPLETED notification. recipient unresolved. itemId={}", event.getItemId());
+            return;
+        }
+
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("stockItemId", event.getStockItemId());
+        variables.put("itemId", event.getItemId());
+        variables.put("title", resolved.title());
+        variables.put("quantity", event.getQuantity());
+        variables.put("remainingQuantity", event.getRemainingQuantity());
+        variables.put("totalQuantity", event.getTotalQuantity());
+
+        dispatchNotification(
+                resolved.recipientId(),
+                NotificationType.STOCK_DEPLETED,
+                "ITEM",
+                event.getItemId(),
+                event.getEventId(),
+                "재고가 모두 소진되었습니다",
+                safeValue(resolved.title()) + " 상품의 재고가 모두 소진되었습니다.",
+                variables
+        );
+    }
+
+    private void dispatchNotification(Long recipientId,
+                                      NotificationType type,
+                                      String referenceType,
+                                      Object referenceId,
+                                      String eventId,
+                                      String title,
+                                      String message,
+                                      Map<String, Object> variables) {
+        CreateNotificationRequest request = CreateNotificationRequest.builder()
+                .recipientId(recipientId)
+                .type(type.name())
+                .channels(DEFAULT_CHANNELS)
+                .referenceType(referenceType)
+                .referenceId(referenceId == null ? null : String.valueOf(referenceId))
+                .externalEventId(eventId)
+                .title(title)
+                .message(message)
+                .variables(variables)
+                .build();
+        notificationCommandService.createAndSend(request, null);
+    }
+
+    private ResolvedRecipient resolveRecipient(Long itemId, Long explicitRecipientId, String explicitTitle) {
+        Long recipientId = explicitRecipientId;
+        String title = normalizeText(explicitTitle);
+
+        if ((recipientId == null || title == null) && itemId != null) {
+            ProductClient.ProductItemSummary itemSummary = productClient.findItemSummary(itemId);
+            if (itemSummary != null) {
+                if (recipientId == null) {
+                    recipientId = itemSummary.sellerId();
+                }
+                if (title == null) {
+                    title = normalizeText(itemSummary.title());
+                }
+            }
+        }
+
+        return new ResolvedRecipient(recipientId, title);
+    }
+
+    private boolean isValid(String eventId, String eventType, String topic) {
+        if (eventId == null || eventType == null) {
+            log.warn("Skip invalid {} message. eventId={}, eventType={}",
+                    topic, eventId, eventType);
+            return false;
+        }
+        return true;
+    }
+
+    private String normalizeEventType(String eventType) {
+        return eventType == null ? "" : eventType.toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizeText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    private String safeValue(Object value) {
+        return value == null ? "-" : String.valueOf(value);
+    }
+
+    private record ResolvedRecipient(Long recipientId, String title) {
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/PaymentEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/PaymentEventMessage.java
@@ -1,0 +1,19 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long paymentId;
+    private Long purchaseId;
+    private Long orderId;
+    private Long userId;
+    private Long itemId;
+    private Long totalAmount;
+    private Integer quantity;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/StockEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/StockEventMessage.java
@@ -1,0 +1,19 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StockEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private Long stockItemId;
+    private Long itemId;
+    private Integer quantity;
+    private Integer remainingQuantity;
+    private Integer totalQuantity;
+    private Long sellerId;
+    private String title;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationActionCommandApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationActionCommandApi.java
@@ -1,0 +1,47 @@
+package com.example.notification.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.dto.command.response.ReadAllResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Notification Action Command", description = "알림 상태/삭제 API")
+public interface NotificationActionCommandApi {
+
+    @Operation(summary = "알림 읽음 처리")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "알림 없음")
+    })
+    @PatchMapping("/{notificationId}/read")
+    ApiResponse<Void> markAsRead(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @PathVariable Long notificationId
+    );
+
+    @Operation(summary = "전체 알림 읽음 처리")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공")
+    })
+    @PatchMapping("/read-all")
+    ApiResponse<ReadAllResultResponse> markAllAsRead(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId
+    );
+
+    @Operation(summary = "알림 삭제 (soft delete)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "알림 없음")
+    })
+    @DeleteMapping("/{notificationId}")
+    ApiResponse<Void> delete(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @PathVariable Long notificationId
+    );
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationCommandApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationCommandApi.java
@@ -1,0 +1,28 @@
+package com.example.notification.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.dto.command.response.NotificationDispatchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Notification Command", description = "알림 생성/발송 API")
+public interface NotificationCommandApi {
+
+    @Operation(summary = "알림 생성 및 발송")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PostMapping
+    ApiResponse<NotificationDispatchResponse> createAndSend(
+            @Valid @RequestBody CreateNotificationRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId
+    );
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationSettingCommandApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/command/NotificationSettingCommandApi.java
@@ -1,0 +1,39 @@
+package com.example.notification.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.dto.setting.request.UpdateNotificationGlobalPreferenceRequest;
+import com.example.notification.dto.setting.request.UpdateNotificationSettingRequest;
+import com.example.notification.dto.setting.response.NotificationGlobalPreferenceResponse;
+import com.example.notification.dto.setting.response.NotificationSettingItemResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Notification Setting Command", description = "알림 설정 변경 API")
+public interface NotificationSettingCommandApi {
+
+    @Operation(summary = "글로벌 알림 설정 변경")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PatchMapping("/settings/global")
+    ApiResponse<NotificationGlobalPreferenceResponse> updateGlobalPreference(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @RequestBody UpdateNotificationGlobalPreferenceRequest request);
+
+    @Operation(summary = "유형/채널별 알림 설정 변경")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PatchMapping("/settings")
+    ApiResponse<NotificationSettingItemResponse> updateSetting(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @Valid @RequestBody UpdateNotificationSettingRequest request);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationQueryApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationQueryApi.java
@@ -1,0 +1,39 @@
+package com.example.notification.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.notification.dto.query.response.NotificationHistoryItemResponse;
+import com.example.notification.dto.query.response.UnreadCountResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Notification Query", description = "알림 이력 조회 API")
+public interface NotificationQueryApi {
+
+    @Operation(summary = "내 알림 목록 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping
+    ApiResponse<CursorResponse<NotificationHistoryItemResponse>> getMyNotifications(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    );
+
+    @Operation(summary = "미읽음 알림 개수 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/unread-count")
+    ApiResponse<UnreadCountResponse> getUnreadCount(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId
+    );
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationRealtimeApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationRealtimeApi.java
@@ -1,0 +1,19 @@
+package com.example.notification.controller.api.query;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "Notification Realtime", description = "실시간 SSE 알림 API")
+public interface NotificationRealtimeApi {
+
+    @Operation(summary = "SSE 연결 구독")
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    SseEmitter subscribe(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId
+    );
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationSettingQueryApi.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/api/query/NotificationSettingQueryApi.java
@@ -1,0 +1,22 @@
+package com.example.notification.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.dto.setting.response.NotificationSettingsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Notification Setting Query", description = "알림 설정 조회 API")
+public interface NotificationSettingQueryApi {
+
+    @Operation(summary = "내 알림 설정 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/settings")
+    ApiResponse<NotificationSettingsResponse> getMySettings(
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationActionCommandController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationActionCommandController.java
@@ -1,0 +1,35 @@
+package com.example.notification.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.controller.api.command.NotificationActionCommandApi;
+import com.example.notification.dto.command.response.ReadAllResultResponse;
+import com.example.notification.service.command.NotificationActionCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationActionCommandController implements NotificationActionCommandApi {
+
+    private final NotificationActionCommandService notificationActionCommandService;
+
+    @Override
+    public ApiResponse<Void> markAsRead(Long userId, Long notificationId) {
+        notificationActionCommandService.markAsRead(userId, notificationId);
+        return ApiResponse.success();
+    }
+
+    @Override
+    public ApiResponse<ReadAllResultResponse> markAllAsRead(Long userId) {
+        int updated = notificationActionCommandService.markAllAsRead(userId);
+        return ApiResponse.success(ReadAllResultResponse.of(updated));
+    }
+
+    @Override
+    public ApiResponse<Void> delete(Long userId, Long notificationId) {
+        notificationActionCommandService.deleteNotification(userId, notificationId);
+        return ApiResponse.success();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationCommandController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationCommandController.java
@@ -1,0 +1,23 @@
+package com.example.notification.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.controller.api.command.NotificationCommandApi;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.dto.command.response.NotificationDispatchResponse;
+import com.example.notification.service.command.NotificationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationCommandController implements NotificationCommandApi {
+
+    private final NotificationCommandService notificationCommandService;
+
+    @Override
+    public ApiResponse<NotificationDispatchResponse> createAndSend(CreateNotificationRequest request, Long userId) {
+        return ApiResponse.success(notificationCommandService.createAndSend(request, userId));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationSettingCommandController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/command/NotificationSettingCommandController.java
@@ -1,0 +1,32 @@
+package com.example.notification.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.controller.api.command.NotificationSettingCommandApi;
+import com.example.notification.dto.setting.request.UpdateNotificationGlobalPreferenceRequest;
+import com.example.notification.dto.setting.request.UpdateNotificationSettingRequest;
+import com.example.notification.dto.setting.response.NotificationGlobalPreferenceResponse;
+import com.example.notification.dto.setting.response.NotificationSettingItemResponse;
+import com.example.notification.service.setting.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationSettingCommandController implements NotificationSettingCommandApi {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @Override
+    public ApiResponse<NotificationGlobalPreferenceResponse> updateGlobalPreference(
+            Long userId, UpdateNotificationGlobalPreferenceRequest request) {
+        return ApiResponse.success(notificationSettingService.updateGlobalPreference(userId, request));
+    }
+
+    @Override
+    public ApiResponse<NotificationSettingItemResponse> updateSetting(Long userId,
+                                                                      UpdateNotificationSettingRequest request) {
+        return ApiResponse.success(notificationSettingService.upsertSetting(userId, request));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationQueryController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationQueryController.java
@@ -1,0 +1,30 @@
+package com.example.notification.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.notification.controller.api.query.NotificationQueryApi;
+import com.example.notification.dto.query.response.NotificationHistoryItemResponse;
+import com.example.notification.dto.query.response.UnreadCountResponse;
+import com.example.notification.service.query.NotificationQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationQueryController implements NotificationQueryApi {
+
+    private final NotificationQueryService notificationQueryService;
+
+    @Override
+    public ApiResponse<CursorResponse<NotificationHistoryItemResponse>> getMyNotifications(
+            Long userId, String cursor, int size) {
+        return ApiResponse.success(notificationQueryService.findMyNotifications(userId, cursor, size));
+    }
+
+    @Override
+    public ApiResponse<UnreadCountResponse> getUnreadCount(Long userId) {
+        return ApiResponse.success(notificationQueryService.getUnreadCount(userId));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationRealtimeController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationRealtimeController.java
@@ -1,0 +1,21 @@
+package com.example.notification.controller.query;
+
+import com.example.notification.controller.api.query.NotificationRealtimeApi;
+import com.example.notification.service.realtime.SseConnectionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationRealtimeController implements NotificationRealtimeApi {
+
+    private final SseConnectionManager sseConnectionManager;
+
+    @Override
+    public SseEmitter subscribe(Long userId) {
+        return sseConnectionManager.connect(userId);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationSettingQueryController.java
+++ b/servers/services/notification/src/main/java/com/example/notification/controller/query/NotificationSettingQueryController.java
@@ -1,0 +1,22 @@
+package com.example.notification.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.notification.controller.api.query.NotificationSettingQueryApi;
+import com.example.notification.dto.setting.response.NotificationSettingsResponse;
+import com.example.notification.service.setting.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationSettingQueryController implements NotificationSettingQueryApi {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @Override
+    public ApiResponse<NotificationSettingsResponse> getMySettings(Long userId) {
+        return ApiResponse.success(notificationSettingService.getSettings(userId));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/command/request/CreateNotificationRequest.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/command/request/CreateNotificationRequest.java
@@ -1,0 +1,56 @@
+package com.example.notification.dto.command.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CreateNotificationRequest {
+
+    @NotNull(message = "수신자 ID는 필수입니다")
+    private Long recipientId;
+
+    private Long actorId;
+
+    @NotBlank(message = "알림 타입은 필수입니다")
+    @Size(max = 40, message = "알림 타입은 40자를 초과할 수 없습니다")
+    private String type;
+
+    private List<String> channels;
+
+    @Size(max = 10, message = "locale은 10자를 초과할 수 없습니다")
+    private String locale;
+
+    @Email(message = "유효한 이메일 형식이어야 합니다")
+    @Size(max = 320, message = "이메일은 320자를 초과할 수 없습니다")
+    private String emailTo;
+
+    @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
+    private String title;
+    @Size(max = 2000, message = "메시지는 2000자를 초과할 수 없습니다")
+    private String message;
+
+    @Size(max = 50, message = "referenceType은 50자를 초과할 수 없습니다")
+    private String referenceType;
+    @Size(max = 100, message = "referenceId는 100자를 초과할 수 없습니다")
+    private String referenceId;
+
+    @Size(max = 100, message = "externalEventId는 100자를 초과할 수 없습니다")
+    private String externalEventId;
+    @Size(max = 160, message = "dedupeKey는 160자를 초과할 수 없습니다")
+    private String dedupeKey;
+
+    private Map<String, Object> variables;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/command/response/NotificationDispatchResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/command/response/NotificationDispatchResponse.java
@@ -1,0 +1,43 @@
+package com.example.notification.dto.command.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationDispatchResponse {
+
+    @SnowflakeId
+    private Long notificationId;
+
+    private boolean deduplicated;
+    private String status;
+    private List<String> deliveredChannels;
+    private List<String> failedChannels;
+
+    public static NotificationDispatchResponse deduplicated(Long notificationId, String status) {
+        return NotificationDispatchResponse.builder()
+                .notificationId(notificationId)
+                .deduplicated(true)
+                .status(status)
+                .deliveredChannels(List.of())
+                .failedChannels(List.of())
+                .build();
+    }
+
+    public static NotificationDispatchResponse created(Long notificationId,
+                                                       String status,
+                                                       List<String> deliveredChannels,
+                                                       List<String> failedChannels) {
+        return NotificationDispatchResponse.builder()
+                .notificationId(notificationId)
+                .deduplicated(false)
+                .status(status)
+                .deliveredChannels(deliveredChannels)
+                .failedChannels(failedChannels)
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/command/response/ReadAllResultResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/command/response/ReadAllResultResponse.java
@@ -1,0 +1,17 @@
+package com.example.notification.dto.command.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReadAllResultResponse {
+
+    private int updatedCount;
+
+    public static ReadAllResultResponse of(int updatedCount) {
+        return ReadAllResultResponse.builder()
+                .updatedCount(updatedCount)
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/query/response/NotificationDeliverySummaryResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/query/response/NotificationDeliverySummaryResponse.java
@@ -1,0 +1,34 @@
+package com.example.notification.dto.query.response;
+
+import com.example.notification.entity.NotificationDelivery;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationDeliverySummaryResponse {
+
+    private String channel;
+    private String status;
+    private String provider;
+    private int attemptCount;
+    private String lastErrorCode;
+    private String lastErrorMessage;
+    private LocalDateTime nextRetryAt;
+    private LocalDateTime deliveredAt;
+
+    public static NotificationDeliverySummaryResponse from(NotificationDelivery delivery) {
+        return NotificationDeliverySummaryResponse.builder()
+                .channel(delivery.getChannel().name())
+                .status(delivery.getStatus().name())
+                .provider(delivery.getProvider())
+                .attemptCount(delivery.getAttemptCount())
+                .lastErrorCode(delivery.getLastErrorCode())
+                .lastErrorMessage(delivery.getLastErrorMessage())
+                .nextRetryAt(delivery.getNextRetryAt())
+                .deliveredAt(delivery.getDeliveredAt())
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/query/response/NotificationHistoryItemResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/query/response/NotificationHistoryItemResponse.java
@@ -1,0 +1,53 @@
+package com.example.notification.dto.query.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationDelivery;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationHistoryItemResponse {
+
+    @SnowflakeId
+    private Long id;
+
+    private String type;
+    private String channel;
+    private String title;
+    private String message;
+    private String referenceType;
+    private String referenceId;
+    private boolean read;
+    private LocalDateTime readAt;
+    private LocalDateTime createdAt;
+    @Builder.Default
+    private List<NotificationDeliverySummaryResponse> deliveries = List.of();
+
+    public static NotificationHistoryItemResponse from(Notification notification) {
+        return from(notification, List.of());
+    }
+
+    public static NotificationHistoryItemResponse from(Notification notification,
+                                                       List<NotificationDelivery> deliveries) {
+        return NotificationHistoryItemResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType().name())
+                .channel(notification.getChannel().name())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .referenceType(notification.getReferenceType())
+                .referenceId(notification.getReferenceId())
+                .read(notification.isRead())
+                .readAt(notification.getReadAt())
+                .createdAt(notification.getCreatedAt())
+                .deliveries(deliveries.stream()
+                        .map(NotificationDeliverySummaryResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/query/response/UnreadCountResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/query/response/UnreadCountResponse.java
@@ -1,0 +1,17 @@
+package com.example.notification.dto.query.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UnreadCountResponse {
+
+    private long unreadCount;
+
+    public static UnreadCountResponse of(long unreadCount) {
+        return UnreadCountResponse.builder()
+                .unreadCount(unreadCount)
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/setting/request/UpdateNotificationGlobalPreferenceRequest.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/setting/request/UpdateNotificationGlobalPreferenceRequest.java
@@ -1,0 +1,17 @@
+package com.example.notification.dto.setting.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNotificationGlobalPreferenceRequest {
+
+    private Boolean globalEnabled;
+    private String timezone;
+    private Boolean quietHoursEnabled;
+    private LocalTime quietHoursStart;
+    private LocalTime quietHoursEnd;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/setting/request/UpdateNotificationSettingRequest.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/setting/request/UpdateNotificationSettingRequest.java
@@ -1,0 +1,22 @@
+package com.example.notification.dto.setting.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNotificationSettingRequest {
+
+    @NotBlank(message = "알림 타입은 필수입니다")
+    private String type;
+
+    @NotBlank(message = "알림 채널은 필수입니다")
+    private String channel;
+
+    private Boolean enabled;
+    private LocalDateTime mutedUntil;
+    private Boolean clearMute;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationGlobalPreferenceResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationGlobalPreferenceResponse.java
@@ -1,0 +1,28 @@
+package com.example.notification.dto.setting.response;
+
+import com.example.notification.entity.NotificationUserPreference;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class NotificationGlobalPreferenceResponse {
+
+    private boolean globalEnabled;
+    private String timezone;
+    private boolean quietHoursEnabled;
+    private LocalTime quietHoursStart;
+    private LocalTime quietHoursEnd;
+
+    public static NotificationGlobalPreferenceResponse from(NotificationUserPreference preference) {
+        return NotificationGlobalPreferenceResponse.builder()
+                .globalEnabled(preference.isGlobalEnabled())
+                .timezone(preference.getTimezone())
+                .quietHoursEnabled(preference.isQuietHoursEnabled())
+                .quietHoursStart(preference.getQuietHoursStart())
+                .quietHoursEnd(preference.getQuietHoursEnd())
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationSettingItemResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationSettingItemResponse.java
@@ -1,0 +1,26 @@
+package com.example.notification.dto.setting.response;
+
+import com.example.notification.entity.NotificationSetting;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationSettingItemResponse {
+
+    private String type;
+    private String channel;
+    private boolean enabled;
+    private LocalDateTime mutedUntil;
+
+    public static NotificationSettingItemResponse from(NotificationSetting setting) {
+        return NotificationSettingItemResponse.builder()
+                .type(setting.getType().name())
+                .channel(setting.getChannel().name())
+                .enabled(setting.isEnabled())
+                .mutedUntil(setting.getMutedUntil())
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationSettingsResponse.java
+++ b/servers/services/notification/src/main/java/com/example/notification/dto/setting/response/NotificationSettingsResponse.java
@@ -1,0 +1,22 @@
+package com.example.notification.dto.setting.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationSettingsResponse {
+
+    private NotificationGlobalPreferenceResponse preference;
+    private List<NotificationSettingItemResponse> settings;
+
+    public static NotificationSettingsResponse of(NotificationGlobalPreferenceResponse preference,
+                                                  List<NotificationSettingItemResponse> settings) {
+        return NotificationSettingsResponse.builder()
+                .preference(preference)
+                .settings(settings)
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/Notification.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/Notification.java
@@ -1,0 +1,170 @@
+package com.example.notification.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_recipient_read_id",
+                        columnList = "recipient_id, is_read, id"),
+                @Index(name = "idx_notifications_external_event_id",
+                        columnList = "external_event_id"),
+                @Index(name = "idx_notifications_status", columnList = "status")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notifications_dedupe_key", columnNames = "dedupe_key")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class Notification extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "recipient_id", nullable = false)
+    private Long recipientId;
+
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 40)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, length = 20)
+    private NotificationChannel channel;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "message", nullable = false, length = 2000)
+    private String message;
+
+    @Column(name = "reference_type", length = 50)
+    private String referenceType;
+
+    @Column(name = "reference_id", length = 100)
+    private String referenceId;
+
+    @Column(name = "external_event_id", length = 100)
+    private String externalEventId;
+
+    @Column(name = "dedupe_key", nullable = false, length = 160)
+    private String dedupeKey;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb")
+    private Map<String, Object> payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private NotificationStatus status;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    public static Notification create(Long recipientId,
+                                      Long actorId,
+                                      NotificationType type,
+                                      NotificationChannel channel,
+                                      String title,
+                                      String message,
+                                      String referenceType,
+                                      String referenceId,
+                                      String externalEventId,
+                                      String dedupeKey,
+                                      Map<String, Object> payload) {
+        Notification notification = new Notification();
+        notification.recipientId = recipientId;
+        notification.actorId = actorId;
+        notification.type = type;
+        notification.channel = channel;
+        notification.title = title;
+        notification.message = message;
+        notification.referenceType = referenceType;
+        notification.referenceId = referenceId;
+        notification.externalEventId = externalEventId;
+        notification.dedupeKey = resolveDedupeKey(recipientId, type, externalEventId, referenceType, referenceId, dedupeKey);
+        notification.payload = payload;
+        notification.status = NotificationStatus.CREATED;
+        notification.isRead = false;
+        return notification;
+    }
+
+    public void markAsDispatched() {
+        this.status = NotificationStatus.DISPATCHED;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = NotificationStatus.FAILED;
+    }
+
+    public void markAsRead() {
+        if (this.isRead) {
+            return;
+        }
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+        this.status = NotificationStatus.READ;
+    }
+
+    public void markAsUnread() {
+        this.isRead = false;
+        this.readAt = null;
+        if (this.status == NotificationStatus.READ) {
+            this.status = NotificationStatus.DISPATCHED;
+        }
+    }
+
+    public void archive() {
+        this.status = NotificationStatus.ARCHIVED;
+    }
+
+    private static String resolveDedupeKey(Long recipientId,
+                                           NotificationType type,
+                                           String externalEventId,
+                                           String referenceType,
+                                           String referenceId,
+                                           String dedupeKey) {
+        if (!isBlank(dedupeKey)) {
+            return dedupeKey;
+        }
+
+        String event = isBlank(externalEventId) ? "no-event" : externalEventId;
+        String refType = isBlank(referenceType) ? "no-ref-type" : referenceType;
+        String refId = isBlank(referenceId) ? "no-ref-id" : referenceId;
+        return recipientId + ":" + type.name() + ":" + event + ":" + refType + ":" + refId;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationChannel.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationChannel.java
@@ -1,0 +1,9 @@
+package com.example.notification.entity;
+
+public enum NotificationChannel {
+    IN_APP,
+    EMAIL,
+    SMS,
+    KAKAO,
+    PUSH
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationDelivery.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationDelivery.java
@@ -1,0 +1,151 @@
+package com.example.notification.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_deliveries",
+        indexes = {
+                @Index(name = "idx_notification_deliveries_retry",
+                        columnList = "status, next_retry_at"),
+                @Index(name = "idx_notification_deliveries_notification_id",
+                        columnList = "notification_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notification_deliveries_notification_channel",
+                        columnNames = {"notification_id", "channel"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class NotificationDelivery extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "notification_id", nullable = false)
+    private Long notificationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, length = 20)
+    private NotificationChannel channel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private NotificationDeliveryStatus status;
+
+    @Column(name = "provider", nullable = false, length = 50)
+    private String provider;
+
+    @Column(name = "provider_message_id", length = 100)
+    private String providerMessageId;
+
+    @Column(name = "recipient_address", length = 320)
+    private String recipientAddress;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "last_error_code", length = 50)
+    private String lastErrorCode;
+
+    @Column(name = "last_error_message", length = 500)
+    private String lastErrorMessage;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    public static NotificationDelivery createPending(Long notificationId,
+                                                     NotificationChannel channel,
+                                                     String provider,
+                                                     String recipientAddress) {
+        NotificationDelivery delivery = new NotificationDelivery();
+        delivery.notificationId = notificationId;
+        delivery.channel = channel;
+        delivery.status = NotificationDeliveryStatus.PENDING;
+        delivery.provider = provider;
+        delivery.recipientAddress = recipientAddress;
+        delivery.attemptCount = 0;
+        return delivery;
+    }
+
+    public void markPending() {
+        this.status = NotificationDeliveryStatus.PENDING;
+        this.nextRetryAt = null;
+        this.lastErrorCode = null;
+        this.lastErrorMessage = null;
+    }
+
+    public void markSent(String providerMessageId) {
+        this.status = NotificationDeliveryStatus.SENT;
+        this.providerMessageId = providerMessageId;
+        this.attemptCount += 1;
+        this.nextRetryAt = null;
+    }
+
+    public void updateProvider(String provider) {
+        if (provider != null && !provider.isBlank()) {
+            this.provider = provider;
+        }
+    }
+
+    public void updateRecipientAddress(String recipientAddress) {
+        if (recipientAddress != null && !recipientAddress.isBlank()) {
+            this.recipientAddress = recipientAddress;
+        }
+    }
+
+    public void markDelivered() {
+        this.status = NotificationDeliveryStatus.DELIVERED;
+        this.deliveredAt = LocalDateTime.now();
+        this.nextRetryAt = null;
+    }
+
+    public void markRetry(String errorCode, String errorMessage, LocalDateTime nextRetryAt) {
+        this.status = NotificationDeliveryStatus.RETRYING;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.nextRetryAt = nextRetryAt;
+        this.attemptCount += 1;
+    }
+
+    public void markFailed(String errorCode, String errorMessage) {
+        this.status = NotificationDeliveryStatus.FAILED;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.nextRetryAt = null;
+        this.attemptCount += 1;
+    }
+
+    public void markDropped(String errorCode, String errorMessage) {
+        this.status = NotificationDeliveryStatus.DROPPED;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.nextRetryAt = null;
+    }
+
+    public void markBounced(String errorCode, String errorMessage) {
+        this.status = NotificationDeliveryStatus.BOUNCED;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.nextRetryAt = null;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationDeliveryStatus.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationDeliveryStatus.java
@@ -1,0 +1,11 @@
+package com.example.notification.entity;
+
+public enum NotificationDeliveryStatus {
+    PENDING,
+    SENT,
+    DELIVERED,
+    RETRYING,
+    FAILED,
+    DROPPED,
+    BOUNCED
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationSetting.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationSetting.java
@@ -1,0 +1,85 @@
+package com.example.notification.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_settings",
+        indexes = {
+                @Index(name = "idx_notification_settings_user", columnList = "user_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notification_settings_user_type_channel",
+                        columnNames = {"user_id", "type", "channel"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class NotificationSetting extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 40)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, length = 20)
+    private NotificationChannel channel;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    @Column(name = "muted_until")
+    private LocalDateTime mutedUntil;
+
+    public static NotificationSetting createDefault(Long userId,
+                                                    NotificationType type,
+                                                    NotificationChannel channel,
+                                                    boolean enabled) {
+        NotificationSetting setting = new NotificationSetting();
+        setting.userId = userId;
+        setting.type = type;
+        setting.channel = channel;
+        setting.enabled = enabled;
+        return setting;
+    }
+
+    public void updateEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void muteUntil(LocalDateTime mutedUntil) {
+        this.mutedUntil = mutedUntil;
+    }
+
+    public void unmute() {
+        this.mutedUntil = null;
+    }
+
+    public boolean isEnabledNow() {
+        if (!this.enabled) {
+            return false;
+        }
+        return this.mutedUntil == null || LocalDateTime.now().isAfter(this.mutedUntil);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationStatus.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationStatus.java
@@ -1,0 +1,9 @@
+package com.example.notification.entity;
+
+public enum NotificationStatus {
+    CREATED,
+    DISPATCHED,
+    FAILED,
+    READ,
+    ARCHIVED
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationTemplate.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationTemplate.java
@@ -1,0 +1,90 @@
+package com.example.notification.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "notification_templates",
+        indexes = {
+                @Index(name = "idx_notification_templates_lookup",
+                        columnList = "type, channel, locale, enabled")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notification_templates_type_channel_locale_version",
+                        columnNames = {"type", "channel", "locale", "version"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class NotificationTemplate extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 40)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, length = 20)
+    private NotificationChannel channel;
+
+    @Column(name = "locale", nullable = false, length = 10)
+    private String locale;
+
+    @Column(name = "title_template", nullable = false, length = 200)
+    private String titleTemplate;
+
+    @Column(name = "message_template", nullable = false, length = 2000)
+    private String messageTemplate;
+
+    @Column(name = "version", nullable = false)
+    private int version;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    public static NotificationTemplate create(NotificationType type,
+                                              NotificationChannel channel,
+                                              String locale,
+                                              String titleTemplate,
+                                              String messageTemplate,
+                                              int version,
+                                              boolean enabled) {
+        NotificationTemplate template = new NotificationTemplate();
+        template.type = type;
+        template.channel = channel;
+        template.locale = locale;
+        template.titleTemplate = titleTemplate;
+        template.messageTemplate = messageTemplate;
+        template.version = version;
+        template.enabled = enabled;
+        return template;
+    }
+
+    public void updateContent(String titleTemplate, String messageTemplate) {
+        this.titleTemplate = titleTemplate;
+        this.messageTemplate = messageTemplate;
+    }
+
+    public void activate() {
+        this.enabled = true;
+    }
+
+    public void deactivate() {
+        this.enabled = false;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationType.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationType.java
@@ -1,0 +1,10 @@
+package com.example.notification.entity;
+
+public enum NotificationType {
+    FUNDING_SUCCESS,
+    FUNDING_FAIL,
+    PAYMENT,
+    HOTDEAL,
+    STOCK_DEPLETED,
+    GENERAL
+}

--- a/servers/services/notification/src/main/java/com/example/notification/entity/NotificationUserPreference.java
+++ b/servers/services/notification/src/main/java/com/example/notification/entity/NotificationUserPreference.java
@@ -1,0 +1,109 @@
+package com.example.notification.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "notification_user_preferences",
+        indexes = {
+                @Index(name = "idx_notification_user_preferences_user_id", columnList = "user_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notification_user_preferences_user_id", columnNames = "user_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class NotificationUserPreference extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "global_enabled", nullable = false)
+    private boolean globalEnabled;
+
+    @Column(name = "timezone", nullable = false, length = 50)
+    private String timezone;
+
+    @Column(name = "quiet_hours_enabled", nullable = false)
+    private boolean quietHoursEnabled;
+
+    @Column(name = "quiet_hours_start")
+    private LocalTime quietHoursStart;
+
+    @Column(name = "quiet_hours_end")
+    private LocalTime quietHoursEnd;
+
+    public static NotificationUserPreference createDefault(Long userId) {
+        NotificationUserPreference preference = new NotificationUserPreference();
+        preference.userId = userId;
+        preference.globalEnabled = true;
+        preference.timezone = "Asia/Seoul";
+        preference.quietHoursEnabled = false;
+        preference.quietHoursStart = LocalTime.of(22, 0);
+        preference.quietHoursEnd = LocalTime.of(8, 0);
+        return preference;
+    }
+
+    public void updateGlobalEnabled(boolean globalEnabled) {
+        this.globalEnabled = globalEnabled;
+    }
+
+    public void updateTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public void updateQuietHoursEnabled(boolean quietHoursEnabled) {
+        this.quietHoursEnabled = quietHoursEnabled;
+    }
+
+    public void updateQuietHours(LocalTime quietHoursStart, LocalTime quietHoursEnd) {
+        this.quietHoursStart = quietHoursStart;
+        this.quietHoursEnd = quietHoursEnd;
+    }
+
+    public boolean isInQuietHours(LocalDateTime now) {
+        if (!quietHoursEnabled || quietHoursStart == null || quietHoursEnd == null) {
+            return false;
+        }
+
+        LocalTime localTime = resolveLocalTime(now);
+        if (quietHoursStart.equals(quietHoursEnd)) {
+            return true;
+        }
+        if (quietHoursStart.isBefore(quietHoursEnd)) {
+            return !localTime.isBefore(quietHoursStart) && localTime.isBefore(quietHoursEnd);
+        }
+        return !localTime.isBefore(quietHoursStart) || localTime.isBefore(quietHoursEnd);
+    }
+
+    private LocalTime resolveLocalTime(LocalDateTime now) {
+        ZoneId zoneId;
+        try {
+            zoneId = ZoneId.of(this.timezone);
+        } catch (Exception ignored) {
+            zoneId = ZoneId.systemDefault();
+        }
+        ZonedDateTime zonedDateTime = now.atZone(ZoneId.systemDefault()).withZoneSameInstant(zoneId);
+        return zonedDateTime.toLocalTime();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/event/NotificationDeliveryRequestedEvent.java
+++ b/servers/services/notification/src/main/java/com/example/notification/event/NotificationDeliveryRequestedEvent.java
@@ -1,0 +1,40 @@
+package com.example.notification.event;
+
+import com.example.event.DomainEvent;
+import com.example.notification.entity.NotificationChannel;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class NotificationDeliveryRequestedEvent extends DomainEvent {
+
+    private static final String TOPIC = "notification-delivery-events";
+    private static final String EVENT_TYPE = "NOTIFICATION_DELIVERY_REQUESTED";
+
+    private final Long notificationId;
+    private final String channel;
+    private final String emailTo;
+
+    public NotificationDeliveryRequestedEvent(Long notificationId, NotificationChannel channel, String emailTo) {
+        super(TOPIC);
+        this.notificationId = notificationId;
+        this.channel = channel.name();
+        this.emailTo = emailTo;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return EVENT_TYPE;
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("notificationId", notificationId);
+        payload.put("channel", channel);
+        payload.put("emailTo", emailTo);
+        return payload;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/exception/NotificationErrorCode.java
+++ b/servers/services/notification/src/main/java/com/example/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,34 @@
+package com.example.notification.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements DomainErrorCode {
+
+    // ─── Notification ────────────────────────────────
+    NOTIFICATION_NOT_FOUND("NOTIFICATION-001", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    TEMPLATE_NOT_FOUND("NOTIFICATION-002", "알림 템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_NOTIFICATION_TYPE("NOTIFICATION-003", "유효하지 않은 알림 유형입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CHANNEL("NOTIFICATION-004", "유효하지 않은 알림 채널입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SETTING_REQUEST("NOTIFICATION-005", "알림 설정 변경 요청이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TIMEZONE("NOTIFICATION-006", "유효하지 않은 타임존입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_QUIET_HOURS("NOTIFICATION-007", "유효하지 않은 방해 금지 시간 설정입니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN_RECIPIENT("NOTIFICATION-008", "요청 사용자와 수신자가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    FORBIDDEN_ACTOR("NOTIFICATION-009", "요청 사용자가 행위자를 임의 지정할 수 없습니다.", HttpStatus.FORBIDDEN),
+
+    // ─── Delivery ───────────────────────────────────
+    SSE_DELIVERY_FAILED("NOTIFICATION-201", "SSE 알림 전송에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    EMAIL_DELIVERY_FAILED("NOTIFICATION-202", "이메일 알림 전송에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    SSE_CONNECTION_LIMIT_EXCEEDED("NOTIFICATION-203", "SSE 연결 허용 개수를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS),
+
+    // ─── External Service ───────────────────────────
+    USER_SERVICE_ERROR("NOTIFICATION-301", "유저 서비스 호출에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/repository/NotificationDeliveryRepository.java
+++ b/servers/services/notification/src/main/java/com/example/notification/repository/NotificationDeliveryRepository.java
@@ -1,0 +1,47 @@
+package com.example.notification.repository;
+
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationDeliveryStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface NotificationDeliveryRepository extends JpaRepository<NotificationDelivery, Long> {
+
+    Optional<NotificationDelivery> findByNotificationIdAndChannel(Long notificationId, NotificationChannel channel);
+
+    List<NotificationDelivery> findByNotificationIdOrderByIdAsc(Long notificationId);
+
+    List<NotificationDelivery> findByNotificationIdInOrderByNotificationIdAscIdAsc(List<Long> notificationIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE NotificationDelivery d
+               SET d.nextRetryAt = :leaseUntil
+             WHERE d.id = :deliveryId
+               AND d.status IN :claimableStatuses
+               AND (d.nextRetryAt IS NULL OR d.nextRetryAt <= :now)
+            """)
+    int claimDispatchLock(@Param("deliveryId") Long deliveryId,
+                          @Param("claimableStatuses") Set<NotificationDeliveryStatus> claimableStatuses,
+                          @Param("now") LocalDateTime now,
+                          @Param("leaseUntil") LocalDateTime leaseUntil);
+
+    @Query("""
+            SELECT d
+            FROM NotificationDelivery d
+            WHERE d.status IN :statuses
+              AND (d.nextRetryAt IS NULL OR d.nextRetryAt <= :now)
+            ORDER BY d.id ASC
+            """)
+    List<NotificationDelivery> findDispatchTargets(@Param("statuses") Set<NotificationDeliveryStatus> statuses,
+                                                   @Param("now") LocalDateTime now,
+                                                   org.springframework.data.domain.Pageable pageable);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/repository/NotificationRepository.java
+++ b/servers/services/notification/src/main/java/com/example/notification/repository/NotificationRepository.java
@@ -1,0 +1,46 @@
+package com.example.notification.repository;
+
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("""
+            SELECT n
+            FROM Notification n
+            WHERE n.recipientId = :recipientId
+              AND (:cursorId IS NULL OR n.id < :cursorId)
+            ORDER BY n.id DESC
+            """)
+    List<Notification> findByRecipientIdWithCursor(@Param("recipientId") Long recipientId,
+                                                    @Param("cursorId") Long cursorId,
+                                                    org.springframework.data.domain.Pageable pageable);
+
+    long countByRecipientIdAndIsReadFalse(Long recipientId);
+
+    Optional<Notification> findByDedupeKey(String dedupeKey);
+
+    Optional<Notification> findByIdAndRecipientId(Long id, Long recipientId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE Notification n
+               SET n.isRead = true,
+                   n.readAt = :readAt,
+                   n.status = :status
+             WHERE n.recipientId = :recipientId
+               AND n.isRead = false
+               AND n.deletedAt IS NULL
+            """)
+    int markAllAsRead(@Param("recipientId") Long recipientId,
+                      @Param("readAt") LocalDateTime readAt,
+                      @Param("status") NotificationStatus status);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/repository/NotificationSettingRepository.java
+++ b/servers/services/notification/src/main/java/com/example/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,18 @@
+package com.example.notification.repository;
+
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationSetting;
+import com.example.notification.entity.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    List<NotificationSetting> findByUserId(Long userId);
+
+    Optional<NotificationSetting> findByUserIdAndTypeAndChannel(Long userId,
+                                                                 NotificationType type,
+                                                                 NotificationChannel channel);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/repository/NotificationTemplateRepository.java
+++ b/servers/services/notification/src/main/java/com/example/notification/repository/NotificationTemplateRepository.java
@@ -1,0 +1,17 @@
+package com.example.notification.repository;
+
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationTemplate;
+import com.example.notification.entity.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationTemplateRepository extends JpaRepository<NotificationTemplate, Long> {
+
+    Optional<NotificationTemplate> findTopByTypeAndChannelAndLocaleAndEnabledTrueOrderByVersionDesc(
+            NotificationType type, NotificationChannel channel, String locale);
+
+    List<NotificationTemplate> findByTypeAndLocaleOrderByVersionDesc(NotificationType type, String locale);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/repository/NotificationUserPreferenceRepository.java
+++ b/servers/services/notification/src/main/java/com/example/notification/repository/NotificationUserPreferenceRepository.java
@@ -1,0 +1,11 @@
+package com.example.notification.repository;
+
+import com.example.notification.entity.NotificationUserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationUserPreferenceRepository extends JpaRepository<NotificationUserPreference, Long> {
+
+    Optional<NotificationUserPreference> findByUserId(Long userId);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/command/NotificationActionCommandService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/command/NotificationActionCommandService.java
@@ -1,0 +1,50 @@
+package com.example.notification.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationStatus;
+import com.example.notification.exception.NotificationErrorCode;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationActionCommandService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationUnreadCountService notificationUnreadCountService;
+
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndRecipientId(notificationId, userId)
+                .orElseThrow(() -> new BusinessException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        boolean unreadBefore = !notification.isRead();
+        notification.markAsRead();
+        if (unreadBefore) {
+            notificationUnreadCountService.decreaseSafely(userId, 1);
+        }
+    }
+
+    public int markAllAsRead(Long userId) {
+        int updated = notificationRepository.markAllAsRead(userId, LocalDateTime.now(), NotificationStatus.READ);
+        if (updated > 0) {
+            notificationUnreadCountService.decreaseSafely(userId, updated);
+        }
+        return updated;
+    }
+
+    public void deleteNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndRecipientId(notificationId, userId)
+                .orElseThrow(() -> new BusinessException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        boolean unreadBefore = !notification.isRead();
+        notification.softDelete();
+        if (unreadBefore) {
+            notificationUnreadCountService.decreaseSafely(userId, 1);
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/command/NotificationCommandService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/command/NotificationCommandService.java
@@ -1,0 +1,244 @@
+package com.example.notification.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.dto.command.response.NotificationDispatchResponse;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationTemplate;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.event.NotificationDeliveryRequestedEvent;
+import com.example.notification.exception.NotificationErrorCode;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.content.NotificationContentSanitizer;
+import com.example.notification.service.template.NotificationTemplateResolver;
+import com.example.notification.service.template.TemplateRenderService;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationCommandService {
+
+    private static final String DEFAULT_LOCALE = "ko-KR";
+    private static final int MAX_TITLE_LENGTH = 200;
+    private static final int MAX_MESSAGE_LENGTH = 2000;
+    private static final int MAX_REFERENCE_TYPE_LENGTH = 50;
+    private static final int MAX_REFERENCE_ID_LENGTH = 100;
+    private static final int MAX_EXTERNAL_EVENT_ID_LENGTH = 100;
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationTemplateResolver notificationTemplateResolver;
+    private final TemplateRenderService templateRenderService;
+    private final NotificationContentSanitizer notificationContentSanitizer;
+    private final EventPublisher eventPublisher;
+    private final NotificationUnreadCountService notificationUnreadCountService;
+
+    @Transactional
+    public NotificationDispatchResponse createAndSend(CreateNotificationRequest request, Long requestUserId) {
+        validateRequesterContext(request, requestUserId);
+
+        NotificationType type = parseType(request.getType());
+        List<NotificationChannel> channels = parseChannels(request.getChannels());
+
+        String dedupeKey = resolveDedupeKey(request, type);
+        Optional<Notification> existing = notificationRepository.findByDedupeKey(dedupeKey);
+        if (existing.isPresent()) {
+            publishDeliveryRequests(existing.get(), channels, request.getEmailTo());
+            return NotificationDispatchResponse.deduplicated(existing.get().getId(), existing.get().getStatus().name());
+        }
+
+        NotificationChannel primaryChannel = channels.get(0);
+        Map<String, Object> variables = notificationContentSanitizer.sanitizeVariables(request.getVariables());
+        NotificationTemplate template = resolveTemplate(request, type, primaryChannel);
+
+        String title = sanitizeAndLimit(resolveTitle(request, template, variables), MAX_TITLE_LENGTH);
+        String message = sanitizeAndLimit(resolveMessage(request, template, variables), MAX_MESSAGE_LENGTH);
+        Map<String, Object> payload = copyPayload(variables);
+        String referenceType = sanitizeAndLimit(request.getReferenceType(), MAX_REFERENCE_TYPE_LENGTH);
+        String referenceId = sanitizeAndLimit(request.getReferenceId(), MAX_REFERENCE_ID_LENGTH);
+        String externalEventId = sanitizeAndLimit(request.getExternalEventId(), MAX_EXTERNAL_EVENT_ID_LENGTH);
+
+        Long actorId = resolveActorId(request, requestUserId);
+        Notification notification = Notification.create(
+                request.getRecipientId(),
+                actorId,
+                type,
+                primaryChannel,
+                title,
+                message,
+                referenceType,
+                referenceId,
+                externalEventId,
+                dedupeKey,
+                payload
+        );
+
+        try {
+            notificationRepository.save(notification);
+            notificationUnreadCountService.increase(request.getRecipientId());
+        } catch (DataIntegrityViolationException e) {
+            Notification conflict = notificationRepository.findByDedupeKey(dedupeKey)
+                    .orElseThrow(() -> e);
+            publishDeliveryRequests(conflict, channels, request.getEmailTo());
+            return NotificationDispatchResponse.deduplicated(conflict.getId(), conflict.getStatus().name());
+        }
+
+        publishDeliveryRequests(notification, channels, request.getEmailTo());
+
+        return NotificationDispatchResponse.created(
+                notification.getId(),
+                notification.getStatus().name(),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private void publishDeliveryRequests(Notification notification,
+                                         List<NotificationChannel> channels,
+                                         String emailTo) {
+        for (NotificationChannel channel : channels) {
+            eventPublisher.publish(
+                    new NotificationDeliveryRequestedEvent(notification.getId(), channel, emailTo),
+                    EventMetadata.of("Notification", String.valueOf(notification.getId()))
+            );
+        }
+    }
+
+    private NotificationTemplate resolveTemplate(CreateNotificationRequest request,
+                                                 NotificationType type,
+                                                 NotificationChannel channel) {
+        String locale = request.getLocale() == null || request.getLocale().isBlank()
+                ? DEFAULT_LOCALE
+                : request.getLocale();
+
+        return notificationTemplateResolver.resolve(type, channel, locale)
+                .orElseGet(() -> {
+                    if (hasManualContent(request)) {
+                        return null;
+                    }
+                    throw new BusinessException(NotificationErrorCode.TEMPLATE_NOT_FOUND);
+                });
+    }
+
+    private String resolveTitle(CreateNotificationRequest request,
+                                NotificationTemplate template,
+                                Map<String, Object> variables) {
+        if (request.getTitle() != null && !request.getTitle().isBlank()) {
+            return request.getTitle();
+        }
+        if (template == null) {
+            return "";
+        }
+        return templateRenderService.render(template.getTitleTemplate(), variables);
+    }
+
+    private String resolveMessage(CreateNotificationRequest request,
+                                  NotificationTemplate template,
+                                  Map<String, Object> variables) {
+        if (request.getMessage() != null && !request.getMessage().isBlank()) {
+            return request.getMessage();
+        }
+        if (template == null) {
+            return "";
+        }
+        return templateRenderService.render(template.getMessageTemplate(), variables);
+    }
+
+    private String resolveDedupeKey(CreateNotificationRequest request, NotificationType type) {
+        if (request.getDedupeKey() != null && !request.getDedupeKey().isBlank()) {
+            return request.getDedupeKey();
+        }
+
+        String event = safeOrDefault(request.getExternalEventId(), "no-event");
+        String refType = safeOrDefault(request.getReferenceType(), "no-ref-type");
+        String refId = safeOrDefault(request.getReferenceId(), "no-ref-id");
+        return request.getRecipientId() + ":" + type.name() + ":" + event + ":" + refType + ":" + refId;
+    }
+
+    private Map<String, Object> copyPayload(Map<String, Object> variables) {
+        if (variables == null || variables.isEmpty()) {
+            return null;
+        }
+        return new LinkedHashMap<>(variables);
+    }
+
+    private String sanitizeAndLimit(String value, int maxLength) {
+        String sanitized = notificationContentSanitizer.sanitizeText(value);
+        if (sanitized == null || sanitized.length() <= maxLength) {
+            return sanitized;
+        }
+        return sanitized.substring(0, maxLength);
+    }
+
+    private NotificationType parseType(String rawType) {
+        try {
+            return NotificationType.valueOf(rawType.toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            throw new BusinessException(NotificationErrorCode.INVALID_NOTIFICATION_TYPE);
+        }
+    }
+
+    private List<NotificationChannel> parseChannels(List<String> rawChannels) {
+        if (rawChannels == null || rawChannels.isEmpty()) {
+            return List.of(NotificationChannel.IN_APP);
+        }
+
+        Set<NotificationChannel> uniqueChannels = new LinkedHashSet<>();
+        for (String rawChannel : rawChannels) {
+            try {
+                uniqueChannels.add(NotificationChannel.valueOf(rawChannel.toUpperCase(Locale.ROOT)));
+            } catch (Exception ignored) {
+                throw new BusinessException(NotificationErrorCode.INVALID_CHANNEL);
+            }
+        }
+
+        if (uniqueChannels.isEmpty()) {
+            uniqueChannels.add(NotificationChannel.IN_APP);
+        }
+        return List.copyOf(uniqueChannels);
+    }
+
+    private boolean hasManualContent(CreateNotificationRequest request) {
+        return request.getTitle() != null && !request.getTitle().isBlank()
+                && request.getMessage() != null && !request.getMessage().isBlank();
+    }
+
+    private void validateRequesterContext(CreateNotificationRequest request, Long requestUserId) {
+        if (requestUserId == null) {
+            return;
+        }
+
+        if (!requestUserId.equals(request.getRecipientId())) {
+            throw new BusinessException(NotificationErrorCode.FORBIDDEN_RECIPIENT);
+        }
+
+        if (request.getActorId() != null && !requestUserId.equals(request.getActorId())) {
+            throw new BusinessException(NotificationErrorCode.FORBIDDEN_ACTOR);
+        }
+    }
+
+    private Long resolveActorId(CreateNotificationRequest request, Long requestUserId) {
+        if (requestUserId != null) {
+            return requestUserId;
+        }
+        return request.getActorId();
+    }
+
+    private String safeOrDefault(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/content/NotificationContentSanitizer.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/content/NotificationContentSanitizer.java
@@ -1,0 +1,59 @@
+package com.example.notification.service.content;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class NotificationContentSanitizer {
+
+    public String sanitizeText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = stripUnsafeControlChars(value);
+        return HtmlUtils.htmlEscape(normalized);
+    }
+
+    public Map<String, Object> sanitizeVariables(Map<String, Object> variables) {
+        if (variables == null || variables.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        variables.forEach((key, value) -> sanitized.put(key, sanitizeValue(value)));
+        return sanitized;
+    }
+
+    private Object sanitizeValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String text) {
+            return sanitizeText(text);
+        }
+        if (value instanceof Map<?, ?> mapValue) {
+            Map<String, Object> nested = new LinkedHashMap<>();
+            mapValue.forEach((key, nestedValue) -> nested.put(String.valueOf(key), sanitizeValue(nestedValue)));
+            return nested;
+        }
+        if (value instanceof List<?> listValue) {
+            return listValue.stream().map(this::sanitizeValue).toList();
+        }
+        return value;
+    }
+
+    private String stripUnsafeControlChars(String value) {
+        StringBuilder builder = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '\n' || ch == '\r' || ch == '\t' || ch >= 0x20) {
+                builder.append(ch);
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryCommand.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryCommand.java
@@ -1,0 +1,16 @@
+package com.example.notification.service.delivery;
+
+import com.example.notification.entity.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationDeliveryCommand {
+
+    private Long userId;
+    private NotificationType type;
+    private String title;
+    private String message;
+    private String emailTo;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryRetryScheduler.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryRetryScheduler.java
@@ -1,0 +1,28 @@
+package com.example.notification.service.delivery;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationDeliveryRetryScheduler {
+
+    private final NotificationDeliveryService notificationDeliveryService;
+
+    @Scheduled(fixedDelayString = "${notification.delivery.retry-fixed-delay-ms:5000}")
+    public void retryDispatch() {
+        try {
+            notificationDeliveryService.dispatchRetryTargets();
+        } catch (Exception e) {
+            Counter.builder("notification.delivery.retry.scheduler.errors.total")
+                    .register(Metrics.globalRegistry)
+                    .increment();
+            log.warn("Notification delivery retry scheduler failed", e);
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/delivery/NotificationDeliveryService.java
@@ -1,0 +1,345 @@
+package com.example.notification.service.delivery;
+
+import com.example.notification.config.NotificationDeliveryProperties;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationDeliveryStatus;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.email.EmailSendResult;
+import com.example.notification.service.email.NotificationEmailService;
+import com.example.notification.service.realtime.SseEventPublisher;
+import com.example.notification.service.realtime.SseNotificationEvent;
+import com.example.notification.service.setting.NotificationSettingService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationDeliveryService {
+
+    private static final String CODE_DISABLED_BY_POLICY = "DISABLED_BY_POLICY";
+    private static final String CODE_MISSING_EMAIL = "MISSING_EMAIL";
+    private static final String CODE_NOT_IMPLEMENTED = "NOT_IMPLEMENTED";
+    private static final String CODE_EMAIL_FAILED = "EMAIL_SEND_FAILED";
+    private static final String CODE_EMAIL_SKIPPED = "EMAIL_SKIPPED";
+    private static final String CODE_SSE_FAILED = "SSE_SEND_FAILED";
+    private static final String CODE_NOTIFICATION_NOT_FOUND = "NOTIFICATION_NOT_FOUND";
+    private static final Set<NotificationDeliveryStatus> CLAIMABLE_STATUSES = Set.of(
+            NotificationDeliveryStatus.PENDING,
+            NotificationDeliveryStatus.RETRYING
+    );
+
+    private final NotificationDeliveryRepository notificationDeliveryRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationSettingService notificationSettingService;
+    private final NotificationEmailService notificationEmailService;
+    private final SseEventPublisher sseEventPublisher;
+    private final NotificationDeliveryProperties notificationDeliveryProperties;
+
+    public NotificationDelivery deliver(Notification notification,
+                                        NotificationChannel channel,
+                                        NotificationDeliveryCommand command) {
+        NotificationDelivery prepared = prepareDelivery(notification.getId(), channel, command.getEmailTo());
+        if (isTerminal(prepared.getStatus())) {
+            return prepared;
+        }
+        return dispatchExisting(prepared.getId());
+    }
+
+    public List<NotificationDelivery> dispatchPendingByNotificationId(Long notificationId, String fallbackEmailTo) {
+        List<NotificationDelivery> deliveries = notificationDeliveryRepository.findByNotificationIdOrderByIdAsc(notificationId);
+        if (deliveries.isEmpty()) {
+            return List.of();
+        }
+
+        List<NotificationDelivery> dispatched = new ArrayList<>();
+        for (NotificationDelivery delivery : deliveries) {
+            if (isTerminal(delivery.getStatus())) {
+                continue;
+            }
+            if (delivery.getStatus() == NotificationDeliveryStatus.FAILED
+                    && delivery.getAttemptCount() >= maxAttempts()) {
+                continue;
+            }
+
+            NotificationDelivery prepared = prepareDelivery(
+                    delivery.getNotificationId(),
+                    delivery.getChannel(),
+                    hasText(delivery.getRecipientAddress()) ? delivery.getRecipientAddress() : fallbackEmailTo
+            );
+            dispatched.add(dispatchExisting(prepared.getId()));
+        }
+        return dispatched;
+    }
+
+    public void dispatchRetryTargets() {
+        Set<NotificationDeliveryStatus> statuses = Set.of(
+                NotificationDeliveryStatus.PENDING,
+                NotificationDeliveryStatus.RETRYING
+        );
+        List<NotificationDelivery> targets = notificationDeliveryRepository.findDispatchTargets(
+                statuses,
+                LocalDateTime.now(),
+                PageRequest.of(0, Math.max(1, notificationDeliveryProperties.getRetryBatchSize()))
+        );
+        for (NotificationDelivery target : targets) {
+            dispatchExisting(target.getId());
+        }
+    }
+
+    public NotificationDelivery dispatchExisting(Long deliveryId) {
+        NotificationDelivery delivery = notificationDeliveryRepository.findById(deliveryId).orElse(null);
+        if (delivery == null) {
+            return null;
+        }
+        if (isTerminal(delivery.getStatus())) {
+            return delivery;
+        }
+        if (!claimDeliveryForDispatch(deliveryId)) {
+            return notificationDeliveryRepository.findById(deliveryId).orElse(null);
+        }
+        delivery = notificationDeliveryRepository.findById(deliveryId).orElse(null);
+        if (delivery == null) {
+            return null;
+        }
+
+        Notification notification = notificationRepository.findById(delivery.getNotificationId()).orElse(null);
+        if (notification == null) {
+            return applyOutcome(deliveryId, DeliveryOutcome.dropped(
+                    delivery.getProvider(),
+                    CODE_NOTIFICATION_NOT_FOUND,
+                    "notification not found"
+            ));
+        }
+
+        NotificationDeliveryCommand command = NotificationDeliveryCommand.builder()
+                .userId(notification.getRecipientId())
+                .type(notification.getType())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .emailTo(delivery.getRecipientAddress())
+                .build();
+
+        DeliveryOutcome outcome = send(notification, delivery.getChannel(), command, delivery.getId());
+        return applyOutcome(delivery.getId(), outcome);
+    }
+
+    @Transactional
+    protected NotificationDelivery prepareDelivery(Long notificationId,
+                                                   NotificationChannel channel,
+                                                   String emailTo) {
+        NotificationDelivery delivery = notificationDeliveryRepository
+                .findByNotificationIdAndChannel(notificationId, channel)
+                .orElseGet(() -> NotificationDelivery.createPending(notificationId, channel, channel.name(), emailTo));
+
+        delivery.updateRecipientAddress(emailTo);
+
+        if (!isTerminal(delivery.getStatus()) && !isClaimLocked(delivery)) {
+            delivery.markPending();
+        }
+        return notificationDeliveryRepository.save(delivery);
+    }
+
+    private DeliveryOutcome send(Notification notification,
+                                 NotificationChannel channel,
+                                 NotificationDeliveryCommand command,
+                                 Long deliveryId) {
+        if (!notificationSettingService.shouldSendNotification(command.getUserId(), command.getType(), channel)) {
+            return DeliveryOutcome.dropped(channel.name(), CODE_DISABLED_BY_POLICY, "notification disabled by preference");
+        }
+
+        return switch (channel) {
+            case IN_APP -> sendInApp(notification, deliveryId);
+            case EMAIL -> sendEmail(command, channel.name());
+            case SMS, KAKAO, PUSH -> DeliveryOutcome.dropped(
+                    channel.name(),
+                    CODE_NOT_IMPLEMENTED,
+                    "channel delivery not implemented yet"
+            );
+        };
+    }
+
+    private DeliveryOutcome sendInApp(Notification notification, Long deliveryId) {
+        try {
+            sseEventPublisher.publish(SseNotificationEvent.from(notification));
+            return DeliveryOutcome.delivered("IN_APP", "IN_APP:" + deliveryId);
+        } catch (Exception e) {
+            return DeliveryOutcome.failed("IN_APP", CODE_SSE_FAILED, safeMessage(e), true);
+        }
+    }
+
+    private DeliveryOutcome sendEmail(NotificationDeliveryCommand command, String defaultProvider) {
+        if (!hasText(command.getEmailTo())) {
+            return DeliveryOutcome.dropped(defaultProvider, CODE_MISSING_EMAIL, "email recipient is empty");
+        }
+
+        EmailSendResult emailResult = notificationEmailService.send(
+                command.getUserId(),
+                command.getType(),
+                command.getEmailTo(),
+                command.getTitle(),
+                command.getMessage(),
+                null
+        );
+
+        String provider = hasText(emailResult.getProvider()) ? emailResult.getProvider() : defaultProvider;
+        if (emailResult.isSuccess()) {
+            return DeliveryOutcome.delivered(provider, emailResult.getMessageId());
+        }
+        if (emailResult.isSkipped()) {
+            return DeliveryOutcome.dropped(provider, CODE_EMAIL_SKIPPED, emailResult.getErrorMessage());
+        }
+        return DeliveryOutcome.failed(provider, CODE_EMAIL_FAILED, emailResult.getErrorMessage(), true);
+    }
+
+    @Transactional
+    protected NotificationDelivery applyOutcome(Long deliveryId, DeliveryOutcome outcome) {
+        NotificationDelivery delivery = notificationDeliveryRepository.findById(deliveryId).orElse(null);
+        if (delivery == null) {
+            return null;
+        }
+
+        delivery.updateProvider(outcome.provider());
+        switch (outcome.status()) {
+            case DELIVERED -> {
+                delivery.markSent(outcome.providerMessageId());
+                delivery.markDelivered();
+            }
+            case DROPPED -> {
+                delivery.markDropped(outcome.errorCode(), outcome.errorMessage());
+                incrementCounter("notification.delivery.dropped.total", delivery, outcome.errorCode());
+            }
+            case FAILED -> {
+                applyFailure(delivery, outcome);
+                if (delivery.getStatus() == NotificationDeliveryStatus.FAILED) {
+                    log.error("Notification delivery permanently failed. deliveryId={}, notificationId={}, channel={}, attempts={}, errorCode={}, errorMessage={}",
+                            delivery.getId(),
+                            delivery.getNotificationId(),
+                            delivery.getChannel(),
+                            delivery.getAttemptCount(),
+                            outcome.errorCode(),
+                            outcome.errorMessage());
+                    incrementCounter("notification.delivery.failed.total", delivery, outcome.errorCode());
+                } else {
+                    incrementCounter("notification.delivery.retry.scheduled.total", delivery, outcome.errorCode());
+                }
+            }
+        }
+        return notificationDeliveryRepository.save(delivery);
+    }
+
+    private void applyFailure(NotificationDelivery delivery, DeliveryOutcome outcome) {
+        int nextAttempt = delivery.getAttemptCount() + 1;
+        if (outcome.retryable() && nextAttempt < maxAttempts()) {
+            delivery.markRetry(outcome.errorCode(), outcome.errorMessage(), calculateNextRetryAt(nextAttempt));
+            return;
+        }
+        delivery.markFailed(outcome.errorCode(), outcome.errorMessage());
+    }
+
+    private LocalDateTime calculateNextRetryAt(int nextAttempt) {
+        long delay = Math.max(1, notificationDeliveryProperties.getInitialBackoffSeconds());
+        int multiplier = Math.max(1, notificationDeliveryProperties.getBackoffMultiplier());
+        for (int i = 1; i < nextAttempt; i++) {
+            delay = Math.min(delay * multiplier, 24L * 60L * 60L);
+        }
+        return LocalDateTime.now().plusSeconds(delay);
+    }
+
+    private int maxAttempts() {
+        return Math.max(1, notificationDeliveryProperties.getMaxAttempts());
+    }
+
+    @Transactional
+    protected boolean claimDeliveryForDispatch(Long deliveryId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime leaseUntil = now.plusSeconds(Math.max(1, notificationDeliveryProperties.getClaimLeaseSeconds()));
+        return notificationDeliveryRepository.claimDispatchLock(
+                deliveryId,
+                CLAIMABLE_STATUSES,
+                now,
+                leaseUntil
+        ) > 0;
+    }
+
+    private boolean isTerminal(NotificationDeliveryStatus status) {
+        return status == NotificationDeliveryStatus.DELIVERED
+                || status == NotificationDeliveryStatus.DROPPED;
+    }
+
+    private boolean isClaimLocked(NotificationDelivery delivery) {
+        if (!CLAIMABLE_STATUSES.contains(delivery.getStatus())) {
+            return false;
+        }
+        LocalDateTime nextRetryAt = delivery.getNextRetryAt();
+        return nextRetryAt != null && nextRetryAt.isAfter(LocalDateTime.now());
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String safeMessage(Throwable throwable) {
+        if (throwable == null || throwable.getMessage() == null || throwable.getMessage().isBlank()) {
+            return throwable == null ? "unknown error" : throwable.getClass().getSimpleName();
+        }
+        String message = throwable.getMessage();
+        return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    private void incrementCounter(String metricName, NotificationDelivery delivery, String errorCode) {
+        Counter.builder(metricName)
+                .tag("channel", delivery.getChannel().name())
+                .tag("provider", safeTagValue(delivery.getProvider(), "UNKNOWN"))
+                .tag("error_code", safeTagValue(errorCode, "NONE"))
+                .register(Metrics.globalRegistry)
+                .increment();
+    }
+
+    private String safeTagValue(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.length() > 64 ? value.substring(0, 64) : value;
+    }
+
+    private record DeliveryOutcome(
+            DeliveryStatus status,
+            String provider,
+            String providerMessageId,
+            String errorCode,
+            String errorMessage,
+            boolean retryable
+    ) {
+        private static DeliveryOutcome delivered(String provider, String providerMessageId) {
+            return new DeliveryOutcome(DeliveryStatus.DELIVERED, provider, providerMessageId, null, null, false);
+        }
+
+        private static DeliveryOutcome dropped(String provider, String errorCode, String errorMessage) {
+            return new DeliveryOutcome(DeliveryStatus.DROPPED, provider, null, errorCode, errorMessage, false);
+        }
+
+        private static DeliveryOutcome failed(String provider, String errorCode, String errorMessage, boolean retryable) {
+            return new DeliveryOutcome(DeliveryStatus.FAILED, provider, null, errorCode, errorMessage, retryable);
+        }
+    }
+
+    private enum DeliveryStatus {
+        DELIVERED,
+        DROPPED,
+        FAILED
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/EmailProviderType.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/EmailProviderType.java
@@ -1,0 +1,6 @@
+package com.example.notification.service.email;
+
+public enum EmailProviderType {
+    SMTP,
+    SES
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSendCommand.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSendCommand.java
@@ -1,0 +1,14 @@
+package com.example.notification.service.email;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailSendCommand {
+
+    private String to;
+    private String subject;
+    private String textBody;
+    private String htmlBody;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSendResult.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSendResult.java
@@ -1,0 +1,42 @@
+package com.example.notification.service.email;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailSendResult {
+
+    private boolean success;
+    private boolean skipped;
+    private String provider;
+    private String messageId;
+    private String errorMessage;
+
+    public static EmailSendResult success(String provider, String messageId) {
+        return EmailSendResult.builder()
+                .success(true)
+                .skipped(false)
+                .provider(provider)
+                .messageId(messageId)
+                .build();
+    }
+
+    public static EmailSendResult failure(String provider, String errorMessage) {
+        return EmailSendResult.builder()
+                .success(false)
+                .skipped(false)
+                .provider(provider)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    public static EmailSendResult skipped(String provider, String reason) {
+        return EmailSendResult.builder()
+                .success(false)
+                .skipped(true)
+                .provider(provider)
+                .errorMessage(reason)
+                .build();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSender.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSender.java
@@ -1,0 +1,6 @@
+package com.example.notification.service.email;
+
+public interface EmailSender {
+
+    EmailSendResult send(EmailSendCommand command);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSenderStrategy.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/EmailSenderStrategy.java
@@ -1,0 +1,8 @@
+package com.example.notification.service.email;
+
+public interface EmailSenderStrategy {
+
+    EmailProviderType providerType();
+
+    EmailSendResult send(EmailSendCommand command);
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/NotificationEmailService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/NotificationEmailService.java
@@ -1,0 +1,39 @@
+package com.example.notification.service.email;
+
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.service.setting.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationEmailService {
+
+    private final EmailSender emailSender;
+    private final NotificationSettingService notificationSettingService;
+
+    public EmailSendResult send(Long userId,
+                                NotificationType type,
+                                String to,
+                                String subject,
+                                String textBody,
+                                String htmlBody) {
+        boolean allowed = notificationSettingService.shouldSendNotification(
+                userId, type, NotificationChannel.EMAIL
+        );
+        if (!allowed) {
+            log.info("Email notification skipped by user settings. userId={}, type={}", userId, type);
+            return EmailSendResult.skipped("POLICY", "disabled by user preference");
+        }
+
+        return emailSender.send(EmailSendCommand.builder()
+                .to(to)
+                .subject(subject)
+                .textBody(textBody)
+                .htmlBody(htmlBody)
+                .build());
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/RoutingEmailSender.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/RoutingEmailSender.java
@@ -1,0 +1,70 @@
+package com.example.notification.service.email;
+
+import com.example.notification.config.NotificationEmailProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class RoutingEmailSender implements EmailSender {
+
+    private final NotificationEmailProperties properties;
+    private final List<EmailSenderStrategy> strategies;
+    private final Map<EmailProviderType, EmailSenderStrategy> strategyMap = new EnumMap<>(EmailProviderType.class);
+
+    @PostConstruct
+    void initializeStrategyMap() {
+        for (EmailSenderStrategy strategy : strategies) {
+            EmailSenderStrategy previous = strategyMap.put(strategy.providerType(), strategy);
+            if (previous != null) {
+                throw new IllegalStateException("Duplicate email strategy for provider: " + strategy.providerType());
+            }
+        }
+    }
+
+    @Override
+    public EmailSendResult send(EmailSendCommand command) {
+        EmailProviderType primary = properties.getProvider();
+        EmailSendResult primaryResult = sendVia(primary, command);
+        if (primaryResult.isSuccess() || primaryResult.isSkipped()) {
+            return primaryResult;
+        }
+
+        if (!properties.isFallbackEnabled()) {
+            return primaryResult;
+        }
+
+        EmailProviderType fallback = properties.getFallbackProvider();
+        if (fallback == null || fallback == primary) {
+            return primaryResult;
+        }
+
+        EmailSendResult fallbackResult = sendVia(fallback, command);
+        if (fallbackResult.isSuccess() || fallbackResult.isSkipped()) {
+            return fallbackResult;
+        }
+
+        log.warn("Email send failed on both providers. primary={}, fallback={}", primary, fallback);
+        return EmailSendResult.failure(
+                primary.name(),
+                "primary=" + primaryResult.getErrorMessage() + ", fallback=" + fallbackResult.getErrorMessage()
+        );
+    }
+
+    private EmailSendResult sendVia(EmailProviderType providerType, EmailSendCommand command) {
+        EmailSenderStrategy strategy = strategyMap.get(providerType);
+        if (strategy == null) {
+            return EmailSendResult.failure(providerType.name(), "email strategy not configured");
+        }
+        return strategy.send(command);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/SesEmailSender.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/SesEmailSender.java
@@ -1,0 +1,76 @@
+package com.example.notification.service.email;
+
+import com.example.notification.config.NotificationEmailProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.Body;
+import software.amazon.awssdk.services.ses.model.Content;
+import software.amazon.awssdk.services.ses.model.Destination;
+import software.amazon.awssdk.services.ses.model.Message;
+import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SendEmailResponse;
+import software.amazon.awssdk.services.ses.model.SesException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SesEmailSender implements EmailSenderStrategy {
+
+    private final SesClient sesClient;
+    private final NotificationEmailProperties notificationEmailProperties;
+
+    @Override
+    public EmailProviderType providerType() {
+        return EmailProviderType.SES;
+    }
+
+    @Override
+    public EmailSendResult send(EmailSendCommand command) {
+        try {
+            Content subject = Content.builder()
+                    .data(command.getSubject())
+                    .charset("UTF-8")
+                    .build();
+
+            Body.Builder bodyBuilder = Body.builder();
+            if (command.getTextBody() != null && !command.getTextBody().isBlank()) {
+                bodyBuilder.text(Content.builder()
+                        .data(command.getTextBody())
+                        .charset("UTF-8")
+                        .build());
+            }
+            if (command.getHtmlBody() != null && !command.getHtmlBody().isBlank()) {
+                bodyBuilder.html(Content.builder()
+                        .data(command.getHtmlBody())
+                        .charset("UTF-8")
+                        .build());
+            }
+
+            SendEmailRequest.Builder requestBuilder = SendEmailRequest.builder()
+                    .source(notificationEmailProperties.getFromAddress())
+                    .destination(Destination.builder().toAddresses(command.getTo()).build())
+                    .message(Message.builder()
+                            .subject(subject)
+                            .body(bodyBuilder.build())
+                            .build());
+
+            String configurationSet = notificationEmailProperties.getConfigurationSet();
+            if (configurationSet != null && !configurationSet.isBlank()) {
+                requestBuilder.configurationSetName(configurationSet);
+            }
+
+            SendEmailResponse response = sesClient.sendEmail(requestBuilder.build());
+            return EmailSendResult.success("SES", response.messageId());
+        } catch (SesException e) {
+            log.error("SES email send failed: to={}, subject={}", command.getTo(), command.getSubject(), e);
+            return EmailSendResult.failure("SES", e.awsErrorDetails() == null
+                    ? e.getMessage()
+                    : e.awsErrorDetails().errorMessage());
+        } catch (Exception e) {
+            log.error("SES email send failed: to={}, subject={}", command.getTo(), command.getSubject(), e);
+            return EmailSendResult.failure("SES", e.getMessage());
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/SmtpEmailSender.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/SmtpEmailSender.java
@@ -1,0 +1,51 @@
+package com.example.notification.service.email;
+
+import com.example.notification.config.NotificationEmailProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmtpEmailSender implements EmailSenderStrategy {
+
+    private final JavaMailSender javaMailSender;
+    private final NotificationEmailProperties notificationEmailProperties;
+
+    @Override
+    public EmailProviderType providerType() {
+        return EmailProviderType.SMTP;
+    }
+
+    @Override
+    public EmailSendResult send(EmailSendCommand command) {
+        try {
+            var mimeMessage = javaMailSender.createMimeMessage();
+            var helper = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.name());
+            helper.setTo(command.getTo());
+            helper.setSubject(command.getSubject());
+            if (notificationEmailProperties.getFromAddress() != null
+                    && !notificationEmailProperties.getFromAddress().isBlank()) {
+                helper.setFrom(notificationEmailProperties.getFromAddress());
+            }
+
+            String textBody = command.getTextBody() == null ? "" : command.getTextBody();
+            if (command.getHtmlBody() != null && !command.getHtmlBody().isBlank()) {
+                helper.setText(textBody, command.getHtmlBody());
+            } else {
+                helper.setText(textBody, false);
+            }
+
+            javaMailSender.send(mimeMessage);
+            return EmailSendResult.success("SMTP", mimeMessage.getMessageID());
+        } catch (Exception e) {
+            log.error("SMTP email send failed: to={}, subject={}", command.getTo(), command.getSubject(), e);
+            return EmailSendResult.failure("SMTP", e.getMessage());
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/query/NotificationQueryService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/query/NotificationQueryService.java
@@ -1,0 +1,70 @@
+package com.example.notification.service.query;
+
+import com.example.core.pagination.CursorResponse;
+import com.example.core.pagination.CursorUtils;
+import com.example.notification.dto.query.response.NotificationHistoryItemResponse;
+import com.example.notification.dto.query.response.UnreadCountResponse;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationDeliveryRepository notificationDeliveryRepository;
+    private final NotificationUnreadCountService notificationUnreadCountService;
+
+    public CursorResponse<NotificationHistoryItemResponse> findMyNotifications(Long userId, String cursor, int size) {
+        Long cursorId = CursorUtils.decodeLong(cursor);
+        PageRequest pageable = PageRequest.of(0, size + 1);
+
+        List<Notification> notifications = notificationRepository.findByRecipientIdWithCursor(userId, cursorId, pageable);
+        boolean hasNext = notifications.size() > size;
+        List<Notification> pageItems = hasNext ? notifications.subList(0, size) : notifications;
+
+        Map<Long, List<NotificationDelivery>> deliveriesByNotificationId = loadDeliveries(pageItems);
+        List<NotificationHistoryItemResponse> items = pageItems.stream()
+                .map(notification -> NotificationHistoryItemResponse.from(
+                        notification,
+                        deliveriesByNotificationId.getOrDefault(notification.getId(), List.of())
+                ))
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId())
+                : null;
+        return CursorResponse.of(items, nextCursor);
+    }
+
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        long unreadCount = notificationUnreadCountService.getOrLoad(userId);
+        return UnreadCountResponse.of(unreadCount);
+    }
+
+    private Map<Long, List<NotificationDelivery>> loadDeliveries(List<Notification> notifications) {
+        if (notifications == null || notifications.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<Long> notificationIds = notifications.stream()
+                .map(Notification::getId)
+                .toList();
+        List<NotificationDelivery> deliveries = notificationDeliveryRepository
+                .findByNotificationIdInOrderByNotificationIdAscIdAsc(notificationIds);
+        return deliveries.stream()
+                .collect(Collectors.groupingBy(NotificationDelivery::getNotificationId));
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseConnectionManager.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseConnectionManager.java
@@ -1,0 +1,118 @@
+package com.example.notification.service.realtime;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.config.NotificationSseProperties;
+import com.example.notification.exception.NotificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseConnectionManager {
+
+    private static final long SSE_TIMEOUT_MS = 30L * 60L * 1000L;
+    private static final String CONNECT_EVENT = "connected";
+    private static final String NOTIFICATION_EVENT = "notification";
+    private static final String HEARTBEAT_EVENT = "heartbeat";
+
+    private final NotificationSseProperties sseProperties;
+    private final Map<Long, Map<String, SseEmitter>> userEmitters = new ConcurrentHashMap<>();
+    private final AtomicInteger totalConnections = new AtomicInteger(0);
+
+    public SseEmitter connect(Long userId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MS);
+        String connectionId = buildConnectionId(userId);
+        Map<String, SseEmitter> emitters = userEmitters.computeIfAbsent(userId, ignored -> new ConcurrentHashMap<>());
+
+        synchronized (this) {
+            int maxPerUser = Math.max(1, sseProperties.getMaxConnectionsPerUser());
+            int maxTotal = Math.max(1, sseProperties.getMaxTotalConnections());
+
+            if (emitters.size() >= maxPerUser || totalConnections.get() >= maxTotal) {
+                throw new BusinessException(NotificationErrorCode.SSE_CONNECTION_LIMIT_EXCEEDED);
+            }
+            emitters.put(connectionId, emitter);
+            totalConnections.incrementAndGet();
+        }
+
+        emitter.onCompletion(() -> disconnect(userId, connectionId));
+        emitter.onTimeout(() -> disconnect(userId, connectionId));
+        emitter.onError(ignored -> disconnect(userId, connectionId));
+
+        sendEvent(userId, connectionId, emitter, CONNECT_EVENT, Map.of(
+                "connectionId", connectionId,
+                "connectedAt", LocalDateTime.now().toString()
+        ));
+        return emitter;
+    }
+
+    public void publishToUser(SseNotificationEvent event) {
+        if (event == null || event.getUserId() == null) {
+            return;
+        }
+        Map<String, SseEmitter> emitters = userEmitters.get(event.getUserId());
+        if (emitters == null || emitters.isEmpty()) {
+            return;
+        }
+
+        emitters.forEach((connectionId, emitter) ->
+                sendEvent(event.getUserId(), connectionId, emitter, NOTIFICATION_EVENT, event));
+    }
+
+    public void publishHeartbeat() {
+        if (userEmitters.isEmpty()) {
+            return;
+        }
+        userEmitters.forEach((userId, emitters) -> emitters.forEach((connectionId, emitter) ->
+                sendEvent(userId, connectionId, emitter, HEARTBEAT_EVENT, LocalDateTime.now().toString())));
+    }
+
+    public int connectionCount(Long userId) {
+        Map<String, SseEmitter> emitters = userEmitters.get(userId);
+        return emitters == null ? 0 : emitters.size();
+    }
+
+    public int totalConnectionCount() {
+        return totalConnections.get();
+    }
+
+    private void sendEvent(Long userId, String connectionId, SseEmitter emitter, String eventName, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(connectionId)
+                    .name(eventName)
+                    .data(data));
+        } catch (IOException e) {
+            log.debug("SSE send failed. userId={}, connectionId={}, event={}", userId, connectionId, eventName, e);
+            disconnect(userId, connectionId);
+        }
+    }
+
+    private void disconnect(Long userId, String connectionId) {
+        Map<String, SseEmitter> emitters = userEmitters.get(userId);
+        if (emitters == null) {
+            return;
+        }
+        SseEmitter removed = emitters.remove(connectionId);
+        if (removed != null) {
+            totalConnections.updateAndGet(value -> value > 0 ? value - 1 : 0);
+        }
+        if (emitters.isEmpty()) {
+            userEmitters.remove(userId);
+        }
+    }
+
+    private String buildConnectionId(Long userId) {
+        return userId + ":" + UUID.randomUUID();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseEventPublisher.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseEventPublisher.java
@@ -1,0 +1,36 @@
+package com.example.notification.service.realtime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseEventPublisher {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final SseConnectionManager sseConnectionManager;
+
+    @Value("${notification.sse.topic:sse-notifications}")
+    private String sseTopic;
+
+    public void publish(SseNotificationEvent event) {
+        if (event == null || event.getUserId() == null) {
+            return;
+        }
+
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            stringRedisTemplate.convertAndSend(sseTopic, payload);
+        } catch (Exception e) {
+            log.warn("SSE redis publish failed. fallback local publish. topic={}, userId={}",
+                    sseTopic, event.getUserId(), e);
+            sseConnectionManager.publishToUser(event);
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseHeartbeatScheduler.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseHeartbeatScheduler.java
@@ -1,0 +1,17 @@
+package com.example.notification.service.realtime;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SseHeartbeatScheduler {
+
+    private final SseConnectionManager sseConnectionManager;
+
+    @Scheduled(fixedDelayString = "${notification.sse.heartbeat-ms:10000}")
+    public void publishHeartbeat() {
+        sseConnectionManager.publishHeartbeat();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseNotificationEvent.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseNotificationEvent.java
@@ -1,0 +1,66 @@
+package com.example.notification.service.realtime;
+
+import com.example.notification.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.util.HtmlUtils;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class SseNotificationEvent {
+
+    private Long userId;
+    private Long notificationId;
+    private String type;
+    private String title;
+    private String message;
+    private String referenceType;
+    private String referenceId;
+    private String status;
+    private LocalDateTime occurredAt;
+
+    @Builder
+    private SseNotificationEvent(Long userId,
+                                 Long notificationId,
+                                 String type,
+                                 String title,
+                                 String message,
+                                 String referenceType,
+                                 String referenceId,
+                                 String status,
+                                 LocalDateTime occurredAt) {
+        this.userId = userId;
+        this.notificationId = notificationId;
+        this.type = type;
+        this.title = title;
+        this.message = message;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.status = status;
+        this.occurredAt = occurredAt;
+    }
+
+    public static SseNotificationEvent from(Notification notification) {
+        return SseNotificationEvent.builder()
+                .userId(notification.getRecipientId())
+                .notificationId(notification.getId())
+                .type(notification.getType().name())
+                .title(sanitize(notification.getTitle()))
+                .message(sanitize(notification.getMessage()))
+                .referenceType(sanitize(notification.getReferenceType()))
+                .referenceId(sanitize(notification.getReferenceId()))
+                .status(notification.getStatus().name())
+                .occurredAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        return HtmlUtils.htmlEscape(value);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseRedisSubscriber.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/realtime/SseRedisSubscriber.java
@@ -1,0 +1,30 @@
+package com.example.notification.service.realtime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseRedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final SseConnectionManager sseConnectionManager;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String payload = new String(message.getBody(), StandardCharsets.UTF_8);
+            SseNotificationEvent event = objectMapper.readValue(payload, SseNotificationEvent.class);
+            sseConnectionManager.publishToUser(event);
+        } catch (Exception e) {
+            log.warn("Failed to consume SSE redis message", e);
+        }
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/setting/NotificationSettingPolicy.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/setting/NotificationSettingPolicy.java
@@ -1,0 +1,26 @@
+package com.example.notification.service.setting;
+
+import com.example.notification.entity.NotificationChannel;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class NotificationSettingPolicy {
+
+    private static final List<NotificationChannel> SUPPORTED_CHANNELS = List.of(
+            NotificationChannel.IN_APP,
+            NotificationChannel.EMAIL,
+            NotificationChannel.SMS,
+            NotificationChannel.KAKAO,
+            NotificationChannel.PUSH
+    );
+
+    public List<NotificationChannel> supportedChannels() {
+        return SUPPORTED_CHANNELS;
+    }
+
+    public boolean isDefaultEnabled(NotificationChannel channel) {
+        return channel == NotificationChannel.IN_APP || channel == NotificationChannel.EMAIL;
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/setting/NotificationSettingService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/setting/NotificationSettingService.java
@@ -1,0 +1,208 @@
+package com.example.notification.service.setting;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.dto.setting.request.UpdateNotificationGlobalPreferenceRequest;
+import com.example.notification.dto.setting.request.UpdateNotificationSettingRequest;
+import com.example.notification.dto.setting.response.NotificationGlobalPreferenceResponse;
+import com.example.notification.dto.setting.response.NotificationSettingItemResponse;
+import com.example.notification.dto.setting.response.NotificationSettingsResponse;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationSetting;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.entity.NotificationUserPreference;
+import com.example.notification.exception.NotificationErrorCode;
+import com.example.notification.repository.NotificationSettingRepository;
+import com.example.notification.repository.NotificationUserPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final NotificationUserPreferenceRepository notificationUserPreferenceRepository;
+    private final NotificationSettingPolicy notificationSettingPolicy;
+
+    @Transactional
+    public NotificationSettingsResponse getSettings(Long userId) {
+        NotificationUserPreference preference = loadOrCreatePreference(userId);
+        List<NotificationSetting> settings = loadOrCreateSettings(userId);
+        List<NotificationSettingItemResponse> settingResponses = settings.stream()
+                .sorted(Comparator
+                        .comparing(NotificationSetting::getType)
+                        .thenComparing(NotificationSetting::getChannel))
+                .map(NotificationSettingItemResponse::from)
+                .toList();
+
+        return NotificationSettingsResponse.of(
+                NotificationGlobalPreferenceResponse.from(preference),
+                settingResponses
+        );
+    }
+
+    @Transactional
+    public NotificationGlobalPreferenceResponse updateGlobalPreference(Long userId,
+                                                                       UpdateNotificationGlobalPreferenceRequest request) {
+        NotificationUserPreference preference = loadOrCreatePreference(userId);
+
+        if (request.getGlobalEnabled() != null) {
+            preference.updateGlobalEnabled(request.getGlobalEnabled());
+        }
+
+        if (request.getTimezone() != null && !request.getTimezone().isBlank()) {
+            validateTimezone(request.getTimezone());
+            preference.updateTimezone(request.getTimezone());
+        }
+
+        if (request.getQuietHoursEnabled() != null) {
+            preference.updateQuietHoursEnabled(request.getQuietHoursEnabled());
+        }
+
+        boolean quietHoursRequested = request.getQuietHoursStart() != null || request.getQuietHoursEnd() != null;
+        if (quietHoursRequested || preference.isQuietHoursEnabled()) {
+            LocalTime quietStart = request.getQuietHoursStart() != null
+                    ? request.getQuietHoursStart()
+                    : preference.getQuietHoursStart();
+            LocalTime quietEnd = request.getQuietHoursEnd() != null
+                    ? request.getQuietHoursEnd()
+                    : preference.getQuietHoursEnd();
+            validateQuietHours(quietStart, quietEnd);
+            preference.updateQuietHours(quietStart, quietEnd);
+        }
+
+        return NotificationGlobalPreferenceResponse.from(preference);
+    }
+
+    @Transactional
+    public NotificationSettingItemResponse upsertSetting(Long userId, UpdateNotificationSettingRequest request) {
+        NotificationType type = parseType(request.getType());
+        NotificationChannel channel = parseChannel(request.getChannel());
+
+        NotificationSetting setting = notificationSettingRepository
+                .findByUserIdAndTypeAndChannel(userId, type, channel)
+                .orElseGet(() -> NotificationSetting.createDefault(
+                        userId, type, channel, notificationSettingPolicy.isDefaultEnabled(channel)
+                ));
+
+        boolean changed = false;
+        if (request.getEnabled() != null) {
+            setting.updateEnabled(request.getEnabled());
+            changed = true;
+        }
+        if (Boolean.TRUE.equals(request.getClearMute())) {
+            setting.unmute();
+            changed = true;
+        }
+        if (request.getMutedUntil() != null) {
+            setting.muteUntil(request.getMutedUntil());
+            changed = true;
+        }
+
+        if (!changed) {
+            throw new BusinessException(NotificationErrorCode.INVALID_SETTING_REQUEST);
+        }
+
+        NotificationSetting saved = notificationSettingRepository.save(setting);
+        return NotificationSettingItemResponse.from(saved);
+    }
+
+    @Transactional
+    public boolean shouldSendNotification(Long userId, NotificationType type, NotificationChannel channel) {
+        NotificationUserPreference preference = notificationUserPreferenceRepository.findByUserId(userId)
+                .orElseGet(() -> NotificationUserPreference.createDefault(userId));
+        if (!preference.isGlobalEnabled()) {
+            return false;
+        }
+        if (preference.isInQuietHours(LocalDateTime.now())) {
+            return false;
+        }
+
+        NotificationSetting setting = notificationSettingRepository
+                .findByUserIdAndTypeAndChannel(userId, type, channel)
+                .orElse(null);
+
+        if (setting == null) {
+            return notificationSettingPolicy.isDefaultEnabled(channel);
+        }
+        return setting.isEnabledNow();
+    }
+
+    private NotificationUserPreference loadOrCreatePreference(Long userId) {
+        return notificationUserPreferenceRepository.findByUserId(userId)
+                .orElseGet(() -> notificationUserPreferenceRepository.save(
+                        NotificationUserPreference.createDefault(userId)
+                ));
+    }
+
+    private List<NotificationSetting> loadOrCreateSettings(Long userId) {
+        List<NotificationSetting> settings = notificationSettingRepository.findByUserId(userId);
+        Map<NotificationType, Map<NotificationChannel, NotificationSetting>> settingMap = new EnumMap<>(NotificationType.class);
+        for (NotificationSetting setting : settings) {
+            settingMap
+                    .computeIfAbsent(setting.getType(), key -> new EnumMap<>(NotificationChannel.class))
+                    .put(setting.getChannel(), setting);
+        }
+
+        List<NotificationSetting> missing = new ArrayList<>();
+        for (NotificationType type : NotificationType.values()) {
+            for (NotificationChannel channel : notificationSettingPolicy.supportedChannels()) {
+                Map<NotificationChannel, NotificationSetting> channels = settingMap.get(type);
+                if (channels == null || !channels.containsKey(channel)) {
+                    missing.add(NotificationSetting.createDefault(
+                            userId, type, channel, notificationSettingPolicy.isDefaultEnabled(channel)
+                    ));
+                }
+            }
+        }
+
+        if (!missing.isEmpty()) {
+            notificationSettingRepository.saveAll(missing);
+            settings = notificationSettingRepository.findByUserId(userId);
+        }
+
+        return settings;
+    }
+
+    private NotificationType parseType(String rawType) {
+        try {
+            return NotificationType.valueOf(rawType.toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            throw new BusinessException(NotificationErrorCode.INVALID_NOTIFICATION_TYPE);
+        }
+    }
+
+    private NotificationChannel parseChannel(String rawChannel) {
+        try {
+            return NotificationChannel.valueOf(rawChannel.toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            throw new BusinessException(NotificationErrorCode.INVALID_CHANNEL);
+        }
+    }
+
+    private void validateTimezone(String timezone) {
+        try {
+            ZoneId.of(timezone);
+        } catch (Exception ignored) {
+            throw new BusinessException(NotificationErrorCode.INVALID_TIMEZONE);
+        }
+    }
+
+    private void validateQuietHours(LocalTime quietStart, LocalTime quietEnd) {
+        if (quietStart == null || quietEnd == null) {
+            throw new BusinessException(NotificationErrorCode.INVALID_QUIET_HOURS);
+        }
+    }
+
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/template/NotificationTemplateResolver.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/template/NotificationTemplateResolver.java
@@ -1,0 +1,51 @@
+package com.example.notification.service.template;
+
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationTemplate;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.repository.NotificationTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationTemplateResolver {
+
+    private static final String DEFAULT_LOCALE = "ko-KR";
+
+    private final NotificationTemplateRepository notificationTemplateRepository;
+
+    public Optional<NotificationTemplate> resolve(NotificationType type,
+                                                  NotificationChannel channel,
+                                                  String requestedLocale) {
+        for (String candidate : candidateLocales(requestedLocale)) {
+            Optional<NotificationTemplate> template = notificationTemplateRepository
+                    .findTopByTypeAndChannelAndLocaleAndEnabledTrueOrderByVersionDesc(type, channel, candidate);
+            if (template.isPresent()) {
+                return template;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<String> candidateLocales(String requestedLocale) {
+        Set<String> candidates = new LinkedHashSet<>();
+        if (requestedLocale != null && !requestedLocale.isBlank()) {
+            String normalized = requestedLocale.trim();
+            candidates.add(normalized);
+            int separator = normalized.indexOf('-');
+            if (separator > 0) {
+                candidates.add(normalized.substring(0, separator));
+            }
+        }
+        candidates.add(DEFAULT_LOCALE);
+        candidates.add("en-US");
+        return new ArrayList<>(candidates);
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/template/TemplateRenderService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/template/TemplateRenderService.java
@@ -1,0 +1,31 @@
+package com.example.notification.service.template;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class TemplateRenderService {
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*([a-zA-Z0-9_.-]+)\\s*}}");
+
+    public String render(String template, Map<String, Object> variables) {
+        if (template == null || template.isBlank()) {
+            return "";
+        }
+
+        Map<String, Object> safeVariables = variables == null ? Map.of() : variables;
+        Matcher matcher = VARIABLE_PATTERN.matcher(template);
+        StringBuffer rendered = new StringBuffer();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            Object value = safeVariables.get(key);
+            String replacement = value == null ? "" : String.valueOf(value);
+            matcher.appendReplacement(rendered, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(rendered);
+        return rendered.toString();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/unread/NotificationUnreadCountService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/unread/NotificationUnreadCountService.java
@@ -1,0 +1,111 @@
+package com.example.notification.service.unread;
+
+import com.example.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationUnreadCountService {
+
+    private static final String KEY_PREFIX = "notification:unread:";
+    private static final Duration KEY_TTL = Duration.ofDays(7);
+    private static final String DECREASE_SAFE_LUA = """
+            local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+            local delta = tonumber(ARGV[1])
+            local next = current - delta
+            if next < 0 then
+              next = 0
+            end
+            redis.call('SET', KEYS[1], next)
+            if tonumber(ARGV[2]) > 0 then
+              redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+            end
+            return next
+            """;
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final NotificationRepository notificationRepository;
+
+    public long getOrLoad(Long userId) {
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(key(userId));
+            if (cached != null) {
+                return normalizeCount(parseLong(cached));
+            }
+        } catch (Exception e) {
+            log.warn("Unread count cache lookup failed. userId={}", userId, e);
+        }
+        return refreshFromDb(userId);
+    }
+
+    public void increase(Long userId) {
+        try {
+            Long value = stringRedisTemplate.opsForValue().increment(key(userId));
+            stringRedisTemplate.expire(key(userId), KEY_TTL);
+            if (value != null && value < 0) {
+                set(userId, 0);
+            }
+        } catch (Exception e) {
+            log.warn("Unread count increment failed. userId={}", userId, e);
+        }
+    }
+
+    public void decreaseSafely(Long userId, long delta) {
+        if (delta <= 0) {
+            return;
+        }
+        try {
+            DefaultRedisScript<Long> script = new DefaultRedisScript<>(DECREASE_SAFE_LUA, Long.class);
+            stringRedisTemplate.execute(
+                    script,
+                    Collections.singletonList(key(userId)),
+                    String.valueOf(delta),
+                    String.valueOf(KEY_TTL.toSeconds())
+            );
+        } catch (Exception e) {
+            log.warn("Unread count decrement failed. userId={}, delta={}", userId, delta, e);
+        }
+    }
+
+    public void set(Long userId, long count) {
+        try {
+            stringRedisTemplate.opsForValue().set(
+                    key(userId),
+                    String.valueOf(normalizeCount(count)),
+                    KEY_TTL
+            );
+        } catch (Exception e) {
+            log.warn("Unread count cache set failed. userId={}, count={}", userId, count, e);
+        }
+    }
+
+    public long refreshFromDb(Long userId) {
+        long count = notificationRepository.countByRecipientIdAndIsReadFalse(userId);
+        set(userId, count);
+        return count;
+    }
+
+    private String key(Long userId) {
+        return KEY_PREFIX + userId;
+    }
+
+    private long parseLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (Exception ignored) {
+            return 0L;
+        }
+    }
+
+    private long normalizeCount(long count) {
+        return Math.max(0, count);
+    }
+}

--- a/servers/services/notification/src/main/resources/application-prod.yml
+++ b/servers/services/notification/src/main/resources/application-prod.yml
@@ -1,0 +1,18 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: never
+
+notification:
+  security:
+    gateway-auth-enabled: true

--- a/servers/services/notification/src/main/resources/application.yml
+++ b/servers/services/notification/src/main/resources/application.yml
@@ -1,0 +1,113 @@
+server:
+  port: ${SERVER_PORT:8092}
+
+spring:
+  application:
+    name: notification-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/notification_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: notification-service-group
+      auto-offset-reset: earliest
+
+  # ─── Mail ─────────────────────────────────────
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:1025}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: ${MAIL_SMTP_AUTH:false}
+          starttls:
+            enable: ${MAIL_SMTP_STARTTLS:false}
+
+notification:
+  security:
+    gateway-auth-enabled: ${NOTIFICATION_SECURITY_GATEWAY_AUTH_ENABLED:true}
+    internal-auth-header: ${NOTIFICATION_SECURITY_INTERNAL_AUTH_HEADER:X-Internal-Auth}
+    internal-auth-token: ${NOTIFICATION_SECURITY_INTERNAL_AUTH_TOKEN:}
+    user-id-header: ${NOTIFICATION_SECURITY_USER_ID_HEADER:X-User-Id}
+  sse:
+    topic: ${NOTIFICATION_SSE_TOPIC:sse-notifications}
+    heartbeat-ms: ${NOTIFICATION_SSE_HEARTBEAT_MS:10000}
+    max-connections-per-user: ${NOTIFICATION_SSE_MAX_CONNECTIONS_PER_USER:3}
+    max-total-connections: ${NOTIFICATION_SSE_MAX_TOTAL_CONNECTIONS:5000}
+  delivery:
+    max-attempts: ${NOTIFICATION_DELIVERY_MAX_ATTEMPTS:3}
+    initial-backoff-seconds: ${NOTIFICATION_DELIVERY_INITIAL_BACKOFF_SECONDS:10}
+    backoff-multiplier: ${NOTIFICATION_DELIVERY_BACKOFF_MULTIPLIER:2}
+    retry-batch-size: ${NOTIFICATION_DELIVERY_RETRY_BATCH_SIZE:100}
+    retry-fixed-delay-ms: ${NOTIFICATION_DELIVERY_RETRY_FIXED_DELAY_MS:5000}
+    claim-lease-seconds: ${NOTIFICATION_DELIVERY_CLAIM_LEASE_SECONDS:30}
+  email:
+    provider: ${NOTIFICATION_EMAIL_PROVIDER:smtp}
+    fallback-enabled: ${NOTIFICATION_EMAIL_FALLBACK_ENABLED:false}
+    fallback-provider: ${NOTIFICATION_EMAIL_FALLBACK_PROVIDER:smtp}
+    from-address: ${NOTIFICATION_EMAIL_FROM:no-reply@example.com}
+    ses-region: ${NOTIFICATION_SES_REGION:ap-northeast-2}
+    configuration-set: ${NOTIFICATION_SES_CONFIGURATION_SET:}
+
+# ─── Snowflake ID ────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:9}
+
+  service:
+    user-url: ${USER_SERVICE_URL:http://localhost:8082}
+    product-url: ${PRODUCT_SERVICE_URL:http://localhost:8084}
+
+  # ─── OpenAPI ──────────────────────────────────
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Notification Service API"
+    version: "1.0.0"
+    description: |
+      실시간 인앱 알림(SSE) 및 알림 이력 관리 서비스
+
+# ─── Actuator ─────────────────────────────────
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+# ─── Logging ──────────────────────────────────
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/servers/services/notification/src/test/java/com/example/notification/config/GatewayHeaderValidationFilterTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/config/GatewayHeaderValidationFilterTest.java
@@ -1,0 +1,165 @@
+package com.example.notification.config;
+
+import com.example.contracts.http.HttpHeaderNames;
+import com.example.security.context.HmacSigner;
+import com.example.security.context.SignedHeaderParser;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GatewayHeaderValidationFilterTest {
+
+    @Test
+    void doFilter_skipsActuatorWithoutHeaders() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(true);
+        properties.setInternalAuthToken("secret-token");
+
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void doFilter_rejectsWhenGatewayTokenInvalid() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(true);
+        properties.setInternalAuthToken("secret-token");
+
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        request.addHeader("X-Internal-Auth", "wrong");
+        request.addHeader("X-User-Id", "10");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("NOTIFICATION-AUTH-001");
+    }
+
+    @Test
+    void doFilter_rejectsWhenUserHeaderMissing() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(true);
+        properties.setInternalAuthToken("secret-token");
+
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        request.addHeader("X-Internal-Auth", "secret-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("NOTIFICATION-AUTH-002");
+    }
+
+    @Test
+    void doFilter_allowsRequestWhenHeadersValid() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(true);
+        properties.setInternalAuthToken("secret-token");
+
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        request.addHeader("X-Internal-Auth", "secret-token");
+        request.addHeader("X-User-Id", "10");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void doFilter_rejectsWhenSignedHeaderValidationFails() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(false);
+
+        SignedHeaderParser parser = new SignedHeaderParser(new HmacSigner("gateway-sign-key"), 300_000);
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, parser);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        request.addHeader(HttpHeaderNames.USER_ID, "10");
+        request.addHeader(HttpHeaderNames.USER_ROLES, "ROLE_USER");
+        request.addHeader(HttpHeaderNames.NONCE, "nonce-1");
+        request.addHeader(HttpHeaderNames.TIMESTAMP, String.valueOf(System.currentTimeMillis()));
+        request.addHeader(HttpHeaderNames.SIGNATURE, "invalid-signature");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("NOTIFICATION-AUTH-002");
+    }
+
+    @Test
+    void doFilter_allowsRequestWhenSignedHeadersValid() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(false);
+
+        HmacSigner signer = new HmacSigner("gateway-sign-key");
+        SignedHeaderParser parser = new SignedHeaderParser(signer, 300_000);
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, parser);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        String userId = "10";
+        String roles = "ROLE_USER";
+        String nonce = "nonce-2";
+        long timestamp = System.currentTimeMillis();
+        String payload = HmacSigner.buildSignaturePayload(userId, roles, nonce, timestamp);
+        String signature = signer.sign(payload);
+
+        request.addHeader(HttpHeaderNames.USER_ID, userId);
+        request.addHeader(HttpHeaderNames.USER_ROLES, roles);
+        request.addHeader(HttpHeaderNames.NONCE, nonce);
+        request.addHeader(HttpHeaderNames.TIMESTAMP, String.valueOf(timestamp));
+        request.addHeader(HttpHeaderNames.SIGNATURE, signature);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void doFilter_allowsSignedHeaderFlowWhenGatewayTokenNotConfigured() throws ServletException, IOException {
+        NotificationSecurityProperties properties = new NotificationSecurityProperties();
+        properties.setGatewayAuthEnabled(true);
+        properties.setInternalAuthToken("");
+
+        HmacSigner signer = new HmacSigner("gateway-sign-key");
+        SignedHeaderParser parser = new SignedHeaderParser(signer, 300_000);
+        GatewayHeaderValidationFilter filter = new GatewayHeaderValidationFilter(properties, parser);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/notifications");
+        String userId = "10";
+        String roles = "ROLE_USER";
+        String nonce = "nonce-3";
+        long timestamp = System.currentTimeMillis();
+        String payload = HmacSigner.buildSignaturePayload(userId, roles, nonce, timestamp);
+        String signature = signer.sign(payload);
+
+        request.addHeader(HttpHeaderNames.USER_ID, userId);
+        request.addHeader(HttpHeaderNames.USER_ROLES, roles);
+        request.addHeader(HttpHeaderNames.NONCE, nonce);
+        request.addHeader(HttpHeaderNames.TIMESTAMP, String.valueOf(timestamp));
+        request.addHeader(HttpHeaderNames.SIGNATURE, signature);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/consumer/NotificationDeliveryEventConsumerTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/consumer/NotificationDeliveryEventConsumerTest.java
@@ -1,0 +1,184 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.delivery.NotificationDeliveryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDeliveryEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationDeliveryRepository notificationDeliveryRepository;
+
+    @Mock
+    private NotificationDeliveryService notificationDeliveryService;
+
+    @InjectMocks
+    private NotificationDeliveryEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+
+    @Test
+    void consumeDispatchRequest_dispatchesAndMarksAsDispatchedWhenDelivered() {
+        Notification notification = Notification.create(
+                10L,
+                20L,
+                NotificationType.GENERAL,
+                NotificationChannel.IN_APP,
+                "title",
+                "message",
+                null,
+                null,
+                "evt-1",
+                "dedupe-1",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 101L);
+
+        NotificationDelivery delivered = NotificationDelivery.createPending(
+                101L, NotificationChannel.IN_APP, "IN_APP", null
+        );
+        ReflectionTestUtils.setField(delivered, "id", 900L);
+        delivered.markSent("IN_APP:900");
+        delivered.markDelivered();
+
+        when(notificationRepository.findById(101L)).thenReturn(Optional.of(notification));
+        when(notificationDeliveryService.deliver(eq(notification), eq(NotificationChannel.IN_APP), any()))
+                .thenReturn(delivered);
+        when(notificationDeliveryRepository.findByNotificationIdOrderByIdAsc(101L))
+                .thenReturn(List.of(delivered));
+
+        String message = """
+                {
+                  "eventId": "delivery-evt-1",
+                  "eventType": "NOTIFICATION_DELIVERY_REQUESTED",
+                  "notificationId": 101,
+                  "channel": "IN_APP"
+                }
+                """;
+
+        consumer.consumeDispatchRequest(message);
+
+        verify(notificationDeliveryService).deliver(eq(notification), eq(NotificationChannel.IN_APP), any());
+        verify(notificationRepository).save(notification);
+        assertThat(notification.getStatus().name()).isEqualTo("DISPATCHED");
+    }
+
+    @Test
+    void consumeDispatchRequest_marksAsFailedWhenAllDeliveriesFailed() {
+        Notification notification = Notification.create(
+                10L,
+                20L,
+                NotificationType.PAYMENT,
+                NotificationChannel.EMAIL,
+                "title",
+                "message",
+                null,
+                null,
+                "evt-2",
+                "dedupe-2",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 202L);
+
+        NotificationDelivery failed = NotificationDelivery.createPending(
+                202L, NotificationChannel.EMAIL, "EMAIL", "a@example.com"
+        );
+        ReflectionTestUtils.setField(failed, "id", 901L);
+        failed.markFailed("EMAIL_SEND_FAILED", "smtp timeout");
+
+        when(notificationRepository.findById(202L)).thenReturn(Optional.of(notification));
+        when(notificationDeliveryService.deliver(eq(notification), eq(NotificationChannel.EMAIL), any()))
+                .thenReturn(failed);
+        when(notificationDeliveryRepository.findByNotificationIdOrderByIdAsc(202L))
+                .thenReturn(List.of(failed));
+
+        String message = """
+                {
+                  "eventId": "delivery-evt-2",
+                  "eventType": "NOTIFICATION_DELIVERY_REQUESTED",
+                  "notificationId": 202,
+                  "channel": "EMAIL",
+                  "emailTo": "a@example.com"
+                }
+                """;
+
+        consumer.consumeDispatchRequest(message);
+
+        verify(notificationRepository).save(notification);
+        assertThat(notification.getStatus().name()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void consumeDispatchRequest_throwsWhenChannelIsInvalid() {
+        Notification notification = Notification.create(
+                10L,
+                20L,
+                NotificationType.GENERAL,
+                NotificationChannel.IN_APP,
+                "title",
+                "message",
+                null,
+                null,
+                "evt-3",
+                "dedupe-3",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 303L);
+
+        when(notificationRepository.findById(303L)).thenReturn(Optional.of(notification));
+
+        String message = """
+                {
+                  "eventId": "delivery-evt-3",
+                  "eventType": "NOTIFICATION_DELIVERY_REQUESTED",
+                  "notificationId": 303,
+                  "channel": "UNKNOWN"
+                }
+                """;
+
+        assertThrows(IllegalArgumentException.class, () -> consumer.consumeDispatchRequest(message));
+
+        verify(notificationDeliveryService, never()).deliver(any(), any(), any());
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/consumer/NotificationEventConsumerTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/consumer/NotificationEventConsumerTest.java
@@ -1,0 +1,103 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.notification.client.ProductClient;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.service.command.NotificationCommandService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private NotificationCommandService notificationCommandService;
+
+    @Mock
+    private ProductClient productClient;
+
+    @InjectMocks
+    private NotificationEventConsumer notificationEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+
+    @Test
+    void consumeFunding_dispatchesFundingSuccessNotification() {
+        String message = """
+                {
+                  "eventId": "evt-funding-1",
+                  "eventType": "FUNDING_SUCCEEDED",
+                  "campaignId": 1001,
+                  "itemId": 2001,
+                  "sellerId": 3001,
+                  "goalAmount": 100000,
+                  "currentAmount": 120000,
+                  "currentQuantity": 55
+                }
+                """;
+
+        notificationEventConsumer.consumeFunding(message);
+
+        ArgumentCaptor<CreateNotificationRequest> captor = ArgumentCaptor.forClass(CreateNotificationRequest.class);
+        verify(notificationCommandService).createAndSend(captor.capture(), eq(null));
+
+        CreateNotificationRequest request = captor.getValue();
+        assertThat(request.getRecipientId()).isEqualTo(3001L);
+        assertThat(request.getType()).isEqualTo("FUNDING_SUCCESS");
+        assertThat(request.getReferenceType()).isEqualTo("CAMPAIGN");
+        assertThat(request.getReferenceId()).isEqualTo("1001");
+        assertThat(request.getExternalEventId()).isEqualTo("evt-funding-1");
+    }
+
+    @Test
+    void consumeStock_resolvesRecipientFromProductWhenMissing() {
+        when(productClient.findItemSummary(44L))
+                .thenReturn(new ProductClient.ProductItemSummary(44L, 99L, "테스트 상품"));
+
+        String message = """
+                {
+                  "eventId": "evt-stock-1",
+                  "eventType": "STOCK_DEPLETED",
+                  "stockItemId": 55,
+                  "itemId": 44
+                }
+                """;
+
+        notificationEventConsumer.consumeStock(message);
+
+        ArgumentCaptor<CreateNotificationRequest> captor = ArgumentCaptor.forClass(CreateNotificationRequest.class);
+        verify(notificationCommandService).createAndSend(captor.capture(), eq(null));
+
+        CreateNotificationRequest request = captor.getValue();
+        assertThat(request.getRecipientId()).isEqualTo(99L);
+        assertThat(request.getType()).isEqualTo("STOCK_DEPLETED");
+        assertThat(request.getReferenceType()).isEqualTo("ITEM");
+        assertThat(request.getReferenceId()).isEqualTo("44");
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/command/NotificationActionCommandServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/command/NotificationActionCommandServiceTest.java
@@ -1,0 +1,86 @@
+package com.example.notification.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationStatus;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationActionCommandServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationUnreadCountService notificationUnreadCountService;
+
+    @InjectMocks
+    private NotificationActionCommandService notificationActionCommandService;
+
+    @Test
+    void markAsRead_updatesNotificationState() {
+        Notification notification = Notification.create(
+                10L, 1L, NotificationType.PAYMENT, NotificationChannel.IN_APP,
+                "title", "message", null, null, null, "dedupe", null
+        );
+        when(notificationRepository.findByIdAndRecipientId(99L, 10L)).thenReturn(Optional.of(notification));
+
+        notificationActionCommandService.markAsRead(10L, 99L);
+
+        assertThat(notification.isRead()).isTrue();
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.READ);
+        assertThat(notification.getReadAt()).isNotNull();
+        verify(notificationUnreadCountService).decreaseSafely(10L, 1);
+    }
+
+    @Test
+    void markAllAsRead_returnsUpdatedCount() {
+        when(notificationRepository.markAllAsRead(eq(10L), any(LocalDateTime.class), eq(NotificationStatus.READ)))
+                .thenReturn(5);
+
+        int updatedCount = notificationActionCommandService.markAllAsRead(10L);
+
+        assertThat(updatedCount).isEqualTo(5);
+        verify(notificationUnreadCountService).decreaseSafely(10L, 5);
+    }
+
+    @Test
+    void deleteNotification_marksSoftDelete() {
+        Notification notification = Notification.create(
+                10L, 1L, NotificationType.GENERAL, NotificationChannel.IN_APP,
+                "title", "message", null, null, null, "dedupe-2", null
+        );
+        when(notificationRepository.findByIdAndRecipientId(100L, 10L)).thenReturn(Optional.of(notification));
+
+        notificationActionCommandService.deleteNotification(10L, 100L);
+
+        assertThat(notification.isDeleted()).isTrue();
+        verify(notificationUnreadCountService).decreaseSafely(10L, 1);
+    }
+
+    @Test
+    void markAsRead_throwsWhenNotificationMissing() {
+        when(notificationRepository.findByIdAndRecipientId(77L, 10L)).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> notificationActionCommandService.markAsRead(10L, 77L));
+        verify(notificationRepository).findByIdAndRecipientId(77L, 10L);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/command/NotificationCommandServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/command/NotificationCommandServiceTest.java
@@ -1,0 +1,205 @@
+package com.example.notification.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.DomainEvent;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.notification.dto.command.request.CreateNotificationRequest;
+import com.example.notification.dto.command.response.NotificationDispatchResponse;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationTemplate;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.event.NotificationDeliveryRequestedEvent;
+import com.example.notification.exception.NotificationErrorCode;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.content.NotificationContentSanitizer;
+import com.example.notification.service.template.NotificationTemplateResolver;
+import com.example.notification.service.template.TemplateRenderService;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCommandServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationTemplateResolver notificationTemplateResolver;
+
+    @Mock
+    private TemplateRenderService templateRenderService;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private NotificationUnreadCountService notificationUnreadCountService;
+
+    @Spy
+    private NotificationContentSanitizer notificationContentSanitizer;
+
+    @InjectMocks
+    private NotificationCommandService notificationCommandService;
+
+    @Test
+    void createAndSend_returnsDeduplicatedWhenSameKeyExists() {
+        Notification existing = Notification.create(
+                10L, 20L, NotificationType.GENERAL, NotificationChannel.IN_APP,
+                "title", "message", null, null, "evt-1", "dedupe-1", null
+        );
+        ReflectionTestUtils.setField(existing, "id", 999L);
+
+        when(notificationRepository.findByDedupeKey("dedupe-1")).thenReturn(Optional.of(existing));
+
+        CreateNotificationRequest request = new CreateNotificationRequest();
+        ReflectionTestUtils.setField(request, "recipientId", 10L);
+        ReflectionTestUtils.setField(request, "type", "GENERAL");
+        ReflectionTestUtils.setField(request, "dedupeKey", "dedupe-1");
+
+        NotificationDispatchResponse response = notificationCommandService.createAndSend(request, 10L);
+
+        assertThat(response.isDeduplicated()).isTrue();
+        assertThat(response.getNotificationId()).isEqualTo(999L);
+        verify(eventPublisher).publish(any(DomainEvent.class), any(EventMetadata.class));
+        verify(notificationRepository, never()).save(any(Notification.class));
+        verify(notificationUnreadCountService, never()).increase(any());
+    }
+
+    @Test
+    void createAndSend_savesNotificationAndPublishesDeliveryEvents() {
+        when(notificationRepository.findByDedupeKey(any())).thenReturn(Optional.empty());
+        when(notificationTemplateResolver.resolve(
+                eq(NotificationType.PAYMENT), eq(NotificationChannel.IN_APP), eq("ko-KR")
+        )).thenReturn(Optional.of(NotificationTemplate.create(
+                NotificationType.PAYMENT,
+                NotificationChannel.IN_APP,
+                "ko-KR",
+                "{{userName}}님 결제가 완료됐어요",
+                "{{amount}}원 결제 성공",
+                1,
+                true
+        )));
+        when(templateRenderService.render(eq("{{userName}}님 결제가 완료됐어요"), any()))
+                .thenReturn("딩주님 결제가 완료됐어요");
+        when(templateRenderService.render(eq("{{amount}}원 결제 성공"), any()))
+                .thenReturn("10000원 결제 성공");
+
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> {
+            Notification saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 12345L);
+            return saved;
+        });
+
+        CreateNotificationRequest request = new CreateNotificationRequest();
+        ReflectionTestUtils.setField(request, "recipientId", 77L);
+        ReflectionTestUtils.setField(request, "type", "PAYMENT");
+        ReflectionTestUtils.setField(request, "channels", List.of("IN_APP", "EMAIL"));
+        ReflectionTestUtils.setField(request, "locale", "ko-KR");
+        ReflectionTestUtils.setField(request, "emailTo", "ding@example.com");
+        ReflectionTestUtils.setField(request, "externalEventId", "evt-100");
+        ReflectionTestUtils.setField(request, "variables", Map.of("userName", "딩주", "amount", 10000));
+
+        NotificationDispatchResponse response = notificationCommandService.createAndSend(request, 77L);
+
+        assertThat(response.isDeduplicated()).isFalse();
+        assertThat(response.getNotificationId()).isEqualTo(12345L);
+        assertThat(response.getDeliveredChannels()).isEmpty();
+        assertThat(response.getFailedChannels()).isEmpty();
+        assertThat(response.getStatus()).isEqualTo("CREATED");
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, atLeastOnce()).save(captor.capture());
+        verify(notificationUnreadCountService).increase(77L);
+        assertThat(captor.getValue().getRecipientId()).isEqualTo(77L);
+        assertThat(captor.getValue().getTitle()).isEqualTo("딩주님 결제가 완료됐어요");
+
+        ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher, times(2)).publish(eventCaptor.capture(), any(EventMetadata.class));
+
+        assertThat(eventCaptor.getAllValues())
+                .allMatch(event -> event instanceof NotificationDeliveryRequestedEvent);
+        assertThat(eventCaptor.getAllValues())
+                .extracting(event -> event.getPayload().get("channel"))
+                .containsExactly("IN_APP", "EMAIL");
+    }
+
+    @Test
+    void createAndSend_throwsWhenRecipientDiffersFromRequester() {
+        CreateNotificationRequest request = new CreateNotificationRequest();
+        ReflectionTestUtils.setField(request, "recipientId", 200L);
+        ReflectionTestUtils.setField(request, "type", "GENERAL");
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> notificationCommandService.createAndSend(request, 100L)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(NotificationErrorCode.FORBIDDEN_RECIPIENT);
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void createAndSend_throwsWhenActorIsSpoofed() {
+        CreateNotificationRequest request = new CreateNotificationRequest();
+        ReflectionTestUtils.setField(request, "recipientId", 100L);
+        ReflectionTestUtils.setField(request, "actorId", 999L);
+        ReflectionTestUtils.setField(request, "type", "GENERAL");
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> notificationCommandService.createAndSend(request, 100L)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(NotificationErrorCode.FORBIDDEN_ACTOR);
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void createAndSend_sanitizesHtmlContentBeforePersisting() {
+        when(notificationRepository.findByDedupeKey(any())).thenReturn(Optional.empty());
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> {
+            Notification saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 56789L);
+            return saved;
+        });
+
+        CreateNotificationRequest request = new CreateNotificationRequest();
+        ReflectionTestUtils.setField(request, "recipientId", 77L);
+        ReflectionTestUtils.setField(request, "type", "GENERAL");
+        ReflectionTestUtils.setField(request, "title", "<script>alert('x')</script>");
+        ReflectionTestUtils.setField(request, "message", "<img src=x onerror=alert('x')>");
+        ReflectionTestUtils.setField(request, "variables", Map.of("itemTitle", "<b>굿즈</b>"));
+
+        notificationCommandService.createAndSend(request, 77L);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, atLeastOnce()).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getTitle()).isEqualTo("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;");
+        assertThat(saved.getMessage()).isEqualTo("&lt;img src=x onerror=alert(&#39;x&#39;)&gt;");
+        assertThat(saved.getPayload()).containsEntry("itemTitle", "&lt;b&gt;굿즈&lt;/b&gt;");
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/delivery/NotificationDeliveryServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/delivery/NotificationDeliveryServiceTest.java
@@ -1,0 +1,219 @@
+package com.example.notification.service.delivery;
+
+import com.example.notification.config.NotificationDeliveryProperties;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationDeliveryStatus;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.email.EmailSendResult;
+import com.example.notification.service.email.NotificationEmailService;
+import com.example.notification.service.realtime.SseEventPublisher;
+import com.example.notification.service.setting.NotificationSettingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDeliveryServiceTest {
+
+    @Mock
+    private NotificationDeliveryRepository notificationDeliveryRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationSettingService notificationSettingService;
+
+    @Mock
+    private NotificationEmailService notificationEmailService;
+
+    @Mock
+    private SseEventPublisher sseEventPublisher;
+
+    private NotificationDeliveryService notificationDeliveryService;
+
+    @BeforeEach
+    void setUp() {
+        NotificationDeliveryProperties properties = new NotificationDeliveryProperties();
+        properties.setMaxAttempts(3);
+        properties.setInitialBackoffSeconds(10);
+        properties.setBackoffMultiplier(2);
+        properties.setRetryBatchSize(100);
+        properties.setClaimLeaseSeconds(30);
+
+        notificationDeliveryService = new NotificationDeliveryService(
+                notificationDeliveryRepository,
+                notificationRepository,
+                notificationSettingService,
+                notificationEmailService,
+                sseEventPublisher,
+                properties
+        );
+
+        lenient().when(notificationDeliveryRepository.save(any(NotificationDelivery.class))).thenAnswer(invocation -> {
+            NotificationDelivery delivery = invocation.getArgument(0);
+            if (delivery.getId() == null) {
+                ReflectionTestUtils.setField(delivery, "id", 1L);
+            }
+            return delivery;
+        });
+    }
+
+    @Test
+    void deliver_emailFailure_marksRetrying() {
+        Notification notification = Notification.create(
+                10L,
+                10L,
+                NotificationType.PAYMENT,
+                NotificationChannel.EMAIL,
+                "title",
+                "message",
+                null,
+                null,
+                "evt-1",
+                "dedupe-1",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 99L);
+
+        when(notificationDeliveryRepository.findByNotificationIdAndChannel(99L, NotificationChannel.EMAIL))
+                .thenReturn(Optional.empty());
+        when(notificationDeliveryRepository.claimDispatchLock(eq(1L), any(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(notificationDeliveryRepository.findById(anyLong())).thenAnswer(invocation -> {
+            Long id = invocation.getArgument(0);
+            NotificationDelivery pending = NotificationDelivery.createPending(
+                    99L,
+                    NotificationChannel.EMAIL,
+                    "EMAIL",
+                    "user@example.com"
+            );
+            ReflectionTestUtils.setField(pending, "id", id);
+            return Optional.of(pending);
+        });
+        when(notificationRepository.findById(99L)).thenReturn(Optional.of(notification));
+        when(notificationSettingService.shouldSendNotification(10L, NotificationType.PAYMENT, NotificationChannel.EMAIL))
+                .thenReturn(true);
+        when(notificationEmailService.send(10L, NotificationType.PAYMENT, "user@example.com", "title", "message", null))
+                .thenReturn(EmailSendResult.failure("SMTP", "smtp timeout"));
+
+        NotificationDelivery delivered = notificationDeliveryService.deliver(
+                notification,
+                NotificationChannel.EMAIL,
+                NotificationDeliveryCommand.builder()
+                        .userId(10L)
+                        .type(NotificationType.PAYMENT)
+                        .title("title")
+                        .message("message")
+                        .emailTo("user@example.com")
+                        .build()
+        );
+
+        assertThat(delivered.getStatus()).isEqualTo(NotificationDeliveryStatus.RETRYING);
+        assertThat(delivered.getNextRetryAt()).isNotNull();
+    }
+
+    @Test
+    void dispatchRetryTargets_retriesAndDelivers() {
+        Notification notification = Notification.create(
+                10L,
+                10L,
+                NotificationType.PAYMENT,
+                NotificationChannel.EMAIL,
+                "title",
+                "message",
+                null,
+                null,
+                "evt-2",
+                "dedupe-2",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 99L);
+
+        NotificationDelivery retryTarget = NotificationDelivery.createPending(
+                99L,
+                NotificationChannel.EMAIL,
+                "EMAIL",
+                "user@example.com"
+        );
+        ReflectionTestUtils.setField(retryTarget, "id", 77L);
+        retryTarget.markRetry("ERR", "failed", LocalDateTime.now().minusSeconds(1));
+
+        when(notificationDeliveryRepository.findDispatchTargets(
+                eq(Set.of(NotificationDeliveryStatus.PENDING, NotificationDeliveryStatus.RETRYING)),
+                any(LocalDateTime.class),
+                any()
+        )).thenReturn(List.of(retryTarget));
+        when(notificationDeliveryRepository.findById(77L)).thenReturn(Optional.of(retryTarget));
+        when(notificationDeliveryRepository.claimDispatchLock(eq(77L), any(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(notificationRepository.findById(99L)).thenReturn(Optional.of(notification));
+        when(notificationSettingService.shouldSendNotification(10L, NotificationType.PAYMENT, NotificationChannel.EMAIL))
+                .thenReturn(true);
+        when(notificationEmailService.send(10L, NotificationType.PAYMENT, "user@example.com", "title", "message", null))
+                .thenReturn(EmailSendResult.success("SMTP", "msg-1"));
+
+        notificationDeliveryService.dispatchRetryTargets();
+
+        assertThat(retryTarget.getStatus()).isEqualTo(NotificationDeliveryStatus.DELIVERED);
+    }
+
+    @Test
+    void dispatchExisting_dropsWhenNotificationMissing() {
+        NotificationDelivery pending = NotificationDelivery.createPending(
+                999L,
+                NotificationChannel.IN_APP,
+                "IN_APP",
+                null
+        );
+        ReflectionTestUtils.setField(pending, "id", 55L);
+
+        when(notificationDeliveryRepository.findById(55L)).thenReturn(Optional.of(pending));
+        when(notificationDeliveryRepository.claimDispatchLock(eq(55L), any(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(notificationRepository.findById(999L)).thenReturn(Optional.empty());
+
+        NotificationDelivery result = notificationDeliveryService.dispatchExisting(55L);
+
+        assertThat(result.getStatus()).isEqualTo(NotificationDeliveryStatus.DROPPED);
+    }
+
+    @Test
+    void dispatchExisting_skipsWhenClaimLost() {
+        NotificationDelivery pending = NotificationDelivery.createPending(
+                999L,
+                NotificationChannel.IN_APP,
+                "IN_APP",
+                null
+        );
+        ReflectionTestUtils.setField(pending, "id", 66L);
+
+        when(notificationDeliveryRepository.findById(66L)).thenReturn(Optional.of(pending));
+        when(notificationDeliveryRepository.claimDispatchLock(eq(66L), any(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(0);
+
+        NotificationDelivery result = notificationDeliveryService.dispatchExisting(66L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(NotificationDeliveryStatus.PENDING);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/email/RoutingEmailSenderTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/email/RoutingEmailSenderTest.java
@@ -1,0 +1,91 @@
+package com.example.notification.service.email;
+
+import com.example.notification.config.NotificationEmailProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoutingEmailSenderTest {
+
+    @Mock
+    private EmailSenderStrategy smtpStrategy;
+
+    @Mock
+    private EmailSenderStrategy sesStrategy;
+
+    private NotificationEmailProperties properties;
+    private EmailSendCommand command;
+
+    @BeforeEach
+    void setUp() {
+        properties = new NotificationEmailProperties();
+        command = EmailSendCommand.builder()
+                .to("tester@example.com")
+                .subject("subject")
+                .textBody("body")
+                .build();
+    }
+
+    @Test
+    void send_fallsBackWhenPrimaryFails() {
+        when(sesStrategy.providerType()).thenReturn(EmailProviderType.SES);
+        when(smtpStrategy.providerType()).thenReturn(EmailProviderType.SMTP);
+        when(sesStrategy.send(any())).thenReturn(EmailSendResult.failure("SES", "temporary failure"));
+        when(smtpStrategy.send(any())).thenReturn(EmailSendResult.success("SMTP", "smtp-msg-id"));
+
+        RoutingEmailSender routingEmailSender = new RoutingEmailSender(properties, List.of(sesStrategy, smtpStrategy));
+        routingEmailSender.initializeStrategyMap();
+
+        properties.setProvider(EmailProviderType.SES);
+        properties.setFallbackEnabled(true);
+        properties.setFallbackProvider(EmailProviderType.SMTP);
+
+        EmailSendResult result = routingEmailSender.send(command);
+
+        assertTrue(result.isSuccess());
+        verify(sesStrategy).send(any());
+        verify(smtpStrategy).send(any());
+    }
+
+    @Test
+    void send_returnsPrimaryFailureWhenFallbackDisabled() {
+        when(sesStrategy.providerType()).thenReturn(EmailProviderType.SES);
+        when(sesStrategy.send(any())).thenReturn(EmailSendResult.failure("SES", "service unavailable"));
+
+        RoutingEmailSender routingEmailSender = new RoutingEmailSender(properties, List.of(sesStrategy));
+        routingEmailSender.initializeStrategyMap();
+
+        properties.setProvider(EmailProviderType.SES);
+        properties.setFallbackEnabled(false);
+
+        EmailSendResult result = routingEmailSender.send(command);
+
+        assertFalse(result.isSuccess());
+        verify(sesStrategy).send(any());
+    }
+
+    @Test
+    void send_returnsFailureWhenStrategyMissing() {
+        when(smtpStrategy.providerType()).thenReturn(EmailProviderType.SMTP);
+
+        RoutingEmailSender routingEmailSender = new RoutingEmailSender(properties, List.of(smtpStrategy));
+        routingEmailSender.initializeStrategyMap();
+
+        properties.setProvider(EmailProviderType.SES);
+
+        EmailSendResult result = routingEmailSender.send(command);
+
+        assertFalse(result.isSuccess());
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/query/NotificationQueryServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/query/NotificationQueryServiceTest.java
@@ -1,0 +1,102 @@
+package com.example.notification.service.query;
+
+import com.example.core.pagination.CursorResponse;
+import com.example.core.pagination.CursorUtils;
+import com.example.notification.dto.query.response.NotificationHistoryItemResponse;
+import com.example.notification.dto.query.response.UnreadCountResponse;
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationDelivery;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.repository.NotificationDeliveryRepository;
+import com.example.notification.repository.NotificationRepository;
+import com.example.notification.service.unread.NotificationUnreadCountService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationQueryServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationUnreadCountService notificationUnreadCountService;
+
+    @Mock
+    private NotificationDeliveryRepository notificationDeliveryRepository;
+
+    @InjectMocks
+    private NotificationQueryService notificationQueryService;
+
+    @Test
+    void findMyNotifications_returnsCursorPage() {
+        Notification first = Notification.create(10L, 1L, NotificationType.GENERAL, NotificationChannel.IN_APP,
+                "t1", "m1", null, null, null, "d1", null);
+        Notification second = Notification.create(10L, 1L, NotificationType.GENERAL, NotificationChannel.IN_APP,
+                "t2", "m2", null, null, null, "d2", null);
+        Notification third = Notification.create(10L, 1L, NotificationType.GENERAL, NotificationChannel.IN_APP,
+                "t3", "m3", null, null, null, "d3", null);
+        ReflectionTestUtils.setField(first, "id", 300L);
+        ReflectionTestUtils.setField(second, "id", 200L);
+        ReflectionTestUtils.setField(third, "id", 100L);
+
+        when(notificationRepository.findByRecipientIdWithCursor(
+                eq(10L), eq(null), eq(PageRequest.of(0, 3))
+        )).thenReturn(List.of(first, second, third));
+
+        NotificationDelivery firstDelivery = NotificationDelivery.createPending(
+                300L,
+                NotificationChannel.IN_APP,
+                "IN_APP",
+                null
+        );
+        ReflectionTestUtils.setField(firstDelivery, "id", 900L);
+        firstDelivery.markSent("IN_APP:900");
+        firstDelivery.markDelivered();
+
+        NotificationDelivery secondDelivery = NotificationDelivery.createPending(
+                200L,
+                NotificationChannel.EMAIL,
+                "EMAIL",
+                "test@example.com"
+        );
+        ReflectionTestUtils.setField(secondDelivery, "id", 901L);
+        secondDelivery.markRetry("EMAIL_SEND_FAILED", "smtp timeout", null);
+
+        when(notificationDeliveryRepository.findByNotificationIdInOrderByNotificationIdAscIdAsc(
+                eq(List.of(300L, 200L))
+        )).thenReturn(List.of(firstDelivery, secondDelivery));
+
+        CursorResponse<NotificationHistoryItemResponse> result =
+                notificationQueryService.findMyNotifications(10L, null, 2);
+
+        assertThat(result.getItems()).hasSize(2);
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isEqualTo(CursorUtils.encode(200L));
+        assertThat(result.getItems().get(0).getDeliveries()).hasSize(1);
+        assertThat(result.getItems().get(0).getDeliveries().get(0).getStatus()).isEqualTo("DELIVERED");
+        assertThat(result.getItems().get(1).getDeliveries()).hasSize(1);
+        assertThat(result.getItems().get(1).getDeliveries().get(0).getStatus()).isEqualTo("RETRYING");
+    }
+
+    @Test
+    void getUnreadCount_returnsCount() {
+        when(notificationUnreadCountService.getOrLoad(10L)).thenReturn(7L);
+
+        UnreadCountResponse response = notificationQueryService.getUnreadCount(10L);
+
+        assertThat(response.getUnreadCount()).isEqualTo(7L);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/realtime/SseConnectionManagerTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/realtime/SseConnectionManagerTest.java
@@ -1,0 +1,43 @@
+package com.example.notification.service.realtime;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.config.NotificationSseProperties;
+import com.example.notification.exception.NotificationErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SseConnectionManagerTest {
+
+    @Test
+    void connect_rejectsWhenPerUserConnectionLimitExceeded() {
+        NotificationSseProperties properties = new NotificationSseProperties();
+        properties.setMaxConnectionsPerUser(1);
+        properties.setMaxTotalConnections(10);
+
+        SseConnectionManager manager = new SseConnectionManager(properties);
+        SseEmitter first = manager.connect(1L);
+        assertThat(first).isNotNull();
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> manager.connect(1L));
+        assertThat(exception.getErrorCode()).isEqualTo(NotificationErrorCode.SSE_CONNECTION_LIMIT_EXCEEDED);
+        assertThat(manager.connectionCount(1L)).isEqualTo(1);
+    }
+
+    @Test
+    void connect_rejectsWhenTotalConnectionLimitExceeded() {
+        NotificationSseProperties properties = new NotificationSseProperties();
+        properties.setMaxConnectionsPerUser(3);
+        properties.setMaxTotalConnections(1);
+
+        SseConnectionManager manager = new SseConnectionManager(properties);
+        SseEmitter first = manager.connect(1L);
+        assertThat(first).isNotNull();
+
+        BusinessException exception = assertThrows(BusinessException.class, () -> manager.connect(2L));
+        assertThat(exception.getErrorCode()).isEqualTo(NotificationErrorCode.SSE_CONNECTION_LIMIT_EXCEEDED);
+        assertThat(manager.totalConnectionCount()).isEqualTo(1);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/realtime/SseNotificationEventTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/realtime/SseNotificationEventTest.java
@@ -1,0 +1,37 @@
+package com.example.notification.service.realtime;
+
+import com.example.notification.entity.Notification;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationType;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SseNotificationEventTest {
+
+    @Test
+    void from_escapesHtmlSensitiveFields() {
+        Notification notification = Notification.create(
+                10L,
+                10L,
+                NotificationType.GENERAL,
+                NotificationChannel.IN_APP,
+                "<script>alert('x')</script>",
+                "<img src=x onerror=alert('x')>",
+                "<b>ITEM</b>",
+                "<a>1</a>",
+                "evt-1",
+                "dedupe-1",
+                null
+        );
+        ReflectionTestUtils.setField(notification, "id", 100L);
+
+        SseNotificationEvent event = SseNotificationEvent.from(notification);
+
+        assertThat(event.getTitle()).isEqualTo("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;");
+        assertThat(event.getMessage()).isEqualTo("&lt;img src=x onerror=alert(&#39;x&#39;)&gt;");
+        assertThat(event.getReferenceType()).isEqualTo("&lt;b&gt;ITEM&lt;/b&gt;");
+        assertThat(event.getReferenceId()).isEqualTo("&lt;a&gt;1&lt;/a&gt;");
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/setting/NotificationSettingServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/setting/NotificationSettingServiceTest.java
@@ -1,0 +1,89 @@
+package com.example.notification.service.setting;
+
+import com.example.core.exception.BusinessException;
+import com.example.notification.dto.setting.request.UpdateNotificationSettingRequest;
+import com.example.notification.entity.NotificationChannel;
+import com.example.notification.entity.NotificationSetting;
+import com.example.notification.entity.NotificationType;
+import com.example.notification.entity.NotificationUserPreference;
+import com.example.notification.repository.NotificationSettingRepository;
+import com.example.notification.repository.NotificationUserPreferenceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSettingServiceTest {
+
+    @Mock
+    private NotificationSettingRepository notificationSettingRepository;
+
+    @Mock
+    private NotificationUserPreferenceRepository notificationUserPreferenceRepository;
+
+    @Mock
+    private NotificationSettingPolicy notificationSettingPolicy;
+
+    @InjectMocks
+    private NotificationSettingService notificationSettingService;
+
+    @Test
+    void shouldSendNotification_returnsFalseWhenGlobalDisabled() {
+        NotificationUserPreference preference = NotificationUserPreference.createDefault(1L);
+        preference.updateGlobalEnabled(false);
+        when(notificationUserPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(preference));
+
+        boolean sendable = notificationSettingService.shouldSendNotification(
+                1L, NotificationType.PAYMENT, NotificationChannel.EMAIL
+        );
+
+        assertFalse(sendable);
+        verify(notificationSettingRepository, never()).findByUserIdAndTypeAndChannel(anyLong(), any(), any());
+    }
+
+    @Test
+    void shouldSendNotification_usesDefaultPolicyWhenNoUserSetting() {
+        NotificationUserPreference preference = NotificationUserPreference.createDefault(1L);
+        when(notificationUserPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(preference));
+        when(notificationSettingRepository.findByUserIdAndTypeAndChannel(
+                1L, NotificationType.STOCK_DEPLETED, NotificationChannel.SMS
+        )).thenReturn(Optional.empty());
+        when(notificationSettingPolicy.isDefaultEnabled(NotificationChannel.SMS)).thenReturn(false);
+
+        boolean sendable = notificationSettingService.shouldSendNotification(
+                1L, NotificationType.STOCK_DEPLETED, NotificationChannel.SMS
+        );
+
+        assertFalse(sendable);
+        verify(notificationSettingPolicy).isDefaultEnabled(NotificationChannel.SMS);
+    }
+
+    @Test
+    void upsertSetting_throwsWhenNoFieldToUpdate() {
+        NotificationSetting existing = NotificationSetting.createDefault(
+                1L, NotificationType.GENERAL, NotificationChannel.EMAIL, true
+        );
+        when(notificationSettingRepository.findByUserIdAndTypeAndChannel(
+                1L, NotificationType.GENERAL, NotificationChannel.EMAIL
+        )).thenReturn(Optional.of(existing));
+
+        UpdateNotificationSettingRequest request = new UpdateNotificationSettingRequest();
+        ReflectionTestUtils.setField(request, "type", "GENERAL");
+        ReflectionTestUtils.setField(request, "channel", "EMAIL");
+
+        assertThrows(BusinessException.class, () -> notificationSettingService.upsertSetting(1L, request));
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/template/TemplateRenderServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/template/TemplateRenderServiceTest.java
@@ -1,0 +1,32 @@
+package com.example.notification.service.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplateRenderServiceTest {
+
+    private final TemplateRenderService templateRenderService = new TemplateRenderService();
+
+    @Test
+    void render_replacesTemplateVariables() {
+        String rendered = templateRenderService.render(
+                "안녕하세요 {{userName}}, {{itemName}} 오픈!",
+                Map.of("userName", "딩주", "itemName", "봄 콘서트")
+        );
+
+        assertThat(rendered).isEqualTo("안녕하세요 딩주, 봄 콘서트 오픈!");
+    }
+
+    @Test
+    void render_keepsEmptyForMissingVariables() {
+        String rendered = templateRenderService.render(
+                "{{known}}/{{unknown}}",
+                Map.of("known", "ok")
+        );
+
+        assertThat(rendered).isEqualTo("ok/");
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/unread/NotificationUnreadCountServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/unread/NotificationUnreadCountServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.notification.service.unread;
+
+import com.example.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationUnreadCountServiceTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private NotificationUnreadCountService notificationUnreadCountService;
+
+    @Test
+    void getOrLoad_returnsCachedValueWhenExists() {
+        notificationUnreadCountService = new NotificationUnreadCountService(stringRedisTemplate, notificationRepository);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("notification:unread:10")).thenReturn("7");
+
+        long unread = notificationUnreadCountService.getOrLoad(10L);
+
+        assertThat(unread).isEqualTo(7L);
+        verify(notificationRepository, never()).countByRecipientIdAndIsReadFalse(10L);
+    }
+
+    @Test
+    void getOrLoad_loadsFromDbWhenCacheMiss() {
+        notificationUnreadCountService = new NotificationUnreadCountService(stringRedisTemplate, notificationRepository);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("notification:unread:10")).thenReturn(null);
+        when(notificationRepository.countByRecipientIdAndIsReadFalse(10L)).thenReturn(3L);
+
+        long unread = notificationUnreadCountService.getOrLoad(10L);
+
+        assertThat(unread).isEqualTo(3L);
+        verify(valueOperations).set(eq("notification:unread:10"), eq("3"), any(Duration.class));
+    }
+
+    @Test
+    void increase_updatesCacheCounter() {
+        notificationUnreadCountService = new NotificationUnreadCountService(stringRedisTemplate, notificationRepository);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment("notification:unread:10")).thenReturn(2L);
+
+        notificationUnreadCountService.increase(10L);
+
+        verify(valueOperations).increment("notification:unread:10");
+        verify(stringRedisTemplate).expire(eq("notification:unread:10"), any(Duration.class));
+    }
+
+    @Test
+    void decreaseSafely_executesLuaScript() {
+        notificationUnreadCountService = new NotificationUnreadCountService(stringRedisTemplate, notificationRepository);
+        notificationUnreadCountService.decreaseSafely(10L, 2L);
+
+        verify(stringRedisTemplate).execute(
+                any(),
+                eq(Collections.singletonList("notification:unread:10")),
+                eq("2"),
+                any()
+        );
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include("servers:services:user")
 include("servers:services:product")
 include("servers:services:stock")
 include("servers:services:funding")
+include("servers:services:notification")
 include("servers:services:sales")
 include("servers:services:hot-deal")
 


### PR DESCRIPTION
## 개요
Notification 서비스를 신규 추가하고, 이벤트 소비 기반 알림 생성/전달/조회/설정/실시간(SSE) 기능의 MVP 경로를 구축했습니다.

### 관련 이슈
- Closes #13
- Closes #232
- Closes #233
- Closes #240
- Closes #243
- Closes #248
- Closes #250
- Closes #252
- Closes #256
- Closes #263
- Closes #275
- Closes #285
- Closes #292
- Closes #300
- Closes #301
- Closes #306

### 작업 / 변경 내용
- `servers:services:notification` 모듈 신규 추가 및 `settings.gradle.kts` 등록
- Notification 도메인 엔티티/리포지토리/서비스/컨트롤러/DTO 계층 구현
- Kafka 소비자(`funding-events`, `payment-events`, `hotdeal-events`, `stock-events`) 기반 알림 생성 로직 구현
- 알림 전달 경로 구현(SSE, Email) 및 전달 상태/재시도 스케줄러 구현
- Redis 기반 미읽음 카운트 및 멀티 인스턴스 SSE Pub/Sub 연동
- 알림 설정(글로벌 ON/OFF, 타입/채널별 설정) API 및 정책 구현
- 보안 필터(`GatewayHeaderValidationFilter`) 및 게이트웨이 헤더 신뢰 검증 경로 추가
- MailHog 로컬 SMTP 테스트를 위해 `docker/docker-compose.yml`에 `mailhog` 서비스 추가
- Notification 서비스 단위 테스트 세트 추가

### 테스트 / 체크리스트
- [x] 로컬에서 빌드 확인 (`env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:hot-deal:compileJava --no-daemon`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:notification:test --no-daemon`)
- [x] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- Notification은 현재 gateway 헤더 기반 인증 경계(`X-User-Id` + 내부 auth 토큰)를 전제로 동작합니다.
- API Gateway 라우팅 연결 후 외부 트래픽 경유 경로에서 최종 검증이 필요합니다.
