### PR TITLE
[EPIC-625] Search 재고 이벤트 정합성 강화(absolute+version)

### DIFF
--- a/servers/services/search/src/main/java/com/example/search/client/StockQueryClient.java
+++ b/servers/services/search/src/main/java/com/example/search/client/StockQueryClient.java
@@ -1,0 +1,47 @@
+package com.example.search.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class StockQueryClient {
+
+    private final WebClient webClient;
+
+    public StockQueryClient(WebClient.Builder webClientBuilder,
+                            @Value("${app.service.stock-url:http://localhost:8085}") String stockServiceUrl) {
+        this.webClient = webClientBuilder.baseUrl(stockServiceUrl).build();
+    }
+
+    public int fetchAvailableStockTotal(Long itemId) {
+        try {
+            JsonNode response = webClient.get()
+                    .uri("/internal/v1/stock/items/{itemId}", itemId)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.path("success").asBoolean()) {
+                throw new IllegalStateException("stock summary api failed");
+            }
+
+            JsonNode stocks = response.path("data").path("stocks");
+            if (!stocks.isArray()) {
+                return 0;
+            }
+
+            int total = 0;
+            for (JsonNode stock : stocks) {
+                total += stock.path("availableQuantity").asInt(0);
+            }
+            return total;
+        } catch (Exception e) {
+            log.warn("Failed to fetch stock summary. itemId={}", itemId, e);
+            throw new IllegalStateException("failed to fetch stock summary. itemId=" + itemId, e);
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/consumer/StockEventConsumer.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/StockEventConsumer.java
@@ -62,18 +62,35 @@ public class StockEventConsumer {
     private void route(StockEventMessage event) {
         String normalizedType = normalizeEventType(event.getEventType());
         switch (normalizedType) {
-            case "STOCK_DECREASED" -> handleStockDecreased(event);
+            case "STOCK_DECREASED", "STOCK_INCREASED" -> handleLegacyStockChanged(event, normalizedType);
+            case "ITEM_AVAILABLE_STOCK_CHANGED" -> handleItemAvailableStockChanged(event);
             default -> log.debug("[SearchStockConsumer] 처리하지 않는 이벤트 타입: {}", event.getEventType());
         }
     }
 
-    private void handleStockDecreased(StockEventMessage event) {
-        if (event.getRemainingQuantity() == null) {
-            log.warn("[SearchStockConsumer] remainingQuantity 누락으로 재고 업데이트 스킵. itemId={}", event.getItemId());
+    private void handleLegacyStockChanged(StockEventMessage event, String eventType) {
+        Integer stock = event.resolveLegacyStockQuantity();
+        if (stock == null) {
+            log.warn("[SearchStockConsumer] legacy 재고 값 누락으로 업데이트 스킵. eventType={}, itemId={}",
+                    eventType, event.getItemId());
             return;
         }
 
-        searchIndexingService.updateItemStock(event.getItemId(), event.getRemainingQuantity());
+        searchIndexingService.updateItemStock(event.getItemId(), stock);
+        searchResultCacheService.evictAll();
+    }
+
+    private void handleItemAvailableStockChanged(StockEventMessage event) {
+        if (event.getAvailableStockTotal() == null || event.getStockVersion() == null) {
+            log.warn("[SearchStockConsumer] availableStockTotal/stockVersion 누락으로 스냅샷 업데이트 스킵. itemId={}",
+                    event.getItemId());
+            return;
+        }
+        searchIndexingService.updateItemStockVersioned(
+                event.getItemId(),
+                event.getAvailableStockTotal(),
+                event.getStockVersion()
+        );
         searchResultCacheService.evictAll();
     }
 

--- a/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
@@ -14,4 +14,14 @@ public class StockEventMessage {
     private Long itemId;
     private Integer quantity;
     private Integer remainingQuantity;
+    private Integer currentQuantity;
+    private Integer availableStockTotal;
+    private Long stockVersion;
+
+    public Integer resolveLegacyStockQuantity() {
+        if (currentQuantity != null) {
+            return currentQuantity;
+        }
+        return remainingQuantity;
+    }
 }

--- a/servers/services/search/src/main/java/com/example/search/controller/api/internal/SearchStockReconciliationApi.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/api/internal/SearchStockReconciliationApi.java
@@ -1,0 +1,16 @@
+package com.example.search.controller.api.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Search Internal Reconciliation", description = "검색 재고 정합성 점검 내부 API")
+public interface SearchStockReconciliationApi {
+
+    @Operation(summary = "itemId 기준 재고 정합성 점검")
+    @GetMapping("/stock/{itemId}")
+    ApiResponse<StockReconciliationResponse> reconcileStock(@PathVariable Long itemId);
+}

--- a/servers/services/search/src/main/java/com/example/search/controller/internal/SearchStockReconciliationController.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/internal/SearchStockReconciliationController.java
@@ -1,0 +1,23 @@
+package com.example.search.controller.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.search.controller.api.internal.SearchStockReconciliationApi;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.reconciliation.StockReconciliationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/search/reconciliation")
+@RequiredArgsConstructor
+public class SearchStockReconciliationController implements SearchStockReconciliationApi {
+
+    private final StockReconciliationService stockReconciliationService;
+
+    @Override
+    public ApiResponse<StockReconciliationResponse> reconcileStock(@PathVariable Long itemId) {
+        return ApiResponse.success(stockReconciliationService.reconcileItem(itemId));
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
+++ b/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
@@ -49,6 +49,9 @@ public class ItemDocument {
     @Field(type = FieldType.Integer)
     private Integer stock;
 
+    @Field(type = FieldType.Long)
+    private Long stockVersion;
+
     @Field(type = FieldType.Keyword)
     private List<String> tags;
 

--- a/servers/services/search/src/main/java/com/example/search/dto/reconciliation/response/StockReconciliationResponse.java
+++ b/servers/services/search/src/main/java/com/example/search/dto/reconciliation/response/StockReconciliationResponse.java
@@ -1,0 +1,15 @@
+package com.example.search.dto.reconciliation.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockReconciliationResponse {
+
+    private final Long itemId;
+    private final Integer sourceAvailableStock;
+    private final Integer indexedStock;
+    private final boolean matched;
+    private final String result;
+}

--- a/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
@@ -7,6 +7,7 @@ import com.example.search.exception.SearchErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.springframework.stereotype.Service;
 
@@ -73,6 +74,35 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
     }
 
     @Override
+    public void updateItemStockVersioned(Long itemId, Integer stock, Long stockVersion) {
+        if (itemId == null || stock == null || stockVersion == null) {
+            return;
+        }
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("itemId", itemId);
+        params.put("stock", stock);
+        params.put("stockVersion", stockVersion);
+
+        Map<String, Object> script = new LinkedHashMap<>();
+        script.put("lang", "painless");
+        script.put("source",
+                "if (ctx._source.stockVersion == null || params.stockVersion > ctx._source.stockVersion) { " +
+                        "ctx._source.itemId = params.itemId; " +
+                        "ctx._source.stock = params.stock; " +
+                        "ctx._source.stockVersion = params.stockVersion; " +
+                        "} else { ctx.op = 'none'; }");
+        script.put("params", params);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("script", script);
+
+        Request request = new Request("POST", endpointForUpdate(itemId));
+        request.setJsonEntity(JsonUtils.toJson(body));
+        performRequestAllowMissing(request, itemId, "ITEM_AVAILABLE_STOCK_CHANGED");
+    }
+
+    @Override
     public void deleteItem(Long itemId) {
         if (itemId == null) {
             return;
@@ -103,6 +133,30 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
             log.debug("Search index updated. eventType={}, itemId={}", eventType, itemId);
         } catch (IOException e) {
             log.error("Search index request failed. eventType={}, itemId={}", eventType, itemId, e);
+            throw new BusinessException(
+                    SearchErrorCode.SEARCH_INDEXING_FAILED,
+                    "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,
+                    e
+            );
+        }
+    }
+
+    private void performRequestAllowMissing(Request request, Long itemId, String eventType) {
+        try {
+            restClient.performRequest(request);
+            log.debug("Search index updated. eventType={}, itemId={}", eventType, itemId);
+        } catch (ResponseException e) {
+            int status = e.getResponse() == null ? -1 : e.getResponse().getStatusLine().getStatusCode();
+            if (status == 404) {
+                log.debug("Search document not found. skip stock sync. eventType={}, itemId={}", eventType, itemId);
+                return;
+            }
+            throw new BusinessException(
+                    SearchErrorCode.SEARCH_INDEXING_FAILED,
+                    "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,
+                    e
+            );
+        } catch (IOException e) {
             throw new BusinessException(
                     SearchErrorCode.SEARCH_INDEXING_FAILED,
                     "검색 인덱싱에 실패했습니다. itemId=" + itemId + ", eventType=" + eventType,

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
@@ -75,6 +75,8 @@ public class SearchIndexingFailureService {
             case "ITEM_STATUS_CHANGED" -> replayItemStatusChanged(payload);
             case "ITEM_DELETED" -> replayItemDeleted(payload);
             case "STOCK_DECREASED" -> replayStockDecreased(payload);
+            case "STOCK_INCREASED" -> replayStockIncreased(payload);
+            case "ITEM_AVAILABLE_STOCK_CHANGED" -> replayItemAvailableStockChanged(payload);
             default -> throw new BusinessException(SearchErrorCode.SEARCH_INDEXING_FAILED,
                     "지원하지 않는 재처리 이벤트 타입입니다. eventType=" + eventType);
         }
@@ -112,6 +114,20 @@ public class SearchIndexingFailureService {
     private void replayStockDecreased(String payload) {
         StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
         searchIndexingService.updateItemStock(event.getItemId(), event.getRemainingQuantity());
+    }
+
+    private void replayStockIncreased(String payload) {
+        StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
+        searchIndexingService.updateItemStock(event.getItemId(), event.resolveLegacyStockQuantity());
+    }
+
+    private void replayItemAvailableStockChanged(String payload) {
+        StockEventMessage event = JsonUtils.fromJson(payload, StockEventMessage.class);
+        searchIndexingService.updateItemStockVersioned(
+                event.getItemId(),
+                event.getAvailableStockTotal(),
+                event.getStockVersion()
+        );
     }
 
     private void recordFailure(String eventId, String eventType, Long itemId, String payload, Exception e) {

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
@@ -16,5 +16,7 @@ public interface SearchIndexingService {
 
     void updateItemStock(Long itemId, Integer stock);
 
+    void updateItemStockVersioned(Long itemId, Integer stock, Long stockVersion);
+
     void deleteItem(Long itemId);
 }

--- a/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
@@ -56,4 +56,9 @@ public class SearchMetricsService {
     public void updateKafkaLag(long lag) {
         kafkaLagMax.set(Math.max(lag, -1L));
     }
+
+    public void recordStockReconciliation(String result) {
+        String safeResult = (result == null || result.isBlank()) ? "unknown" : result;
+        meterRegistry.counter("search.reconciliation.checks", "result", safeResult).increment();
+    }
 }

--- a/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationScheduler.java
+++ b/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationScheduler.java
@@ -1,0 +1,42 @@
+package com.example.search.service.reconciliation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockReconciliationScheduler {
+
+    private final StockReconciliationService stockReconciliationService;
+
+    @Value("${search.reconciliation.enabled:false}")
+    private boolean reconciliationEnabled;
+
+    @Value("${search.reconciliation.sample-item-ids:}")
+    private String sampleItemIds;
+
+    @Scheduled(fixedDelayString = "${search.reconciliation.interval-ms:300000}")
+    public void reconcileSampleItems() {
+        if (!reconciliationEnabled || !StringUtils.hasText(sampleItemIds)) {
+            return;
+        }
+
+        String[] tokens = sampleItemIds.split(",");
+        for (String token : tokens) {
+            if (!StringUtils.hasText(token)) {
+                continue;
+            }
+            try {
+                Long itemId = Long.parseLong(token.trim());
+                stockReconciliationService.reconcileItem(itemId);
+            } catch (NumberFormatException e) {
+                log.warn("[StockReconcile] invalid sample item id. raw={}", token);
+            }
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/reconciliation/StockReconciliationService.java
@@ -1,0 +1,129 @@
+package com.example.search.service.reconciliation;
+
+import com.example.core.util.JsonUtils;
+import com.example.search.client.StockQueryClient;
+import com.example.search.document.ItemDocument;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.metrics.SearchMetricsService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockReconciliationService {
+
+    private final RestClient restClient;
+    private final StockQueryClient stockQueryClient;
+    private final SearchMetricsService searchMetricsService;
+
+    @Value("${search.metrics.runbook-url:https://runbook.example/search}")
+    private String runbookUrl;
+
+    public StockReconciliationResponse reconcileItem(Long itemId) {
+        Integer sourceStock;
+        try {
+            sourceStock = stockQueryClient.fetchAvailableStockTotal(itemId);
+        } catch (Exception e) {
+            searchMetricsService.recordStockReconciliation("source_error");
+            return buildResponse(itemId, null, null, false, "source_error");
+        }
+
+        Integer indexedStock;
+        try {
+            indexedStock = fetchIndexedStock(itemId);
+        } catch (Exception e) {
+            searchMetricsService.recordStockReconciliation("index_error");
+            log.warn("[StockReconcile] index read failed. itemId={}, runbook={}", itemId, runbookUrl, e);
+            return buildResponse(itemId, sourceStock, null, false, "index_error");
+        }
+
+        if (indexedStock == null) {
+            searchMetricsService.recordStockReconciliation("index_missing");
+            log.warn("[StockReconcile] indexed document missing. itemId={}, sourceStock={}, runbook={}",
+                    itemId, sourceStock, runbookUrl);
+            return buildResponse(itemId, sourceStock, null, false, "index_missing");
+        }
+
+        boolean matched = sourceStock.equals(indexedStock);
+        String result = matched ? "matched" : "mismatch";
+        searchMetricsService.recordStockReconciliation(result);
+        if (!matched) {
+            log.warn("[StockReconcile] stock mismatch detected. itemId={}, sourceStock={}, indexedStock={}, runbook={}",
+                    itemId, sourceStock, indexedStock, runbookUrl);
+        }
+        return buildResponse(itemId, sourceStock, indexedStock, matched, result);
+    }
+
+    private Integer fetchIndexedStock(Long itemId) throws Exception {
+        Request request = new Request("GET", "/" + ItemDocument.ITEMS_READ_ALIAS + "/_doc/" + itemId);
+        try {
+            Response response = restClient.performRequest(request);
+            String json = EntityUtils.toString(response.getEntity());
+            Map<String, Object> root = JsonUtils.fromJson(json, new TypeReference<>() {
+            });
+            Object found = root.get("found");
+            if (found instanceof Boolean foundValue && !foundValue) {
+                return null;
+            }
+
+            Map<String, Object> source = toMap(root.get("_source"));
+            if (source.isEmpty()) {
+                return null;
+            }
+            return asInteger(source.get("stock"));
+        } catch (ResponseException e) {
+            int status = e.getResponse() == null ? -1 : e.getResponse().getStatusLine().getStatusCode();
+            if (status == 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private StockReconciliationResponse buildResponse(Long itemId,
+                                                      Integer sourceStock,
+                                                      Integer indexedStock,
+                                                      boolean matched,
+                                                      String result) {
+        return StockReconciliationResponse.builder()
+                .itemId(itemId)
+                .sourceAvailableStock(sourceStock)
+                .indexedStock(indexedStock)
+                .matched(matched)
+                .result(result)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toMap(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
+    }
+
+    private Integer asInteger(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String str) {
+            try {
+                return Integer.parseInt(str);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/servers/services/search/src/main/resources/application.yml
+++ b/servers/services/search/src/main/resources/application.yml
@@ -61,9 +61,15 @@ search:
     kafka-lag:
       enabled: ${SEARCH_METRICS_KAFKA_LAG_ENABLED:true}
       interval-ms: ${SEARCH_METRICS_KAFKA_LAG_INTERVAL_MS:30000}
+  reconciliation:
+    enabled: ${SEARCH_RECONCILIATION_ENABLED:false}
+    interval-ms: ${SEARCH_RECONCILIATION_INTERVAL_MS:300000}
+    sample-item-ids: ${SEARCH_RECONCILIATION_SAMPLE_ITEM_IDS:}
 
 # ─── Snowflake ID ────────────────────────────
 app:
+  service:
+    stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
   snowflake:
     datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
     worker-id: ${SNOWFLAKE_WORKER_ID:11}

--- a/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
+++ b/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
@@ -89,6 +89,9 @@
       "stock": {
         "type": "integer"
       },
+      "stockVersion": {
+        "type": "long"
+      },
       "tags": {
         "type": "keyword"
       },

--- a/servers/services/search/src/test/java/com/example/search/consumer/StockEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/StockEventConsumerTest.java
@@ -63,6 +63,44 @@ class StockEventConsumerTest {
     }
 
     @Test
+    void consume_routesItemAvailableStockChangedToVersionedUpdate() {
+        stubIdempotentExecution();
+
+        String message = """
+                {
+                  "eventId": "evt-stock-2",
+                  "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                  "itemId": 101,
+                  "availableStockTotal": 11,
+                  "stockVersion": 57
+                }
+                """;
+
+        stockEventConsumer.consume(message);
+
+        verify(searchIndexingService).updateItemStockVersioned(101L, 11, 57L);
+        verify(searchResultCacheService).evictAll();
+    }
+
+    @Test
+    void consume_skipsVersionedUpdateWhenSnapshotFieldsMissing() {
+        stubIdempotentExecution();
+
+        String message = """
+                {
+                  "eventId": "evt-stock-3",
+                  "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                  "itemId": 101,
+                  "availableStockTotal": 11
+                }
+                """;
+
+        stockEventConsumer.consume(message);
+
+        verify(searchIndexingService, never()).updateItemStockVersioned(any(), any(), any());
+    }
+
+    @Test
     void consume_ignoresInvalidEventWithoutIdempotentExecution() {
         String message = """
                 {
@@ -75,6 +113,7 @@ class StockEventConsumerTest {
 
         verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
         verify(searchIndexingService, never()).updateItemStock(any(), any());
+        verify(searchIndexingService, never()).updateItemStockVersioned(any(), any(), any());
         verify(searchResultCacheService, never()).evictAll();
     }
 

--- a/servers/services/search/src/test/java/com/example/search/controller/internal/SearchStockReconciliationControllerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/controller/internal/SearchStockReconciliationControllerTest.java
@@ -1,0 +1,42 @@
+package com.example.search.controller.internal;
+
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.reconciliation.StockReconciliationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SearchStockReconciliationController.class)
+class SearchStockReconciliationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StockReconciliationService stockReconciliationService;
+
+    @Test
+    void reconcileStock_returnsSuccessResponse() throws Exception {
+        StockReconciliationResponse response = StockReconciliationResponse.builder()
+                .itemId(101L)
+                .sourceAvailableStock(12)
+                .indexedStock(10)
+                .matched(false)
+                .result("mismatch")
+                .build();
+        given(stockReconciliationService.reconcileItem(101L)).willReturn(response);
+
+        mockMvc.perform(get("/internal/v1/search/reconciliation/stock/101"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.itemId").value(101))
+                .andExpect(jsonPath("$.data.result").value("mismatch"));
+    }
+}

--- a/servers/services/search/src/test/java/com/example/search/service/index/ElasticsearchIndexingServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/ElasticsearchIndexingServiceTest.java
@@ -73,6 +73,24 @@ class ElasticsearchIndexingServiceTest {
     }
 
     @Test
+    void updateItemStockVersioned_sendsScriptUpdateRequest() throws Exception {
+        when(restClient.performRequest(any(Request.class))).thenReturn(mock(Response.class));
+
+        indexingService.updateItemStockVersioned(15L, 9, 57L);
+
+        ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+        verify(restClient).performRequest(captor.capture());
+        Request request = captor.getValue();
+
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getEndpoint()).isEqualTo("/items-write/_update/15");
+        String json = EntityUtils.toString(request.getEntity());
+        assertThat(json).contains("\"script\"");
+        assertThat(json).contains("\"stockVersion\":57");
+        assertThat(json).contains("\"stock\":9");
+    }
+
+    @Test
     void updateItemStock_wrapsIOExceptionAsBusinessException() throws Exception {
         when(restClient.performRequest(any(Request.class))).thenThrow(new IOException("es-down"));
 

--- a/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
@@ -98,6 +98,37 @@ class SearchIndexingFailureServiceTest {
         assertThat(response.getRetryCount()).isEqualTo(1);
     }
 
+    @Test
+    void retryFailure_replaysVersionedStockSnapshot() {
+        SearchIndexingFailure failure = SearchIndexingFailure.builder()
+                .eventId("evt-stock-57")
+                .eventType("ITEM_AVAILABLE_STOCK_CHANGED")
+                .itemId(101L)
+                .payload("""
+                        {
+                          "eventId": "evt-stock-57",
+                          "eventType": "ITEM_AVAILABLE_STOCK_CHANGED",
+                          "itemId": 101,
+                          "availableStockTotal": 12,
+                          "stockVersion": 57
+                        }
+                        """)
+                .retryCount(0)
+                .status(SearchIndexingFailureStatus.PENDING)
+                .failureReason("initial")
+                .build();
+
+        when(failureRepository.findById(2L)).thenReturn(Optional.of(failure));
+        when(failureRepository.save(any(SearchIndexingFailure.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        IndexingFailureRetryResponse response = searchIndexingFailureService.retryFailure(2L);
+
+        verify(searchIndexingService).updateItemStockVersioned(101L, 12, 57L);
+        verify(searchResultCacheService).evictAll();
+        assertThat(response.getStatus()).isEqualTo(SearchIndexingFailureStatus.RESOLVED);
+    }
+
     private void setField(Object target, String fieldName, Object value) {
         try {
             java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);

--- a/servers/services/search/src/test/java/com/example/search/service/reconciliation/StockReconciliationServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/reconciliation/StockReconciliationServiceTest.java
@@ -1,0 +1,110 @@
+package com.example.search.service.reconciliation;
+
+import com.example.search.client.StockQueryClient;
+import com.example.search.dto.reconciliation.response.StockReconciliationResponse;
+import com.example.search.service.metrics.SearchMetricsService;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockReconciliationServiceTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private StockQueryClient stockQueryClient;
+
+    @Mock
+    private SearchMetricsService searchMetricsService;
+
+    private StockReconciliationService stockReconciliationService;
+
+    @BeforeEach
+    void setUp() {
+        stockReconciliationService = new StockReconciliationService(
+                restClient,
+                stockQueryClient,
+                searchMetricsService
+        );
+        ReflectionTestUtils.setField(stockReconciliationService, "runbookUrl", "https://runbook.example/search");
+    }
+
+    @Test
+    void reconcileItem_returnsMatchedWhenStocksAreEqual() throws Exception {
+        when(stockQueryClient.fetchAvailableStockTotal(101L)).thenReturn(12);
+
+        Response response = org.mockito.Mockito.mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity("""
+                {
+                  "found": true,
+                  "_source": {
+                    "itemId": 101,
+                    "stock": 12
+                  }
+                }
+                """, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(101L);
+
+        assertThat(result.isMatched()).isTrue();
+        assertThat(result.getResult()).isEqualTo("matched");
+        assertThat(result.getSourceAvailableStock()).isEqualTo(12);
+        assertThat(result.getIndexedStock()).isEqualTo(12);
+        verify(searchMetricsService).recordStockReconciliation("matched");
+    }
+
+    @Test
+    void reconcileItem_returnsMismatchWhenValuesDiffer() throws Exception {
+        when(stockQueryClient.fetchAvailableStockTotal(102L)).thenReturn(10);
+
+        Response response = org.mockito.Mockito.mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity("""
+                {
+                  "found": true,
+                  "_source": {
+                    "itemId": 102,
+                    "stock": 8
+                  }
+                }
+                """, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(102L);
+
+        assertThat(result.isMatched()).isFalse();
+        assertThat(result.getResult()).isEqualTo("mismatch");
+        assertThat(result.getSourceAvailableStock()).isEqualTo(10);
+        assertThat(result.getIndexedStock()).isEqualTo(8);
+        verify(searchMetricsService).recordStockReconciliation("mismatch");
+    }
+
+    @Test
+    void reconcileItem_returnsSourceErrorWhenStockQueryFails() {
+        when(stockQueryClient.fetchAvailableStockTotal(103L))
+                .thenThrow(new IllegalStateException("stock down"));
+
+        StockReconciliationResponse result = stockReconciliationService.reconcileItem(103L);
+
+        assertThat(result.isMatched()).isFalse();
+        assertThat(result.getResult()).isEqualTo("source_error");
+        assertThat(result.getSourceAvailableStock()).isNull();
+        assertThat(result.getIndexedStock()).isNull();
+        verify(searchMetricsService).recordStockReconciliation("source_error");
+    }
+}

--- a/servers/services/search/src/test/resources/application-test.yml
+++ b/servers/services/search/src/test/resources/application-test.yml
@@ -25,6 +25,8 @@ search:
   metrics:
     kafka-lag:
       enabled: false
+  reconciliation:
+    enabled: false
 
 app:
   outbox:

--- a/servers/services/stock/src/main/java/com/example/stock/entity/StockSyncVersion.java
+++ b/servers/services/stock/src/main/java/com/example/stock/entity/StockSyncVersion.java
@@ -1,0 +1,34 @@
+package com.example.stock.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stock_sync_versions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockSyncVersion {
+
+    @Id
+    private Long itemId;
+
+    @Column(nullable = false)
+    private long version;
+
+    public static StockSyncVersion initialize(Long itemId) {
+        StockSyncVersion syncVersion = new StockSyncVersion();
+        syncVersion.itemId = itemId;
+        syncVersion.version = 0L;
+        return syncVersion;
+    }
+
+    public long incrementAndGet() {
+        this.version += 1L;
+        return this.version;
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/event/ItemAvailableStockChangedEvent.java
+++ b/servers/services/stock/src/main/java/com/example/stock/event/ItemAvailableStockChangedEvent.java
@@ -1,0 +1,36 @@
+package com.example.stock.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ItemAvailableStockChangedEvent extends DomainEvent {
+
+    private final Long itemId;
+    private final int availableStockTotal;
+    private final long stockVersion;
+
+    public ItemAvailableStockChangedEvent(Long itemId, int availableStockTotal, long stockVersion) {
+        super("stock-events");
+        this.itemId = itemId;
+        this.availableStockTotal = availableStockTotal;
+        this.stockVersion = stockVersion;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ITEM_AVAILABLE_STOCK_CHANGED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "itemId", itemId,
+                "availableStockTotal", availableStockTotal,
+                "stockVersion", stockVersion,
+                "occurredAt", getOccurredAt().toString()
+        );
+    }
+}

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockItemRepository.java
@@ -22,4 +22,7 @@ public interface StockItemRepository extends JpaRepository<StockItem, Long> {
     List<StockItem> findByItemId(Long itemId);
 
     List<StockItem> findByItemIdAndStockItemType(Long itemId, StockItemType stockItemType);
+
+    @Query("SELECT COALESCE(SUM(s.availableQuantity), 0) FROM StockItem s WHERE s.itemId = :itemId")
+    Long sumAvailableQuantityByItemId(@Param("itemId") Long itemId);
 }

--- a/servers/services/stock/src/main/java/com/example/stock/repository/StockSyncVersionRepository.java
+++ b/servers/services/stock/src/main/java/com/example/stock/repository/StockSyncVersionRepository.java
@@ -1,0 +1,17 @@
+package com.example.stock.repository;
+
+import com.example.stock.entity.StockSyncVersion;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface StockSyncVersionRepository extends JpaRepository<StockSyncVersion, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM StockSyncVersion s WHERE s.itemId = :itemId")
+    Optional<StockSyncVersion> findByItemIdWithLock(@Param("itemId") Long itemId);
+}

--- a/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
+++ b/servers/services/stock/src/main/java/com/example/stock/service/command/StockCommandService.java
@@ -8,6 +8,7 @@ import com.example.stock.dto.request.*;
 import com.example.stock.dto.response.ReservationResponse;
 import com.example.stock.dto.response.StockResponse;
 import com.example.stock.entity.*;
+import com.example.stock.event.ItemAvailableStockChangedEvent;
 import com.example.stock.event.StockDecreasedEvent;
 import com.example.stock.event.StockDepletedEvent;
 import com.example.stock.event.StockIncreasedEvent;
@@ -16,9 +17,11 @@ import com.example.stock.exception.StockErrorCode;
 import com.example.stock.repository.StockHistoryRepository;
 import com.example.stock.repository.StockItemRepository;
 import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.repository.StockSyncVersionRepository;
 import com.example.stock.service.StockCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +37,7 @@ public class StockCommandService {
     private final StockItemRepository stockItemRepository;
     private final StockReservationRepository stockReservationRepository;
     private final StockHistoryRepository stockHistoryRepository;
+    private final StockSyncVersionRepository stockSyncVersionRepository;
     private final StockCacheService stockCacheService;
     private final EventPublisher eventPublisher;
 
@@ -55,6 +59,7 @@ public class StockCommandService {
 
         // 이벤트 발행
         publishStockEvents(stockItem, request.getQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -73,6 +78,7 @@ public class StockCommandService {
         eventPublisher.publish(
                 new StockIncreasedEvent(stockItem.getId(), stockItem.getItemId(), request.getQuantity(), stockItem.getAvailableQuantity()),
                 EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -97,6 +103,7 @@ public class StockCommandService {
                 "예약 생성 (userId=" + request.getUserId() + ")", reservation.getId()));
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return ReservationResponse.from(reservation);
     }
@@ -147,6 +154,7 @@ public class StockCommandService {
                 "예약 취소", reservation.getId()));
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return ReservationResponse.from(reservation);
     }
@@ -174,6 +182,7 @@ public class StockCommandService {
         }
 
         stockCacheService.cacheStock(stockItem.getId(), stockItem.getAvailableQuantity());
+        publishItemStockSnapshotEvent(stockItem.getItemId());
 
         return StockResponse.from(stockItem);
     }
@@ -196,6 +205,7 @@ public class StockCommandService {
             stockHistoryRepository.save(StockHistory.create(
                     stockItem.getId(), ChangeType.EXPIRE, reservation.getQuantity(),
                     "예약 만료 자동 복원", reservation.getId()));
+            publishItemStockSnapshotEvent(stockItem.getItemId());
         }
     }
 
@@ -214,6 +224,45 @@ public class StockCommandService {
                             stockItem.getAvailableQuantity(), stockItem.getTotalQuantity()),
                     EventMetadata.of("StockItem", String.valueOf(stockItem.getId())));
         }
+    }
+
+    private void publishItemStockSnapshotEvent(Long itemId) {
+        if (itemId == null) {
+            return;
+        }
+        long stockVersion = nextStockVersion(itemId);
+        int availableStockTotal = sumAvailableStockByItemId(itemId);
+        eventPublisher.publish(
+                new ItemAvailableStockChangedEvent(itemId, availableStockTotal, stockVersion),
+                EventMetadata.of("Item", String.valueOf(itemId))
+        );
+    }
+
+    private long nextStockVersion(Long itemId) {
+        for (int attempt = 0; attempt < 2; attempt++) {
+            StockSyncVersion syncVersion = stockSyncVersionRepository.findByItemIdWithLock(itemId)
+                    .orElse(null);
+            if (syncVersion != null) {
+                return syncVersion.incrementAndGet();
+            }
+            try {
+                stockSyncVersionRepository.saveAndFlush(StockSyncVersion.initialize(itemId));
+            } catch (DataIntegrityViolationException e) {
+                log.debug("Stock sync version row already exists. itemId={}", itemId);
+            }
+        }
+
+        StockSyncVersion syncVersion = stockSyncVersionRepository.findByItemIdWithLock(itemId)
+                .orElseGet(() -> stockSyncVersionRepository.saveAndFlush(StockSyncVersion.initialize(itemId)));
+        return syncVersion.incrementAndGet();
+    }
+
+    private int sumAvailableStockByItemId(Long itemId) {
+        Long total = stockItemRepository.sumAvailableQuantityByItemId(itemId);
+        if (total == null) {
+            return 0;
+        }
+        return Math.toIntExact(total);
     }
 
     private StockItem getStockItemWithLock(Long stockItemId) {

--- a/servers/services/stock/src/test/java/com/example/stock/service/command/StockCommandServiceStockSnapshotEventTest.java
+++ b/servers/services/stock/src/test/java/com/example/stock/service/command/StockCommandServiceStockSnapshotEventTest.java
@@ -1,0 +1,128 @@
+package com.example.stock.service.command;
+
+import com.example.event.DomainEvent;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.stock.dto.request.StockDecreaseRequest;
+import com.example.stock.dto.request.StockIncreaseRequest;
+import com.example.stock.entity.StockItem;
+import com.example.stock.entity.StockItemType;
+import com.example.stock.entity.StockSyncVersion;
+import com.example.stock.event.ItemAvailableStockChangedEvent;
+import com.example.stock.repository.StockHistoryRepository;
+import com.example.stock.repository.StockItemRepository;
+import com.example.stock.repository.StockReservationRepository;
+import com.example.stock.repository.StockSyncVersionRepository;
+import com.example.stock.service.StockCacheService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockCommandServiceStockSnapshotEventTest {
+
+    @Mock
+    private StockItemRepository stockItemRepository;
+
+    @Mock
+    private StockReservationRepository stockReservationRepository;
+
+    @Mock
+    private StockHistoryRepository stockHistoryRepository;
+
+    @Mock
+    private StockSyncVersionRepository stockSyncVersionRepository;
+
+    @Mock
+    private StockCacheService stockCacheService;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private StockCommandService stockCommandService;
+
+    @Test
+    void decreaseStock_publishesItemSnapshotEventWithVersionAndItemKey() {
+        StockItem stockItem = StockItem.create(200L, StockItemType.SEAT_GRADE, 300L, 10);
+        ReflectionTestUtils.setField(stockItem, "id", 100L);
+
+        StockDecreaseRequest request = new StockDecreaseRequest();
+        ReflectionTestUtils.setField(request, "stockItemId", 100L);
+        ReflectionTestUtils.setField(request, "quantity", 1);
+        ReflectionTestUtils.setField(request, "reason", "purchase");
+
+        StockSyncVersion syncVersion = StockSyncVersion.initialize(200L);
+        ReflectionTestUtils.setField(syncVersion, "version", 4L);
+
+        when(stockItemRepository.findByIdWithLock(100L)).thenReturn(Optional.of(stockItem));
+        when(stockItemRepository.sumAvailableQuantityByItemId(200L)).thenReturn(9L);
+        when(stockSyncVersionRepository.findByItemIdWithLock(200L)).thenReturn(Optional.of(syncVersion));
+
+        stockCommandService.decreaseStock(request);
+
+        SnapshotEventResult snapshot = captureSnapshotEvent();
+        assertThat(snapshot.event.getItemId()).isEqualTo(200L);
+        assertThat(snapshot.event.getAvailableStockTotal()).isEqualTo(9);
+        assertThat(snapshot.event.getStockVersion()).isEqualTo(5L);
+        assertThat(snapshot.metadata.aggregateId()).isEqualTo("200");
+    }
+
+    @Test
+    void increaseStock_publishesItemSnapshotEvent() {
+        StockItem stockItem = StockItem.create(201L, StockItemType.SEAT_GRADE, 301L, 10);
+        ReflectionTestUtils.setField(stockItem, "id", 101L);
+
+        StockIncreaseRequest request = new StockIncreaseRequest();
+        ReflectionTestUtils.setField(request, "stockItemId", 101L);
+        ReflectionTestUtils.setField(request, "quantity", 2);
+        ReflectionTestUtils.setField(request, "reason", "refund");
+
+        StockSyncVersion syncVersion = StockSyncVersion.initialize(201L);
+        ReflectionTestUtils.setField(syncVersion, "version", 9L);
+
+        when(stockItemRepository.findByIdWithLock(101L)).thenReturn(Optional.of(stockItem));
+        when(stockItemRepository.sumAvailableQuantityByItemId(201L)).thenReturn(10L);
+        when(stockSyncVersionRepository.findByItemIdWithLock(201L)).thenReturn(Optional.of(syncVersion));
+
+        stockCommandService.increaseStock(request);
+
+        SnapshotEventResult snapshot = captureSnapshotEvent();
+        assertThat(snapshot.event.getItemId()).isEqualTo(201L);
+        assertThat(snapshot.event.getAvailableStockTotal()).isEqualTo(10);
+        assertThat(snapshot.event.getStockVersion()).isEqualTo(10L);
+        assertThat(snapshot.metadata.aggregateId()).isEqualTo("201");
+    }
+
+    private SnapshotEventResult captureSnapshotEvent() {
+        ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+        ArgumentCaptor<EventMetadata> metadataCaptor = ArgumentCaptor.forClass(EventMetadata.class);
+        verify(eventPublisher, atLeastOnce()).publish(eventCaptor.capture(), metadataCaptor.capture());
+
+        List<DomainEvent> events = eventCaptor.getAllValues();
+        int snapshotIndex = IntStream.range(0, events.size())
+                .filter(index -> events.get(index) instanceof ItemAvailableStockChangedEvent)
+                .findFirst()
+                .orElseThrow();
+
+        ItemAvailableStockChangedEvent event = (ItemAvailableStockChangedEvent) events.get(snapshotIndex);
+        EventMetadata metadata = metadataCaptor.getAllValues().get(snapshotIndex);
+        return new SnapshotEventResult(event, metadata);
+    }
+
+    private record SnapshotEventResult(ItemAvailableStockChangedEvent event, EventMetadata metadata) {
+    }
+}


### PR DESCRIPTION
## 변경 요약
Search 재고 정합성 강화를 위한 epic 통합 머지입니다.

### 포함된 Story
- `#626` Stock 재고 스냅샷 이벤트(itemId+version) 전환
- `#628` Search 버전 가드 기반 재고 동기화 + 좀비 문서 방어
- `#627` 재고 정합성 reconciliation 및 관측성 강화

### 핵심 변경
1. Stock 이벤트 모델
- `ITEM_AVAILABLE_STOCK_CHANGED` 이벤트 추가
- `itemId` 기준 `availableStockTotal + stockVersion` 발행
- 재고 변화 경로(감소/증가/예약/취소/만료/초기화) 공통 발행

2. Search 동기화 모델
- `stockVersion` 비교 기반 반영(`incomingVersion > currentVersion`)
- legacy 이벤트(`STOCK_DECREASED/INCREASED`) 병행 수용
- 삭제 문서 404 무시로 좀비 문서 재생성 방지

3. 운영 안정화
- Stock vs Search 재고 정합성 점검 API 추가
- reconciliation 스케줄러/메트릭(`search.reconciliation.checks`) 추가
- runbook 연동 경고 로그 추가

## 검증
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:stock:test :servers:services:search:test --rerun-tasks`

## 이슈 자동 닫기
Closes #625
Closes #626
Closes #627
Closes #628
