### PR TITLE
[STORY-628] Search 버전 가드 기반 재고 동기화

### DIFF
--- a/servers/services/search/src/main/java/com/example/search/consumer/StockEventConsumer.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/StockEventConsumer.java
@@ -62,18 +62,35 @@ public class StockEventConsumer {
     private void route(StockEventMessage event) {
         String normalizedType = normalizeEventType(event.getEventType());
         switch (normalizedType) {
-            case "STOCK_DECREASED" -> handleStockDecreased(event);
+            case "STOCK_DECREASED", "STOCK_INCREASED" -> handleLegacyStockChanged(event, normalizedType);
+            case "ITEM_AVAILABLE_STOCK_CHANGED" -> handleItemAvailableStockChanged(event);
             default -> log.debug("[SearchStockConsumer] 처리하지 않는 이벤트 타입: {}", event.getEventType());
         }
     }
 
-    private void handleStockDecreased(StockEventMessage event) {
-        if (event.getRemainingQuantity() == null) {
-            log.warn("[SearchStockConsumer] remainingQuantity 누락으로 재고 업데이트 스킵. itemId={}", event.getItemId());
+    private void handleLegacyStockChanged(StockEventMessage event, String eventType) {
+        Integer stock = event.resolveLegacyStockQuantity();
+        if (stock == null) {
+            log.warn("[SearchStockConsumer] legacy 재고 값 누락으로 업데이트 스킵. eventType={}, itemId={}",
+                    eventType, event.getItemId());
             return;
         }
 
-        searchIndexingService.updateItemStock(event.getItemId(), event.getRemainingQuantity());
+        searchIndexingService.updateItemStock(event.getItemId(), stock);
+        searchResultCacheService.evictAll();
+    }
+
+    private void handleItemAvailableStockChanged(StockEventMessage event) {
+        if (event.getAvailableStockTotal() == null || event.getStockVersion() == null) {
+            log.warn("[SearchStockConsumer] availableStockTotal/stockVersion 누락으로 스냅샷 업데이트 스킵. itemId={}",
+                    event.getItemId());
+            return;
+        }
+        searchIndexingService.updateItemStockVersioned(
+                event.getItemId(),
+                event.getAvailableStockTotal(),
+                event.getStockVersion()
+        );
         searchResultCacheService.evictAll();
     }
 

--- a/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
@@ -14,4 +14,14 @@ public class StockEventMessage {
     private Long itemId;
     private Integer quantity;
     private Integer remainingQuantity;
+    private Integer currentQuantity;
+    private Integer availableStockTotal;
+    private Long stockVersion;
+
+    public Integer resolveLegacyStockQuantity() {
+        if (currentQuantity != null) {
+            return currentQuantity;
+        }
+        return remainingQuantity;
+    }
 }

--- a/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
+++ b/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
@@ -49,6 +49,9 @@ public class ItemDocument {
     @Field(type = FieldType.Integer)
     private Integer stock;
 
+    @Field(type = FieldType.Long)
+    private Long stockVersion;
+
     @Field(type = FieldType.Keyword)
     private List<String> tags;
 

--- a/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
@@ -7,6 +7,7 @@ import com.example.search.exception.SearchErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.springframework.stereotype.Service;
 
@@ -73,6 +74,35 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
     }
 
     @Override
+    public void updateItemStockVersioned(Long itemId, Integer stock, Long stockVersion) {
+        if (itemId == null || stock == null || stockVersion == null) {
+            return;
+        }
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("itemId", itemId);
+        params.put("stock", stock);
+        params.put("stockVersion", stockVersion);
+
+        Map<String, Object> script = new LinkedHashMap<>();
+        script.put("lang", "painless");
+        script.put("source",
+                "if (ctx._source.stockVersion == null || params.stockVersion > ctx._source.stockVersion) { " +
+                        "ctx._source.itemId = params.itemId; " +
+                        "ctx._source.stock = params.stock; " +
+                        "ctx._source.stockVersion = params.stockVersion; " +
+                        "} else { ctx.op = 'none'; }");
+        script.put("params", params);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("script", script);
+
+        Request request = new Request("POST", endpointForUpdate(itemId));
+        request.setJsonEntity(JsonUtils.toJson(body));
+        performRequestAllowMissing(request, itemId, "ITEM_AVAILABLE_STOCK_CHANGED");
+    }
+
+    @Override
     public void deleteItem(Long itemId) {
         if (itemId == null) {
             return;
@@ -103,6 +133,30 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
             log.debug("Search index updated. eventType={}, itemId={}", eventType, itemId);
         } catch (IOException e) {
             log.error("Search index request failed. eventType={}, itemId={}", eventType, itemId, e);
+            throw new BusinessException(
+                    SearchErrorCode.SEARCH_INDEXING_FAILED,
+                    "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,
+                    e
+            );
+        }
+    }
+
+    private void performRequestAllowMissing(Request request, Long itemId, String eventType) {
+        try {
+            restClient.performRequest(request);
+            log.debug("Search index updated. eventType={}, itemId={}", eventType, itemId);
+        } catch (ResponseException e) {
+            int status = e.getResponse() == null ? -1 : e.getResponse().getStatusLine().getStatusCode();
+            if (status == 404) {
+                log.debug("Search document not found. skip stock sync. eventType={}, itemId={}", eventType, itemId);
+                return;
+            }
+            throw new BusinessException(
+                    SearchErrorCode.SEARCH_INDEXING_FAILED,
+                    "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,
+                    e
+            );
+        } catch (IOException e) {
             throw new BusinessException(
                     SearchErrorCode.SEARCH_INDEXING_FAILED,
                     "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
@@ -75,6 +75,8 @@ public class SearchIndexingFailureService {
             case "ITEM_STATUS_CHANGED" -> replayItemStatusChanged(payload);
             case "ITEM_DELETED" -> replayItemDeleted(payload);
             case "STOCK_DECREASED" -> replayStockDecreased(payload);
+            case "STOCK_INCREASED" -> replayStockIncreased(payload);
+            case "ITEM_AVAILABLE_STOCK_CHANGED" -> replayItemAvailableStockChanged(payload);
             default -> throw new BusinessException(SearchErrorCode.SEARCH_INDEXING_FAILED,
                     "지원하지 않는 재처리 이벤트 타입입니다. eventType=" + eventType);
         }
@@ -112,6 +114,20 @@ public class SearchIndexingFailureService {
     private void replayStockDecreased(String payload) {
         StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
         searchIndexingService.updateItemStock(event.getItemId(), event.getRemainingQuantity());
+    }
+
+    private void replayStockIncreased(String payload) {
+        StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
+        searchIndexingService.updateItemStock(event.getItemId(), event.resolveLegacyStockQuantity());
+    }
+
+    private void replayItemAvailableStockChanged(String payload) {
+        StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
+        searchIndexingService.updateItemStockVersioned(
+                event.getItemId(),
+                event.getAvailableStockTotal(),
+                event.getStockVersion()
+        );
     }
 
     private void recordFailure(String eventId, String eventType, Long itemId, String payload, Exception e) {

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
@@ -16,5 +16,7 @@ public interface SearchIndexingService {
 
     void updateItemStock(Long itemId, Integer stock);
 
+    void updateItemStockVersioned(Long itemId, Integer stock, Long stockVersion);
+
     void deleteItem(Long itemId);
 }

--- a/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
+++ b/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
@@ -89,6 +89,9 @@
       "stock": {
         "type": "integer"
       },
+      "stockVersion": {
+        "type": "long"
+      },
       "tags": {
         "type": "keyword"
       },

--- a/servers/services/search/src/test/java/com/example/search/consumer/StockEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/StockEventConsumerTest.java
@@ -63,6 +63,44 @@ class StockEventConsumerTest {
     }
 
     @Test
+    void consume_routesItemAvailableStockChangedToVersionedUpdate() {
+        stubIdempotentExecution();
+
+        String message = """
+                {
+                  "eventId": "evt-stock-2",
+                  "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                  "itemId": 101,
+                  "availableStockTotal": 11,
+                  "stockVersion": 57
+                }
+                """;
+
+        stockEventConsumer.consume(message);
+
+        verify(searchIndexingService).updateItemStockVersioned(101L, 11, 57L);
+        verify(searchResultCacheService).evictAll();
+    }
+
+    @Test
+    void consume_skipsVersionedUpdateWhenSnapshotFieldsMissing() {
+        stubIdempotentExecution();
+
+        String message = """
+                {
+                  "eventId": "evt-stock-3",
+                  "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                  "itemId": 101,
+                  "availableStockTotal": 11
+                }
+                """;
+
+        stockEventConsumer.consume(message);
+
+        verify(searchIndexingService, never()).updateItemStockVersioned(any(), any(), any());
+    }
+
+    @Test
     void consume_ignoresInvalidEventWithoutIdempotentExecution() {
         String message = """
                 {
@@ -75,6 +113,7 @@ class StockEventConsumerTest {
 
         verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
         verify(searchIndexingService, never()).updateItemStock(any(), any());
+        verify(searchIndexingService, never()).updateItemStockVersioned(any(), any(), any());
         verify(searchResultCacheService, never()).evictAll();
     }
 

--- a/servers/services/search/src/test/java/com/example/search/service/index/ElasticsearchIndexingServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/ElasticsearchIndexingServiceTest.java
@@ -73,6 +73,24 @@ class ElasticsearchIndexingServiceTest {
     }
 
     @Test
+    void updateItemStockVersioned_sendsScriptUpdateRequest() throws Exception {
+        when(restClient.performRequest(any(Request.class))).thenReturn(mock(Response.class));
+
+        indexingService.updateItemStockVersioned(15L, 9, 57L);
+
+        ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+        verify(restClient).performRequest(captor.capture());
+        Request request = captor.getValue();
+
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getEndpoint()).isEqualTo("/items-write/_update/15");
+        String json = EntityUtils.toString(request.getEntity());
+        assertThat(json).contains("\"script\"");
+        assertThat(json).contains("\"stockVersion\":57");
+        assertThat(json).contains("\"stock\":9");
+    }
+
+    @Test
     void updateItemStock_wrapsIOExceptionAsBusinessException() throws Exception {
         when(restClient.performRequest(any(Request.class))).thenThrow(new IOException("es-down"));
 

--- a/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
@@ -98,6 +98,37 @@ class SearchIndexingFailureServiceTest {
         assertThat(response.getRetryCount()).isEqualTo(1);
     }
 
+    @Test
+    void retryFailure_replaysVersionedStockSnapshot() {
+        SearchIndexingFailure failure = SearchIndexingFailure.builder()
+                .eventId("evt-stock-57")
+                .eventType("ITEM_AVAILABLE_STOCK_CHANGED")
+                .itemId(101L)
+                .payload("""
+                        {
+                          "eventId": "evt-stock-57",
+                          "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                          "itemId": 101,
+                          "availableStockTotal": 12,
+                          "stockVersion": 57
+                        }
+                        """)
+                .retryCount(0)
+                .status(SearchIndexingFailureStatus.PENDING)
+                .failureReason("initial")
+                .build();
+
+        when(failureRepository.findById(2L)).thenReturn(Optional.of(failure));
+        when(failureRepository.save(any(SearchIndexingFailure.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        IndexingFailureRetryResponse response = searchIndexingFailureService.retryFailure(2L);
+
+        verify(searchIndexingService).updateItemStockVersioned(101L, 12, 57L);
+        verify(searchResultCacheService).evictAll();
+        assertThat(response.getStatus()).isEqualTo(SearchIndexingFailureStatus.RESOLVED);
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## 변경 내용
- Search `stock-events` 소비에 `ITEM_AVAILABLE_STOCK_CHANGED` 처리 추가
- `stockVersion` 기반 업데이트(`incomingVersion > currentVersion`) 적용
- ES 업데이트를 스크립트 기반 버전 가드로 변경
- 삭제 문서에 대한 재고 동기화 시 404를 무시해 좀비 문서 재생성 방지
- 실패 재처리 서비스가 신규 이벤트 타입(`ITEM_AVAILABLE_STOCK_CHANGED`) 지원
- 인덱스 템플릿/문서 모델에 `stockVersion` 필드 추가

## 호환성
- 기존 `STOCK_DECREASED`/`STOCK_INCREASED` 이벤트는 legacy 경로로 계속 수용
- 신규 스냅샷 이벤트와 병행 운영 가능

## 검증
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:search:test --rerun-tasks`

## 이슈
Closes #628
Related #625
