### PR TITLE
[STORY-626] Stock 재고 스냅샷 이벤트(itemId+version) 전환

### DIFF
--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockSyncVersion.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockSyncVersion.java
@@ -1,0 +1,34 @@
+package com.example.stock.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stock_sync_versions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockSyncVersion {
+
+    @Id
+    private Long itemId;
+
+    @Column(nullable = false)
+    private long version;
+
+    public static StockSyncVersion initialize(Long itemId) {
+        StockSyncVersion syncVersion = new StockSyncVersion();
+        syncVersion.itemId = itemId;
+        syncVersion.version = 0L;
+        return syncVersion;
+    }
+
+    public long incrementAndGet() {
+        this.version += 1L;
+        return this.version;
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/ItemAvailableStockChangedEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/ItemAvailableStockChangedEvent.java
@@ -1,0 +1,36 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ItemAvailableStockChangedEvent extends DomainEvent {
+
+    private final Long itemId;
+    private final int availableStockTotal;
+    private final long stockVersion;
+
+    public ItemAvailableStockChangedEvent(Long itemId, int availableStockTotal, long stockVersion) {
+        super("stock-events");
+        this.itemId = itemId;
+        this.availableStockTotal = availableStockTotal;
+        this.stockVersion = stockVersion;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ITEM_AVAILABLE_STOCK_CHANGED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "itemId", itemId,
+                "availableStockTotal", availableStockTotal,
+                "stockVersion", stockVersion,
+                "occurredAt", getOccurredAt().toString()
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
@@ -22,4 +22,7 @@ public interface StockItemRepository extends JpaRepository<StockItem, Long> {
     List<StockItem> findByItemId(Long itemId);
 
     List<StockItem> findByItemIdAndStockItemType(Long itemId, StockItemType stockItemType);
+
+    @Query("SELECT COALESCE(SUM(s.availableQuantity), 0) FROM StockItem s WHERE s.itemId = :itemId")
+    Long sumAvailableQuantityByItemId(@Param("itemId") Long itemId);
 }

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockSyncVersionRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockSyncVersionRepository.java
@@ -1,0 +1,17 @@
+package com.example.stock.repository;
+
+import com.example.stock.entity.StockSyncVersion;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface StockSyncVersionRepository extends JpaRepository<StockSyncVersion, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM StockSyncVersion s WHERE s.itemId = :itemId")
+    Optional<StockSyncVersion> findByItemIdWithLock(@Param("itemId") Long itemId);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
@@ -8,6 +8,7 @@ import com.example.stock.dto.request.*;
 import com.example.stock.dto.response.ReservationResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.entity.*;
+import com.example.stock.event.ItemAvailableStockChangedEvent;
 import com.example.stock.event.StockDecreasedEvent;
 import com.example.stock.event.StockDepletedEvent;
 import com.example.stock.event.StockIncreasedEvent;
@@ -16,9 +17,11 @@ import com.example.stock.exception.StockErrorCode;
 import com.example.stock.repository.StockHistoryRepository;
 import com.example.stock.repository.StockItemRepository;
 import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.repository.StockSyncVersionRepository;
 import com.example.stock.service.StockCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +37,7 @@ public class StockCommandService {
     private final StockItemRepository stockItemRepository;
     private final StockReservationRepository stockReservationRepository;
     private final StockHistoryRepository stockHistoryRepository;
+    private final StockSyncVersionRepository stockSyncVersionRepository;
     private final StockCacheService stockCacheService;
     private final EventPublisher eventPublisher;
 
@@ -55,6 +59,7 @@ public class StockCommandService {
 
         // 이벤트 발행
         publishStockEvents(stockItem, request.getQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -73,6 +78,7 @@ public class StockCommandService {
         eventPublisher.publish(
                 new StockIncreasedEvent(stockItem.getId(), stockItem.getItemId(), request.getQuantity(), stockItem.getAvailableQuantity()),
                 EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -97,6 +103,7 @@ public class StockCommandService {
                 "예약 생성 (userId=" + request.getUserId() + ")", reservation.getId()));
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return ReservationResponse.from(reservation);
     }
@@ -147,6 +154,7 @@ public class StockCommandService {
                 "예약 취소", reservation.getId()));
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return ReservationResponse.from(reservation);
     }
@@ -174,6 +182,7 @@ public class StockCommandService {
         }
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -196,6 +205,7 @@ public class StockCommandService {
             stockHistoryRepository.save(StockHistory.create(
                     stockItem.getId(), ChangeType.EXPIRE, reservation.getQuantity(),
                     "예약 만료 자동 복원", reservation.getId()));
+            publishItemStockSnapshotEvent(stockItem.getItemId());
         }
     }
 
@@ -214,6 +224,45 @@ public class StockCommandService {
                             stockItem.getAvailableQuantity(), stockItem.getTotalQuantity()),
                     EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
         }
+    }
+
+    private void publishItemStockSnapshotEvent(Long itemId) {
+        if (itemId == null) {
+            return;
+        }
+        long stockVersion = nextStockVersion(itemId);
+        int availableStockTotal = sumAvailableStockByItemId(itemId);
+        eventPublisher.publish(
+                new ItemAvailableStockChangedEvent(itemId, availableStockTotal, stockVersion),
+                EventMetadata.of("Item", String.valueOf(itemId))
+        );
+    }
+
+    private long nextStockVersion(Long itemId) {
+        for (int attempt = 0; attempt < 2; attempt++) {
+            StockSyncVersion syncVersion = stockSyncVersionRepository.findByItemIdWithLock(itemId)
+                    .orElse(null);
+            if (syncVersion != null) {
+                return syncVersion.incrementAndGet();
+            }
+            try {
+                stockSyncVersionRepository.saveAndFlush(StockSyncVersion.initialize(itemId));
+            } catch (DataIntegrityViolationException e) {
+                log.debug("Stock sync version row already exists. itemId={}", itemId);
+            }
+        }
+
+        StockSyncVersion syncVersion = stockSyncVersionRepository.findByItemIdWithLock(itemId)
+                .orElseGet(() -> stockSyncVersionRepository.saveAndFlush(StockSyncVersion.initialize(itemId)));
+        return syncVersion.incrementAndGet();
+    }
+
+    private int sumAvailableStockByItemId(Long itemId) {
+        Long total = stockItemRepository.sumAvailableQuantityByItemId(itemId);
+        if (total == null) {
+            return 0;
+        }
+        return Math.toIntExact(total);
     }
 
     private StockItem getStockItemWithLock(Long stockItemId) {

--- a/servers/services/stock/src/test/java/com/example/stock/service/command/StockCommandServiceStockSnapshotEventTest.java
+++ b/servers/services/stock/src/test/java/com/example/stock/service/command/StockCommandServiceStockSnapshotEventTest.java
@@ -1,0 +1,128 @@
+package com.example.stock.service.command;
+
+import com.example.event.DomainEvent;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.stock.dto.request.StockDecreaseRequest;
+import com.example.stock.dto.request.StockIncreaseRequest;
+import com.example.stock.entity.StockItem;
+import com.example.stock.entity.StockItemType;
+import com.example.stock.entity.StockSyncVersion;
+import com.example.stock.event.ItemAvailableStockChangedEvent;
+import com.example.stock.repository.StockHistoryRepository;
+import com.example.stock.repository.StockItemRepository;
+import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.repository.StockSyncVersionRepository;
+import com.example.stock.service.StockCacheService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockCommandServiceStockSnapshotEventTest {
+
+    @Mock
+    private StockItemRepository stockItemRepository;
+
+    @Mock
+    private StockReservationRepository stockReservationRepository;
+
+    @Mock
+    private StockHistoryRepository stockHistoryRepository;
+
+    @Mock
+    private StockSyncVersionRepository stockSyncVersionRepository;
+
+    @Mock
+    private StockCacheService stockCacheService;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private StockCommandService stockCommandService;
+
+    @Test
+    void decreaseStock_publishesItemSnapshotEventWithVersionAndItemKey() {
+        StockItem stockItem = StockItem.create(200L, StockItemType.SEAT_GRADE, 300L, 10);
+        ReflectionTestUtils.setField(stockItem, "id", 100L);
+
+        StockDecreaseRequest request = new StockDecreaseRequest();
+        ReflectionTestUtils.setField(request, "stockItemId", 100L);
+        ReflectionTestUtils.setField(request, "quantity", 1);
+        ReflectionTestUtils.setField(request, "reason", "purchase");
+
+        StockSyncVersion syncVersion = StockSyncVersion.initialize(200L);
+        ReflectionTestUtils.setField(syncVersion, "version", 4L);
+
+        when(stockItemRepository.findByIdWithLock(100L)).thenReturn(Optional.of(stockItem));
+        when(stockItemRepository.sumAvailableQuantityByItemId(200L)).thenReturn(9L);
+        when(stockSyncVersionRepository.findByItemIdWithLock(200L)).thenReturn(Optional.of(syncVersion));
+
+        stockCommandService.decreaseStock(request);
+
+        SnapshotEventResult snapshot = captureSnapshotEvent();
+        assertThat(snapshot.event.getItemId()).isEqualTo(200L);
+        assertThat(snapshot.event.getAvailableStockTotal()).isEqualTo(9);
+        assertThat(snapshot.event.getStockVersion()).isEqualTo(5L);
+        assertThat(snapshot.metadata.aggregateId()).isEqualTo("200");
+    }
+
+    @Test
+    void increaseStock_publishesItemSnapshotEvent() {
+        StockItem stockItem = StockItem.create(201L, StockItemType.SEAT_GRADE, 301L, 10);
+        ReflectionTestUtils.setField(stockItem, "id", 101L);
+
+        StockIncreaseRequest request = new StockIncreaseRequest();
+        ReflectionTestUtils.setField(request, "stockItemId", 101L);
+        ReflectionTestUtils.setField(request, "quantity", 2);
+        ReflectionTestUtils.setField(request, "reason", "refund");
+
+        StockSyncVersion syncVersion = StockSyncVersion.initialize(201L);
+        ReflectionTestUtils.setField(syncVersion, "version", 9L);
+
+        when(stockItemRepository.findByIdWithLock(101L)).thenReturn(Optional.of(stockItem));
+        when(stockItemRepository.sumAvailableQuantityByItemId(201L)).thenReturn(10L);
+        when(stockSyncVersionRepository.findByItemIdWithLock(201L)).thenReturn(Optional.of(syncVersion));
+
+        stockCommandService.increaseStock(request);
+
+        SnapshotEventResult snapshot = captureSnapshotEvent();
+        assertThat(snapshot.event.getItemId()).isEqualTo(201L);
+        assertThat(snapshot.event.getAvailableStockTotal()).isEqualTo(10);
+        assertThat(snapshot.event.getStockVersion()).isEqualTo(10L);
+        assertThat(snapshot.metadata.aggregateId()).isEqualTo("201");
+    }
+
+    private SnapshotEventResult captureSnapshotEvent() {
+        ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+        ArgumentCaptor<EventMetadata> metadataCaptor = ArgumentCaptor.forClass(EventMetadata.class);
+        verify(eventPublisher, atLeastOnce()).publish(eventCaptor.capture(), metadataCaptor.capture());
+
+        List<DomainEvent> events = eventCaptor.getAllValues();
+        int snapshotIndex = IntStream.range(0, events.size())
+                .filter(index -> events.get(index) instanceof ItemAvailableStockChangedEvent)
+                .findFirst()
+                .orElseThrow();
+
+        ItemAvailableStockChangedEvent event = (ItemAvailableStockChangedEvent) events.get(snapshotIndex);
+        EventMetadata metadata = metadataCaptor.getAllValues().get(snapshotIndex);
+        return new SnapshotEventResult(event, metadata);
+    }
+
+    private record SnapshotEventResult(ItemAvailableStockChangedEvent event, EventMetadata metadata) {
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `ITEM_AVAILABLE_STOCK_CHANGED` 이벤트를 `stock-events` 토픽에 추가
- `itemId` 단위 재고 스냅샷(`availableStockTotal`) + `stockVersion` 발행 구현
- 재고 변화가 실제 발생하는 경로(감소/증가/예약/취소/만료/초기화)에서 공통 발행
- `stock_sync_versions` 엔티티/리포지토리 추가로 item별 단조 증가 버전 관리
- `StockCommandService` 단위 테스트 추가

## 검증
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:stock:test --rerun-tasks`

## 이슈
Closes #626
Related #625
