### PR TITLE
[STORY-627] 재고 정합성 reconciliation 및 관측성 강화

### DIFF
--- a/servers/services/search/src/main/java/com/example/search/client/StockQueryClient.java
+++ b/servers/services/search/src/main/java/com/example/search/client/StockQueryClient.java
@@ -1,0 +1,47 @@
+package com.example.search.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class StockQueryClient {
+
+    private final WebClient webClient;
+
+    public StockQueryClient(WebClient.Builder webClientBuilder,
+                            @Value("${app.service.stock-url:http://localhost:8085}") String stockServiceUrl) {
+        this.webClient = webClientBuilder.baseUrl(stockServiceUrl).build();
+    }
+
+    public int fetchAvailableStockTotal(Long itemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/stock/items/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new IllegalStateException("stock summary api failed");
+            }
+
+            JsonNode stocks = response.path("data").path("stocks");
+            if (!stocks.isArray()) {
+                return 0;
+            }
+
+            int total = 0;
+            for (JsonNode stock : stocks) {
+                total += stock.path("availableQuantity").asInt(0);
+            }
+            return total;
+        } catch (Exception e) {
+            log.warn("Failed to fetch stock summary. itemId={}", itemId, e);
+            throw new IllegalStateException("failed to fetch stock summary. itemId=" + itemId, e);
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/controller/api/internal/SearchStockReconciliationApi.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/api/internal/SearchStockReconciliationApi.java
@@ -1,0 +1,16 @@
+package com.example.search.controller.api.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Search Internal Reconciliation", description = "검색 재고 정합성 점검 내부 API")
+public interface SearchStockReconciliationApi {
+
+    @Operation(summary = "itemId 기준 재고 정합성 점검")
+    @GetMapping("/stock/{itemId}")
+    ApiResponse<StockReconciliationResponse> reconcileStock(@PathVariable Long itemId);
+}

--- a/servers/services/search/src/main/java/com/example/search/controller/internal/SearchStockReconciliationController.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/internal/SearchStockReconciliationController.java
@@ -1,0 +1,23 @@
+package com.example.search.controller.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.search.controller.api.internal.SearchStockReconciliationApi;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.reconciliation.StockReconciliationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/search/reconciliation")
+@RequiredArgsConstructor
+public class SearchStockReconciliationController implements SearchStockReconciliationApi {
+
+    private final StockReconciliationService stockReconciliationService;
+
+    @Override
+    public ApiResponse<StockReconciliationResponse> reconcileStock(@PathVariable Long itemId) {
+        return ApiResponse.success(stockReconciliationService.reconcileItem(itemId));
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/dto/reconciliation/response/StockReconciliationResponse.java
+++ b/servers/services/search/src/main/java/com/example/search/dto/reconciliation/response/StockReconciliationResponse.java
@@ -1,0 +1,15 @@
+package com.example.search.dto.reconciliation.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockReconciliationResponse {
+
+    private final Long itemId;
+    private final Integer sourceAvailableStock;
+    private final Integer indexedStock;
+    private final boolean matched;
+    private final String result;
+}

--- a/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
@@ -56,4 +56,9 @@ public class SearchMetricsService {
     public void updateKafkaLag(long lag) {
         kafkaLagMax.set(Math.max(lag, -1L));
     }
+
+    public void recordStockReconciliation(String result) {
+        String safeResult = (result == null || result.isBlank()) ? "unknown" : result;
+        meterRegistry.counter("search.reconciliation.checks", "result", safeResult).increment();
+    }
 }

--- a/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationScheduler.java
+++ b/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationScheduler.java
@@ -1,0 +1,42 @@
+package com.example.search.service.reconciliation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockReconciliationScheduler {
+
+    private final StockReconciliationService stockReconciliationService;
+
+    @Value("${search.reconciliation.enabled:false}")
+    private boolean reconciliationEnabled;
+
+    @Value("${search.reconciliation.sample-item-ids:}")
+    private String sampleItemIds;
+
+    @Scheduled(fixedDelayString = "${search.reconciliation.interval-ms:300000}")
+    public void reconcileSampleItems() {
+        if (!reconciliationEnabled || !StringUtils.hasText(sampleItemIds)) {
+            return;
+        }
+
+        String[] tokens = sampleItemIds.split(",");
+        for (String token : tokens) {
+            if (!StringUtils.hasText(token)) {
+                continue;
+            }
+            try {
+                Long itemId = Long.parseLong(token.trim());
+                stockReconciliationService.reconcileItem(itemId);
+            } catch (NumberFormatException e) {
+                log.warn("[StockReconcile] invalid sample item id. raw={}", token);
+            }
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationService.java
@@ -1,0 +1,129 @@
+package com.example.search.service.reconciliation;
+
+import com.example.core.util.JsonUtils;
+import com.example.search.client.StockQueryClient;
+import com.example.search.document.ItemDocument;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.metrics.SearchMetricsService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockReconciliationService {
+
+    private final RestClient restClient;
+    private final StockQueryClient stockQueryClient;
+    private final SearchMetricsService searchMetricsService;
+
+    @Value("${search.metrics.runbook-url:https://runbook.example/search}")
+    private String runbookUrl;
+
+    public StockReconciliationResponse reconcileItem(Long itemId) {
+        Integer sourceStock;
+        try {
+            sourceStock = stockQueryClient.fetchAvailableStockTotal(itemId);
+        } catch (Exception e) {
+            searchMetricsService.recordStockReconciliation("source_error");
+            return buildResponse(itemId, null, null, false, "source_error");
+        }
+
+        Integer indexedStock;
+        try {
+            indexedStock = fetchIndexedStock(itemId);
+        } catch (Exception e) {
+            searchMetricsService.recordStockReconciliation("index_error");
+            log.warn("[StockReconcile] index read failed. itemId={}, runbook={}", itemId, runbookUrl, e);
+            return buildResponse(itemId, sourceStock, null, false, "index_error");
+        }
+
+        if (indexedStock == null) {
+            searchMetricsService.recordStockReconciliation("index_missing");
+            log.warn("[StockReconcile] indexed document missing. itemId={}, sourceStock={}, runbook={}",
+                    itemId, sourceStock, runbookUrl);
+            return buildResponse(itemId, sourceStock, null, false, "index_missing");
+        }
+
+        boolean matched = sourceStock.equals(indexedStock);
+        String result = matched ? "matched" : "mismatch";
+        searchMetricsService.recordStockReconciliation(result);
+        if (!matched) {
+            log.warn("[StockReconcile] stock mismatch detected. itemId={}, sourceStock={}, indexedStock={}, runbook={}",
+                    itemId, sourceStock, indexedStock, runbookUrl);
+        }
+        return buildResponse(itemId, sourceStock, indexedStock, matched, result);
+    }
+
+    private Integer fetchIndexedStock(Long itemId) throws Exception {
+        Request request = new Request("GET", "/" + ItemDocument.ITEMS_READ_ALIAS + "/_doc/" + itemId);
+        try {
+            Response response = restClient.performRequest(request);
+            String json = EntityUtils.toString(response.getEntity());
+            Map<String, Object> root = JsonUtils.fromJson(json, new TypeReference<>() {
+            });
+            Object found = root.get("found");
+            if (found instanceof Boolean foundValue && !foundValue) {
+                return null;
+            }
+
+            Map<String, Object> source = toMap(root.get("_source"));
+            if (source.isEmpty()) {
+                return null;
+            }
+            return asInteger(source.get("stock"));
+        } catch (ResponseException e) {
+            int status = e.getResponse() == null ? -1 : e.getResponse().getStatusLine().getStatusCode();
+            if (status == 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private StockReconciliationResponse buildResponse(Long itemId,
+                                                      Integer sourceStock,
+                                                      Integer indexedStock,
+                                                      boolean matched,
+                                                      String result) {
+        return StockReconciliationResponse.builder()
+                .itemId(itemId)
+                .sourceAvailableStock(sourceStock)
+                .indexedStock(indexedStock)
+                .matched(matched)
+                .result(result)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toMap(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
+    }
+
+    private Integer asInteger(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String str) {
+            try {
+                return Integer.parseInt(str);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/servers/services/search/src/main/resources/application.yml
+++ b/servers/services/search/src/main/resources/application.yml
@@ -61,9 +61,15 @@ search:
     kafka-lag:
       enabled: ${SEARCH_METRICS_KAFKA_LAG_ENABLED:true}
       interval-ms: ${SEARCH_METRICS_KAFKA_LAG_INTERVAL_MS:30000}
+  reconciliation:
+    enabled: ${SEARCH_RECONCILIATION_ENABLED:false}
+    interval-ms: ${SEARCH_RECONCILIATION_INTERVAL_MS:300000}
+    sample-item-ids: ${SEARCH_RECONCILIATION_SAMPLE_ITEM_IDS:}
 
 # ─── Snowflake ID ────────────────────────────
 app:
+  service:
+    stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
   snowflake:
     datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
     worker-id: ${SNOWFLAKE_WORKER_ID:11}

--- a/servers/services/search/src/test/java/com/example/search/controller/internal/SearchStockReconciliationControllerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/controller/internal/SearchStockReconciliationControllerTest.java
@@ -1,0 +1,42 @@
+package com.example.search.controller.internal;
+
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.reconciliation.StockReconciliationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SearchStockReconciliationController.class)
+class SearchStockReconciliationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StockReconciliationService stockReconciliationService;
+
+    @Test
+    void reconcileStock_returnsSuccessResponse() throws Exception {
+        StockReconciliationResponse response = StockReconciliationResponse.builder()
+                .itemId(101L)
+                .sourceAvailableStock(12)
+                .indexedStock(10)
+                .matched(false)
+                .result("mismatch")
+                .build();
+        given(stockReconciliationService.reconcileItem(101L)).willReturn(response);
+
+        mockMvc.perform(get("/internal/v1/search/reconciliation/stock/101"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.itemId").value(101))
+                .andExpect(jsonPath("$.data.result").value("mismatch"));
+    }
+}

--- a/servers/services/search/src/test/java/com/example/search/service/reconciliation/StockReconciliationServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/reconciliation/StockReconciliationServiceTest.java
@@ -1,0 +1,110 @@
+package com.example.search.service.reconciliation;
+
+import com.example.search.client.StockQueryClient;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.metrics.SearchMetricsService;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockReconciliationServiceTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private StockQueryClient stockQueryClient;
+
+    @Mock
+    private SearchMetricsService searchMetricsService;
+
+    private StockReconciliationService stockReconciliationService;
+
+    @BeforeEach
+    void setUp() {
+        stockReconciliationService = new StockReconciliationService(
+                restClient,
+                stockQueryClient,
+                searchMetricsService
+        );
+        ReflectionTestUtils.setField(stockReconciliationService, "runbookUrl", "https://runbook.example/search");
+    }
+
+    @Test
+    void reconcileItem_returnsMatchedWhenStocksAreEqual() throws Exception {
+        when(stockQueryClient.fetchAvailableStockTotal(101L)).thenReturn(12);
+
+        Response response = org.mockito.Mockito.mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity("""
+                {
+                  "found": true,
+                  "_source": {
+                    "itemId": 101,
+                    "stock": 12
+                  }
+                }
+                """, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(101L);
+
+        assertThat(result.isMatched()).isTrue();
+        assertThat(result.getResult()).isEqualTo("matched");
+        assertThat(result.getSourceAvailableStock()).isEqualTo(12);
+        assertThat(result.getIndexedStock()).isEqualTo(12);
+        verify(searchMetricsService).recordStockReconciliation("matched");
+    }
+
+    @Test
+    void reconcileItem_returnsMismatchWhenValuesDiffer() throws Exception {
+        when(stockQueryClient.fetchAvailableStockTotal(102L)).thenReturn(10);
+
+        Response response = org.mockito.Mockito.mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity("""
+                {
+                  "found": true,
+                  "_source": {
+                    "itemId": 102,
+                    "stock": 8
+                  }
+                }
+                """, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(102L);
+
+        assertThat(result.isMatched()).isFalse();
+        assertThat(result.getResult()).isEqualTo("mismatch");
+        assertThat(result.getSourceAvailableStock()).isEqualTo(10);
+        assertThat(result.getIndexedStock()).isEqualTo(8);
+        verify(searchMetricsService).recordStockReconciliation("mismatch");
+    }
+
+    @Test
+    void reconcileItem_returnsSourceErrorWhenStockQueryFails() {
+        when(stockQueryClient.fetchAvailableStockTotal(103L))
+                .thenThrow(new IllegalStateException("stock down"));
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(103L);
+
+        assertThat(result.isMatched()).isFalse();
+        assertThat(result.getResult()).isEqualTo("source_error");
+        assertThat(result.getSourceAvailableStock()).isNull();
+        assertThat(result.getIndexedStock()).isNull();
+        verify(searchMetricsService).recordStockReconciliation("source_error");
+    }
+}

--- a/servers/services/search/src/test/resources/application-test.yml
+++ b/servers/services/search/src/test/resources/application-test.yml
@@ -25,6 +25,8 @@ search:
   metrics:
     kafka-lag:
       enabled: false
+  reconciliation:
+    enabled: false
 
 app:
   outbox:


### PR DESCRIPTION
## 변경 내용
- Stock 원본 재고와 Search 인덱스 재고를 비교하는 `StockReconciliationService` 추가
- 내부 점검 API 추가: `GET /internal/v1/search/reconciliation/stock/{itemId}`
- 정합성 점검 결과 DTO 추가(`matched/mismatch/index_missing/source_error/index_error`)
- 샘플 itemId 대상 주기 점검 스케줄러 추가(옵션)
- 정합성 점검 메트릭(`search.reconciliation.checks{result=...}`) 추가
- Stock 내부 조회용 `StockQueryClient` 추가

## 설정
- `app.service.stock-url` (기본값: `http://localhost:8085`)
- `search.reconciliation.enabled` (기본값: `false`)
- `search.reconciliation.interval-ms` (기본값: `300000`)
- `search.reconciliation.sample-item-ids` (쉼표 구분 itemId 목록)

## 검증
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:search:test --rerun-tasks`

## 이슈
Closes #627
Related #625
