### PR TITLE
feat(#633): Gateway 검색/채팅 도메인 연동

### DIFF
--- a/servers/gateways/api-gateway/MODULE.md
+++ b/servers/gateways/api-gateway/MODULE.md
@@ -13,3 +13,7 @@
 ```text
 ./gradlew :servers:gateways:api-gateway:bootRun
 ```
+
+## 보안 헤더 서명
+- `APP_SECURITY_CONTEXT_SIGNING_KEY`를 설정하면 Gateway가 사용자 컨텍스트 헤더를 HMAC으로 서명해 전달합니다.
+- Chat 같은 소비 서비스도 같은 키를 사용해야 검증이 통과합니다.

--- a/servers/gateways/api-gateway/build.gradle.kts
+++ b/servers/gateways/api-gateway/build.gradle.kts
@@ -1,10 +1,21 @@
 dependencies {
     // Spring Cloud Gateway
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    // Security (JWT claim parsing)
+    implementation("org.springframework.security:spring-security-oauth2-jose")
+
+    // Shared modules
+    implementation(project(":libs:contracts:http"))
+    implementation(project(":libs:security:context"))
 
     // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    testAnnotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 
 dependencyManagement {

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewaySecurityContextConfig.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewaySecurityContextConfig.java
@@ -1,0 +1,25 @@
+package com.example.gateway.config;
+
+import com.example.security.context.HmacSigner;
+import com.example.security.context.SecurityContextProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableConfigurationProperties(SecurityContextProperties.class)
+public class GatewaySecurityContextConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "app.security.context", name = "signing-key")
+    public HmacSigner hmacSigner(SecurityContextProperties properties) {
+        if (!StringUtils.hasText(properties.getSigningKey())) {
+            throw new IllegalStateException("app.security.context.signing-key must not be blank");
+        }
+        return new HmacSigner(properties.getSigningKey());
+    }
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewaySecurityProperties.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewaySecurityProperties.java
@@ -1,0 +1,20 @@
+package com.example.gateway.config;
+
+import com.example.contracts.http.HttpHeaderNames;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gateway.security")
+public class GatewaySecurityProperties {
+
+    private String internalAuthHeader = HttpHeaderNames.GATEWAY_AUTH;
+    private String internalAuthToken = "";
+    private List<String> requireJwtPathPrefixes = List.of("/api/v1/chat", "/ws/chat");
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/GatewayJwtPrincipal.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/GatewayJwtPrincipal.java
@@ -1,0 +1,14 @@
+package com.example.gateway.security;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GatewayJwtPrincipal(Long userId, List<String> roles) {
+
+    public String rolesHeaderValue() {
+        String joined = roles.stream()
+                .filter(role -> role != null && !role.isBlank())
+                .collect(Collectors.joining(","));
+        return joined.isBlank() ? "USER" : joined;
+    }
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtClaimParseException.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtClaimParseException.java
@@ -1,0 +1,12 @@
+package com.example.gateway.security;
+
+public class JwtClaimParseException extends RuntimeException {
+
+    public JwtClaimParseException(String message) {
+        super(message);
+    }
+
+    public JwtClaimParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtClaimParser.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtClaimParser.java
@@ -1,0 +1,139 @@
+package com.example.gateway.security;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import org.springframework.stereotype.Component;
+
+import java.text.ParseException;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class JwtClaimParser {
+
+    private static final List<String> USER_ID_CLAIM_CANDIDATES =
+            List.of("userId", "user_id", "uid", "memberId", "sub");
+
+    public GatewayJwtPrincipal parse(String token) {
+        Map<String, Object> claims = parseClaims(token);
+        Long userId = extractUserId(claims);
+        if (userId == null || userId <= 0) {
+            throw new JwtClaimParseException("JWT에서 유효한 사용자 ID를 찾지 못했습니다");
+        }
+
+        List<String> roles = extractRoles(claims);
+        return new GatewayJwtPrincipal(userId, roles);
+    }
+
+    private Map<String, Object> parseClaims(String token) {
+        try {
+            JWT jwt = JWTParser.parse(token);
+            JWTClaimsSet claimsSet = jwt.getJWTClaimsSet();
+            if (claimsSet == null || claimsSet.getClaims() == null) {
+                throw new JwtClaimParseException("JWT 클레임이 비어 있습니다");
+            }
+            return claimsSet.getClaims();
+        } catch (ParseException e) {
+            throw new JwtClaimParseException("JWT 파싱에 실패했습니다", e);
+        }
+    }
+
+    private Long extractUserId(Map<String, Object> claims) {
+        for (String claimName : USER_ID_CLAIM_CANDIDATES) {
+            Object value = claims.get(claimName);
+            Long parsed = toPositiveLong(value);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        return null;
+    }
+
+    private Long toPositiveLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            long parsed = number.longValue();
+            return parsed > 0 ? parsed : null;
+        }
+        if (value instanceof String raw) {
+            try {
+                long parsed = Long.parseLong(raw.trim());
+                return parsed > 0 ? parsed : null;
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private List<String> extractRoles(Map<String, Object> claims) {
+        Set<String> roles = new LinkedHashSet<>();
+
+        addClaimValues(roles, claims.get("roles"));
+        addClaimValues(roles, claims.get("role"));
+        addClaimValues(roles, claims.get("authorities"));
+
+        Object scope = claims.get("scope");
+        if (scope instanceof String scopeText) {
+            addDelimitedValues(roles, scopeText, "\\s+");
+        }
+        Object scp = claims.get("scp");
+        if (scp instanceof String scopeText) {
+            addDelimitedValues(roles, scopeText, "\\s+");
+        } else {
+            addClaimValues(roles, scp);
+        }
+
+        Object realmAccess = claims.get("realm_access");
+        if (realmAccess instanceof Map<?, ?> realmAccessMap) {
+            addClaimValues(roles, realmAccessMap.get("roles"));
+        }
+
+        return List.copyOf(roles);
+    }
+
+    private void addClaimValues(Set<String> roles, Object claimValue) {
+        if (claimValue == null) {
+            return;
+        }
+        if (claimValue instanceof Collection<?> collection) {
+            for (Object value : collection) {
+                addSingleRole(roles, value);
+            }
+            return;
+        }
+        if (claimValue instanceof String text) {
+            if (text.contains(",")) {
+                addDelimitedValues(roles, text, ",");
+                return;
+            }
+            addSingleRole(roles, text);
+            return;
+        }
+        addSingleRole(roles, claimValue);
+    }
+
+    private void addDelimitedValues(Set<String> roles, String text, String regex) {
+        String[] tokens = text.split(regex);
+        for (String token : tokens) {
+            addSingleRole(roles, token);
+        }
+    }
+
+    private void addSingleRole(Set<String> roles, Object value) {
+        if (value == null) {
+            return;
+        }
+        String normalized = String.valueOf(value).trim();
+        if (!normalized.isEmpty()) {
+            roles.add(normalized.toUpperCase(Locale.ROOT));
+        }
+    }
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtHeaderRelayGlobalFilter.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/security/JwtHeaderRelayGlobalFilter.java
@@ -1,0 +1,194 @@
+package com.example.gateway.security;
+
+import com.example.contracts.http.HttpHeaderNames;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.example.security.context.HmacSigner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHeaderRelayGlobalFilter implements GlobalFilter, Ordered {
+
+    private static final List<String> TARGET_PATH_PREFIXES = List.of(
+            "/api/v1/search",
+            "/api/v1/chat",
+            "/ws/chat"
+    );
+
+    private final JwtClaimParser jwtClaimParser;
+    private final GatewaySecurityProperties securityProperties;
+    private final ObjectProvider<HmacSigner> hmacSignerProvider;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+        if (!isTargetPath(path)) {
+            return chain.filter(exchange);
+        }
+
+        String bearerToken;
+        try {
+            bearerToken = resolveBearerToken(exchange.getRequest().getHeaders());
+        } catch (JwtClaimParseException e) {
+            return unauthorized(exchange, "GW-AUTH-001", e.getMessage());
+        }
+
+        boolean jwtRequired = isJwtRequiredPath(path);
+        GatewayJwtPrincipal principal = null;
+        if (StringUtils.hasText(bearerToken)) {
+            try {
+                principal = jwtClaimParser.parse(bearerToken);
+            } catch (JwtClaimParseException e) {
+                return unauthorized(exchange, "GW-AUTH-002", e.getMessage());
+            }
+        } else if (jwtRequired) {
+            return unauthorized(exchange, "GW-AUTH-003", "chat 경로는 Bearer 토큰이 필요합니다");
+        }
+
+        SignedHeaderValues signedHeaders = null;
+        try {
+            if (principal != null) {
+                signedHeaders = createSignedHeaders(principal);
+            }
+        } catch (IllegalArgumentException e) {
+            return unauthorized(exchange, "GW-AUTH-004", "서명 헤더 생성에 실패했습니다");
+        }
+
+        GatewayJwtPrincipal finalPrincipal = principal;
+        SignedHeaderValues finalSignedHeaders = signedHeaders;
+        ServerHttpRequest request = exchange.getRequest().mutate()
+                .headers(headers -> {
+                    removeSensitiveHeaders(headers);
+                    applyInternalAuthHeader(headers);
+                    applyPrincipalHeaders(headers, finalPrincipal, finalSignedHeaders);
+                })
+                .build();
+
+        return chain.filter(exchange.mutate().request(request).build());
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    private boolean isTargetPath(String path) {
+        return TARGET_PATH_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+
+    private boolean isJwtRequiredPath(String path) {
+        List<String> requiredPrefixes = securityProperties.getRequireJwtPathPrefixes();
+        if (requiredPrefixes == null || requiredPrefixes.isEmpty()) {
+            return false;
+        }
+        return requiredPrefixes.stream()
+                .anyMatch(path::startsWith);
+    }
+
+    private String resolveBearerToken(HttpHeaders headers) {
+        String authHeader = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        if (!StringUtils.hasText(authHeader)) {
+            return null;
+        }
+
+        String prefix = "bearer ";
+        if (!authHeader.toLowerCase(Locale.ROOT).startsWith(prefix)) {
+            throw new JwtClaimParseException("Authorization 헤더는 Bearer 형식이어야 합니다");
+        }
+
+        String token = authHeader.substring(prefix.length()).trim();
+        if (!StringUtils.hasText(token)) {
+            throw new JwtClaimParseException("Bearer 토큰이 비어 있습니다");
+        }
+        return token;
+    }
+
+    private SignedHeaderValues createSignedHeaders(GatewayJwtPrincipal principal) {
+        HmacSigner signer = hmacSignerProvider.getIfAvailable();
+        if (signer == null) {
+            return null;
+        }
+
+        String userId = String.valueOf(principal.userId());
+        String roles = principal.rolesHeaderValue();
+        String nonce = UUID.randomUUID().toString();
+        long timestamp = System.currentTimeMillis();
+        String payload = HmacSigner.buildSignaturePayload(userId, roles, nonce, timestamp);
+        String signature = signer.sign(payload);
+        return new SignedHeaderValues(nonce, timestamp, signature);
+    }
+
+    private void removeSensitiveHeaders(HttpHeaders headers) {
+        headers.remove(HttpHeaderNames.USER_ID);
+        headers.remove(HttpHeaderNames.USER_ROLES);
+        headers.remove(HttpHeaderNames.NONCE);
+        headers.remove(HttpHeaderNames.TIMESTAMP);
+        headers.remove(HttpHeaderNames.SIGNATURE);
+        headers.remove(HttpHeaderNames.GATEWAY_AUTH);
+    }
+
+    private void applyInternalAuthHeader(HttpHeaders headers) {
+        if (StringUtils.hasText(securityProperties.getInternalAuthToken())
+                && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
+            headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
+        }
+    }
+
+    private void applyPrincipalHeaders(HttpHeaders headers,
+                                       GatewayJwtPrincipal principal,
+                                       SignedHeaderValues signedHeaders) {
+        if (principal == null) {
+            return;
+        }
+
+        headers.set(HttpHeaderNames.USER_ID, String.valueOf(principal.userId()));
+        String rolesHeader = principal.rolesHeaderValue();
+        headers.set(HttpHeaderNames.USER_ROLES, rolesHeader);
+
+        if (signedHeaders != null) {
+            headers.set(HttpHeaderNames.NONCE, signedHeaders.nonce());
+            headers.set(HttpHeaderNames.TIMESTAMP, String.valueOf(signedHeaders.timestamp()));
+            headers.set(HttpHeaderNames.SIGNATURE, signedHeaders.signature());
+        }
+    }
+
+    private Mono<Void> unauthorized(ServerWebExchange exchange, String code, String message) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        String body = """
+                {
+                  "success": false,
+                  "error": {
+                    "code": "%s",
+                    "message": "%s"
+                  }
+                }
+                """.formatted(code, message);
+        return response.writeWith(Mono.just(response.bufferFactory()
+                .wrap(body.getBytes(StandardCharsets.UTF_8))));
+    }
+
+    private record SignedHeaderValues(String nonce, long timestamp, String signature) {
+    }
+}

--- a/servers/gateways/api-gateway/src/main/resources/application.yml
+++ b/servers/gateways/api-gateway/src/main/resources/application.yml
@@ -1,9 +1,38 @@
 server:
-  port: 8080
+  port: ${SERVER_PORT:18080}
 
 spring:
   application:
     name: api-gateway
+  autoconfigure:
+    exclude:
+      - com.example.security.context.SecurityContextAutoConfiguration
   cloud:
     gateway:
-      routes: []
+      server:
+        webflux:
+          routes:
+            - id: search-service
+              uri: ${app.service.search-url:http://localhost:8088}
+              predicates:
+                - Path=/api/v1/search/**
+            - id: chat-service-api
+              uri: ${app.service.chat-url:http://localhost:8093}
+              predicates:
+                - Path=/api/v1/chat/**
+            - id: chat-service-ws
+              uri: ${app.service.chat-ws-url:ws://localhost:8093}
+              predicates:
+                - Path=/ws/chat,/ws/chat/**
+
+gateway:
+  security:
+    internal-auth-header: ${GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
+    internal-auth-token: ${GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}
+    require-jwt-path-prefixes: ${GATEWAY_SECURITY_REQUIRE_JWT_PATH_PREFIXES:/api/v1/chat,/ws/chat}
+
+app:
+  security:
+    context:
+      signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}
+      max-age-millis: ${APP_SECURITY_CONTEXT_MAX_AGE_MILLIS:300000}

--- a/servers/gateways/api-gateway/src/test/java/com/example/gateway/security/JwtClaimParserTest.java
+++ b/servers/gateways/api-gateway/src/test/java/com/example/gateway/security/JwtClaimParserTest.java
@@ -1,0 +1,71 @@
+package com.example.gateway.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtClaimParserTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final JwtClaimParser parser = new JwtClaimParser();
+
+    @Test
+    void parse_extractsUserIdAndRoles() {
+        String jwt = buildJwt(Map.of(
+                "userId", 101,
+                "roles", List.of("buyer", "user"),
+                "scope", "chat:write chat:read"
+        ));
+
+        GatewayJwtPrincipal principal = parser.parse(jwt);
+
+        assertThat(principal.userId()).isEqualTo(101L);
+        assertThat(principal.roles()).containsExactly("BUYER", "USER", "CHAT:WRITE", "CHAT:READ");
+    }
+
+    @Test
+    void parse_supportsKeycloakStyleClaims() {
+        String jwt = buildJwt(Map.of(
+                "sub", "202",
+                "realm_access", Map.of("roles", List.of("admin", "staff"))
+        ));
+
+        GatewayJwtPrincipal principal = parser.parse(jwt);
+
+        assertThat(principal.userId()).isEqualTo(202L);
+        assertThat(principal.roles()).containsExactly("ADMIN", "STAFF");
+    }
+
+    @Test
+    void parse_throwsWhenNoValidUserIdClaimExists() {
+        String jwt = buildJwt(Map.of("sub", "not-number"));
+
+        assertThatThrownBy(() -> parser.parse(jwt))
+                .isInstanceOf(JwtClaimParseException.class)
+                .hasMessageContaining("사용자 ID");
+    }
+
+    private String buildJwt(Map<String, Object> claims) {
+        try {
+            String header = base64Url("{\"alg\":\"none\",\"typ\":\"JWT\"}");
+            String payload = base64Url(OBJECT_MAPPER.writeValueAsString(claims));
+            return "%s.%s.".formatted(header, payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String base64Url(String raw) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/servers/gateways/api-gateway/src/test/java/com/example/gateway/security/JwtHeaderRelayGlobalFilterTest.java
+++ b/servers/gateways/api-gateway/src/test/java/com/example/gateway/security/JwtHeaderRelayGlobalFilterTest.java
@@ -1,0 +1,164 @@
+package com.example.gateway.security;
+
+import com.example.contracts.http.HttpHeaderNames;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.example.security.context.HmacSigner;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtHeaderRelayGlobalFilterTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final List<String> JWT_REQUIRED_PATHS = List.of("/api/v1/chat", "/ws/chat");
+
+    @Test
+    void filter_setsUserHeadersAndInternalAuthForChatRequest() {
+        JwtHeaderRelayGlobalFilter filter = createFilter("gw-internal-token", null);
+        String jwt = buildJwt(Map.of("userId", 77, "roles", List.of("buyer", "user")));
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/chat/rooms")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+                .header(HttpHeaderNames.USER_ID, "999")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        CapturingChain chain = new CapturingChain();
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.called).isTrue();
+        ServerHttpRequest forwardedRequest = chain.exchange.getRequest();
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.USER_ID)).isEqualTo("77");
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.USER_ROLES)).isEqualTo("BUYER,USER");
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.GATEWAY_AUTH)).isEqualTo("gw-internal-token");
+    }
+
+    @Test
+    void filter_returns401WhenChatRequestHasNoJwt() {
+        JwtHeaderRelayGlobalFilter filter = createFilter("gw-internal-token", null);
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/chat/rooms").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        CapturingChain chain = new CapturingChain();
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.called).isFalse();
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void filter_allowsAnonymousSearchAndRemovesSpoofedHeaders() {
+        JwtHeaderRelayGlobalFilter filter = createFilter("", null);
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/search?q=airpods")
+                .header(HttpHeaderNames.USER_ID, "12345")
+                .header(HttpHeaderNames.USER_ROLES, "ADMIN")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        CapturingChain chain = new CapturingChain();
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.called).isTrue();
+        ServerHttpRequest forwardedRequest = chain.exchange.getRequest();
+        assertThat(forwardedRequest.getHeaders().containsKey(HttpHeaderNames.USER_ID)).isFalse();
+        assertThat(forwardedRequest.getHeaders().containsKey(HttpHeaderNames.USER_ROLES)).isFalse();
+    }
+
+    @Test
+    void filter_addsSignedHeadersWhenSignerExists() {
+        JwtHeaderRelayGlobalFilter filter = createFilter("gw-internal-token", new HmacSigner("test-signing-key"));
+        String jwt = buildJwt(Map.of("sub", "55", "scope", "chat:read"));
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/chat/rooms")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        CapturingChain chain = new CapturingChain();
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.called).isTrue();
+        ServerHttpRequest forwardedRequest = chain.exchange.getRequest();
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.NONCE)).isNotBlank();
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.TIMESTAMP)).isNotBlank();
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.SIGNATURE)).isNotBlank();
+    }
+
+    @Test
+    void filter_setsDefaultRoleWhenJwtHasNoRoles() {
+        JwtHeaderRelayGlobalFilter filter = createFilter("gw-internal-token", null);
+        String jwt = buildJwt(Map.of("userId", 88));
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/chat/rooms")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        CapturingChain chain = new CapturingChain();
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(chain.called).isTrue();
+        ServerHttpRequest forwardedRequest = chain.exchange.getRequest();
+        assertThat(forwardedRequest.getHeaders().getFirst(HttpHeaderNames.USER_ROLES)).isEqualTo("USER");
+    }
+
+    private JwtHeaderRelayGlobalFilter createFilter(String internalToken, HmacSigner signer) {
+        GatewaySecurityProperties properties = new GatewaySecurityProperties();
+        properties.setInternalAuthToken(internalToken);
+        properties.setRequireJwtPathPrefixes(JWT_REQUIRED_PATHS);
+
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        if (signer != null) {
+            beanFactory.addBean("hmacSigner", signer);
+        }
+        return new JwtHeaderRelayGlobalFilter(
+                new JwtClaimParser(),
+                properties,
+                beanFactory.getBeanProvider(HmacSigner.class)
+        );
+    }
+
+    private String buildJwt(Map<String, Object> claims) {
+        try {
+            String header = base64Url("{\"alg\":\"none\",\"typ\":\"JWT\"}");
+            String payload = base64Url(OBJECT_MAPPER.writeValueAsString(claims));
+            return "%s.%s.".formatted(header, payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String base64Url(String raw) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final class CapturingChain implements GatewayFilterChain {
+        private boolean called;
+        private ServerWebExchange exchange;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange) {
+            this.called = true;
+            this.exchange = exchange;
+            return Mono.empty();
+        }
+    }
+}

--- a/servers/services/chat/src/main/resources/application.yml
+++ b/servers/services/chat/src/main/resources/application.yml
@@ -63,6 +63,10 @@ chat:
 
 # ─── Snowflake ID ────────────────────────────
 app:
+  security:
+    context:
+      signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}
+      max-age-millis: ${APP_SECURITY_CONTEXT_MAX_AGE_MILLIS:300000}
   snowflake:
     datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
     worker-id: ${SNOWFLAKE_WORKER_ID:10}


### PR DESCRIPTION
<h2>개요</h2><p>Gateway BFF에서 검색/채팅 도메인 연동에 필요한 라우팅과 내부 인증 컨텍스트 전달을 추가했습니다. 클라이언트 JWT를 게이트웨이에서 파싱해 내부 헤더로 전달하고, HMAC 서명으로 위변조 방지 신뢰 경계를 구성했습니다.</p><h3>관련 이슈</h3><ul><li>Closes #633</li><li>Closes #634</li></ul><h3>작업 / 변경 내용</h3><ul><li>Gateway 라우팅 추가: Search/Chat HTTP, Chat WebSocket 경로 연동</li><li>JWT Claim 파싱 후 내부 전달 헤더(X-User-Id, X-User-Role) 구성</li><li>내부 호출 신뢰성 강화를 위한 HMAC 서명 헤더(X-Principal-Signature, X-Principal-Timestamp) 적용</li><li>외부에서 주입된 스푸핑 헤더 무시/차단 처리</li><li>게이트웨이 전용 보안 설정(gateway.security.*, app.security.context.*) 반영</li><li>curl 기반 E2E로 정상/오류/스푸핑 시나리오 검증</li></ul><h3>테스트 / 체크리스트</h3><ul><li>[ ] 로컬에서 빌드 확인 (./gradlew build)</li><li>[x] 관련 테스트 작성 또는 확인</li><li>[x] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)</li></ul><h3>참고사항</h3><ul><li>검증 명령: env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:gateways:api-gateway:test --rerun-tasks</li><li>검증 명령: env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:chat:compileJava --rerun-tasks</li><li>E2E 검증 스크립트: /tmp/gateway_jwt_header_verify.sh</li></ul>