### PR TITLE
feat(#506): gateway bff auth skeleton and search hardening

### DIFF
--- a/docker/scripts/gateway_jwt_header_verify.sh
+++ b/docker/scripts/gateway_jwt_header_verify.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/gateway-jwt-verify-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+GW_PORT="${GW_PORT:-18173}"
+CHAT_PORT="${CHAT_PORT:-18093}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] gateway/chat logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port ${port} is already in use"
+    return 1
+  fi
+  pass "port ${port} is free"
+}
+
+wait_http_code_prefix() {
+  local name="$1"
+  local url="$2"
+  local prefix="$3"
+  local retries="${4:-120}"
+  local code=""
+  for _ in $(seq 1 "$retries"); do
+    code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" || true)
+    if [[ "$code" == "$prefix"* ]]; then
+      pass "${name} is ready (${code})"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "${name} readiness timeout (last=${code})"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+assert_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "${label} status=${actual}"
+  else
+    fail "${label} expected=${expected} actual=${actual}"
+  fi
+}
+
+b64url() {
+  printf '%s' "$1" | openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+if [[ ! -f "$ROOT/docker/.env" ]]; then
+  echo "[ERR] docker/.env not found at $ROOT/docker/.env" >&2
+  exit 1
+fi
+
+SIGNING_KEY="$(sed -n 's/^APP_SECURITY_CONTEXT_SIGNING_KEY=//p' "$ROOT/docker/.env" | head -n1)"
+MAX_AGE="$(sed -n 's/^APP_SECURITY_CONTEXT_MAX_AGE_MILLIS=//p' "$ROOT/docker/.env" | head -n1)"
+if [[ -z "$SIGNING_KEY" ]]; then
+  echo "[ERR] APP_SECURITY_CONTEXT_SIGNING_KEY is empty in docker/.env" >&2
+  exit 1
+fi
+if [[ -z "$MAX_AGE" ]]; then
+  MAX_AGE=300000
+fi
+
+check_port_free "$GW_PORT"
+check_port_free "$CHAT_PORT"
+
+echo "[INFO] preparing docker infra"
+(cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka mariadb >/dev/null)
+
+echo "[INFO] starting chat-service on port ${CHAT_PORT}"
+(
+  cd "$ROOT"
+  env \
+    GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+    SERVER_PORT="$CHAT_PORT" \
+    APP_SECURITY_CONTEXT_SIGNING_KEY="$SIGNING_KEY" \
+    APP_SECURITY_CONTEXT_MAX_AGE_MILLIS="$MAX_AGE" \
+    CHAT_SECURITY_GATEWAY_AUTH_ENABLED=true \
+    ./gradlew :servers:services:chat:bootRun --no-daemon >"$LOG_DIR/chat.log" 2>&1
+) &
+PIDS+=("$!")
+
+wait_http_code_prefix "chat-service health" "http://127.0.0.1:${CHAT_PORT}/actuator/health" "200" 150
+
+echo "[INFO] starting api-gateway on port ${GW_PORT}"
+(
+  cd "$ROOT"
+  env \
+    GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+    SERVER_PORT="$GW_PORT" \
+    APP_SECURITY_CONTEXT_SIGNING_KEY="$SIGNING_KEY" \
+    APP_SECURITY_CONTEXT_MAX_AGE_MILLIS="$MAX_AGE" \
+    APP_SERVICE_CHAT_URL="http://127.0.0.1:${CHAT_PORT}" \
+    APP_SERVICE_CHAT_WS_URL="ws://127.0.0.1:${CHAT_PORT}" \
+    ./gradlew :servers:gateways:api-gateway:bootRun --no-daemon >"$LOG_DIR/gateway.log" 2>&1
+) &
+PIDS+=("$!")
+
+# api-gateway에는 actuator가 없어 보호된 chat 엔드포인트 401 응답으로 기동 상태를 확인한다.
+wait_http_code_prefix "api-gateway" "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1" "401" 150
+
+JWT_HEADER='{"alg":"none","typ":"JWT"}'
+JWT_PAYLOAD_OK='{"userId":777,"roles":["buyer","user"]}'
+JWT_PAYLOAD_BAD='{"sub":"not-number","roles":["buyer"]}'
+
+TOKEN_OK="$(b64url "$JWT_HEADER").$(b64url "$JWT_PAYLOAD_OK")."
+TOKEN_BAD="$(b64url "$JWT_HEADER").$(b64url "$JWT_PAYLOAD_BAD")."
+
+RAW1="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+  "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1")"
+BODY1="$(extract_http_body "$RAW1")"
+CODE1="$(extract_http_status "$RAW1")"
+echo "$BODY1" >"$LOG_DIR/case1_no_token.json"
+assert_status "case1 no token" "$CODE1" "401"
+
+RAW2="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+  -H "Authorization: Basic abc" \
+  "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1")"
+BODY2="$(extract_http_body "$RAW2")"
+CODE2="$(extract_http_status "$RAW2")"
+echo "$BODY2" >"$LOG_DIR/case2_malformed_auth.json"
+assert_status "case2 malformed auth" "$CODE2" "401"
+
+RAW3="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+  -H "Authorization: Bearer $TOKEN_BAD" \
+  -H "X-User-Id: 999" \
+  -H "X-User-Roles: ADMIN" \
+  "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1")"
+BODY3="$(extract_http_body "$RAW3")"
+CODE3="$(extract_http_status "$RAW3")"
+echo "$BODY3" >"$LOG_DIR/case3_bad_claim_spoof.json"
+assert_status "case3 bad jwt + spoof" "$CODE3" "401"
+
+RAW4="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+  -H "Authorization: Bearer $TOKEN_OK" \
+  -H "X-User-Id: not-a-number" \
+  -H "X-User-Roles: ADMIN" \
+  "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1")"
+BODY4="$(extract_http_body "$RAW4")"
+CODE4="$(extract_http_status "$RAW4")"
+echo "$BODY4" >"$LOG_DIR/case4_valid_jwt_spoof_invalid_header.json"
+assert_status "case4 valid jwt + spoof invalid header" "$CODE4" "200"
+
+RAW5="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+  -H "Authorization: Bearer $TOKEN_OK" \
+  -H 'X-User-Id: <script>alert(1)</script>' \
+  -H 'X-User-Roles: <img src=x onerror=alert(1)>' \
+  "http://127.0.0.1:${GW_PORT}/api/v1/chat/rooms?size=1")"
+BODY5="$(extract_http_body "$RAW5")"
+CODE5="$(extract_http_status "$RAW5")"
+echo "$BODY5" >"$LOG_DIR/case5_valid_jwt_xss_spoof.json"
+assert_status "case5 valid jwt + xss spoof" "$CODE5" "200"
+
+echo "[INFO] result passes=${PASSES} failures=${FAILURES}"
+if [[ "$FAILURES" -gt 0 ]]; then
+  exit 1
+fi
+
+pass "gateway JWT relay e2e passed"

--- a/servers/gateways/api-gateway/MODULE.md
+++ b/servers/gateways/api-gateway/MODULE.md
@@ -14,6 +14,24 @@
 ./gradlew :servers:gateways:api-gateway:bootRun
 ```
 
+## 로컬 E2E 검증
+```text
+./docker/scripts/gateway_jwt_header_verify.sh
+```
+- 기본 포트: Gateway `18173`, Chat `18093`
+- 환경 변수로 변경 가능: `GW_PORT`, `CHAT_PORT`, `LOG_DIR`
+
 ## 보안 헤더 서명
 - `APP_SECURITY_CONTEXT_SIGNING_KEY`를 설정하면 Gateway가 사용자 컨텍스트 헤더를 HMAC으로 서명해 전달합니다.
 - Chat 같은 소비 서비스도 같은 키를 사용해야 검증이 통과합니다.
+
+## BFF 인증 스켈레톤
+- `bff-auth` 프로필이 활성화될 때 OAuth2 BFF 보안체인/TokenRelay 라우팅이 켜집니다.
+- 예시: `SPRING_PROFILES_ACTIVE=bff-auth`
+- 활성화 시 라우팅:
+  - `/api/v1/auth/**` -> Auth Service
+  - `/api/v1/users/**`, `/api/users/**` -> User Service
+- 필수 설정:
+  - `GATEWAY_OAUTH2_ISSUER_URI`
+  - `GATEWAY_OAUTH2_CLIENT_ID`
+  - `GATEWAY_OAUTH2_CLIENT_SECRET`

--- a/servers/gateways/api-gateway/build.gradle.kts
+++ b/servers/gateways/api-gateway/build.gradle.kts
@@ -2,6 +2,8 @@ dependencies {
     // Spring Cloud Gateway
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // Security (JWT claim parsing)
     implementation("org.springframework.security:spring-security-oauth2-jose")

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayAuthProperties.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayAuthProperties.java
@@ -1,0 +1,17 @@
+package com.example.gateway.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "gateway.auth")
+public class GatewayAuthProperties {
+
+    private boolean enabled = false;
+    private String authServiceUrl = "http://localhost:8081";
+    private String userServiceUrl = "http://localhost:8082";
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayAuthRouteConfig.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayAuthRouteConfig.java
@@ -1,0 +1,30 @@
+package com.example.gateway.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayAuthRouteConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "gateway.auth", name = "enabled", havingValue = "true")
+    public RouteLocator authRouteLocator(RouteLocatorBuilder builder, GatewayAuthProperties properties) {
+        return builder.routes()
+                .route("auth-service-api", route -> route
+                        .path("/api/v1/auth/**")
+                        .filters(filter -> filter.tokenRelay())
+                        .uri(properties.getAuthServiceUrl()))
+                .route("user-service-api-v1", route -> route
+                        .path("/api/v1/users/**")
+                        .filters(filter -> filter.tokenRelay())
+                        .uri(properties.getUserServiceUrl()))
+                .route("user-service-api-legacy", route -> route
+                        .path("/api/users/**")
+                        .filters(filter -> filter.tokenRelay())
+                        .uri(properties.getUserServiceUrl()))
+                .build();
+    }
+}

--- a/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayBffSecurityConfig.java
+++ b/servers/gateways/api-gateway/src/main/java/com/example/gateway/config/GatewayBffSecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.gateway.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class GatewayBffSecurityConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "gateway.auth", name = "enabled", havingValue = "true")
+    public SecurityWebFilterChain oauth2SecurityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/api/v1/users/**", "/api/users/**").authenticated()
+                        .anyExchange().permitAll())
+                .oauth2Login(Customizer.withDefaults())
+                .oauth2Client(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "gateway.auth", name = "enabled", havingValue = "false", matchIfMissing = true)
+    public SecurityWebFilterChain permitAllSecurityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchanges -> exchanges.anyExchange().permitAll())
+                .build();
+    }
+}

--- a/servers/gateways/api-gateway/src/main/resources/application-bff-auth.yml
+++ b/servers/gateways/api-gateway/src/main/resources/application-bff-auth.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: bff-auth
+  security:
+    oauth2:
+      client:
+        registration:
+          keycloak:
+            provider: keycloak
+            client-id: ${GATEWAY_OAUTH2_CLIENT_ID}
+            client-secret: ${GATEWAY_OAUTH2_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope: ${GATEWAY_OAUTH2_SCOPES:openid,profile,email}
+        provider:
+          keycloak:
+            issuer-uri: ${GATEWAY_OAUTH2_ISSUER_URI}
+
+gateway:
+  auth:
+    enabled: true

--- a/servers/gateways/api-gateway/src/main/resources/application.yml
+++ b/servers/gateways/api-gateway/src/main/resources/application.yml
@@ -24,8 +24,11 @@ spring:
               uri: ${app.service.chat-ws-url:ws://localhost:8093}
               predicates:
                 - Path=/ws/chat,/ws/chat/**
-
 gateway:
+  auth:
+    enabled: ${GATEWAY_AUTH_ENABLED:false}
+    auth-service-url: ${app.service.auth-url:http://localhost:8081}
+    user-service-url: ${app.service.user-url:http://localhost:8082}
   security:
     internal-auth-header: ${GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
     internal-auth-token: ${GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}

--- a/servers/services/search/src/main/java/com/example/search/controller/api/query/SearchApi.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/api/query/SearchApi.java
@@ -2,16 +2,13 @@ package com.example.search.controller.api.query;
 
 import com.example.api.response.ApiResponse;
 import com.example.core.pagination.CursorResponse;
+import com.example.search.dto.search.request.SearchRequest;
 import com.example.search.dto.search.response.SearchItemResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 @Tag(name = "Search Query", description = "검색 조회 API")
 public interface SearchApi {
@@ -19,14 +16,6 @@ public interface SearchApi {
     @Operation(summary = "상품 검색")
     @GetMapping
     ApiResponse<CursorResponse<SearchItemResponse>> search(
-            @RequestParam @NotBlank String q,
-            @RequestParam(required = false) String category,
-            @RequestParam(required = false) String domainType,
-            @RequestParam(required = false, name = "status") List<String> status,
-            @RequestParam(required = false) @Min(0) Long minPrice,
-            @RequestParam(required = false) @Min(0) Long maxPrice,
-            @RequestParam(defaultValue = "LATEST") String sort,
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+            @Valid @ModelAttribute SearchRequest request
     );
 }

--- a/servers/services/search/src/main/java/com/example/search/controller/query/SearchQueryController.java
+++ b/servers/services/search/src/main/java/com/example/search/controller/query/SearchQueryController.java
@@ -11,8 +11,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @Validated
 @RestController
 @RequestMapping("/api/v1/search")
@@ -22,28 +20,7 @@ public class SearchQueryController implements SearchApi {
     private final SearchQueryService searchQueryService;
 
     @Override
-    public ApiResponse<CursorResponse<SearchItemResponse>> search(
-            String q,
-            String category,
-            String domainType,
-            List<String> status,
-            Long minPrice,
-            Long maxPrice,
-            String sort,
-            String cursor,
-            int size
-    ) {
-        SearchRequest request = new SearchRequest();
-        request.setQ(q);
-        request.setCategory(category);
-        request.setDomainType(domainType);
-        request.setStatus(status);
-        request.setMinPrice(minPrice);
-        request.setMaxPrice(maxPrice);
-        request.setSort(sort);
-        request.setCursor(cursor);
-        request.setSize(size);
-
+    public ApiResponse<CursorResponse<SearchItemResponse>> search(SearchRequest request) {
         return ApiResponse.success(searchQueryService.search(request));
     }
 }

--- a/servers/services/search/src/main/java/com/example/search/service/index/IndexManagementService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/IndexManagementService.java
@@ -24,6 +24,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
 @Service
@@ -34,9 +37,23 @@ public class IndexManagementService {
 
     private final RestClient restClient;
     private final SearchIndexTemplateResolver templateResolver;
+    private final ConcurrentMap<String, ReentrantLock> recreateLocks = new ConcurrentHashMap<>();
 
     public IndexRecreateResponse recreateItemsIndex(String requestedIndexName) {
         String baseName = normalizeIndexBaseName(requestedIndexName);
+        ReentrantLock lock = recreateLocks.computeIfAbsent(baseName, key -> new ReentrantLock());
+        lock.lock();
+        try {
+            return recreateItemsIndexSafely(baseName);
+        } finally {
+            lock.unlock();
+            if (!lock.hasQueuedThreads()) {
+                recreateLocks.remove(baseName, lock);
+            }
+        }
+    }
+
+    private IndexRecreateResponse recreateItemsIndexSafely(String baseName) {
         String readAlias = baseName + "-read";
         String writeAlias = baseName + "-write";
 
@@ -149,16 +166,11 @@ public class IndexManagementService {
             log.warn("Skip deleting failed target index because alias is still attached. target={}", targetIndex);
             return;
         }
-        deleteIndexQuietly(targetIndex);
-    }
 
-    private void deleteIndexQuietly(String indexName) {
-        try {
-            Request request = new Request("DELETE", "/" + indexName);
-            restClient.performRequest(request);
-        } catch (Exception deleteEx) {
-            log.warn("Failed to delete index after alias switch failure. index={}", indexName, deleteEx);
-        }
+        log.warn(
+                "Alias switch failed and orphan index might remain. autoDeleteSkipped=true, target={}",
+                targetIndex
+        );
     }
 
     private void applyAliasActions(List<Map<String, Object>> actions) throws IOException {

--- a/servers/services/search/src/test/java/com/example/search/controller/query/SearchQueryControllerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/controller/query/SearchQueryControllerTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,5 +38,26 @@ class SearchQueryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.totalCount").value(0));
+    }
+
+    @Test
+    void search_returnsBadRequestWhenQueryIsBlank() throws Exception {
+        mockMvc.perform(get("/api/v1/search")
+                        .param("q", "  ")
+                        .param("size", "20"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(searchQueryService);
+    }
+
+    @Test
+    void search_returnsBadRequestWhenMinPriceIsNegative() throws Exception {
+        mockMvc.perform(get("/api/v1/search")
+                        .param("q", "아이폰")
+                        .param("minPrice", "-1")
+                        .param("size", "20"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(searchQueryService);
     }
 }

--- a/servers/services/search/src/test/java/com/example/search/service/index/IndexManagementServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/IndexManagementServiceTest.java
@@ -74,7 +74,7 @@ class IndexManagementServiceTest {
     }
 
     @Test
-    void recreateItemsIndex_deletesCreatedTargetWhenAliasSwitchFails() throws Exception {
+    void recreateItemsIndex_keepsCreatedTargetWhenAliasSwitchFailsToAvoidConcurrentDataLoss() throws Exception {
         List<Request> requests = new ArrayList<>();
 
         when(restClient.performRequest(any(Request.class))).thenAnswer(invocation -> {
@@ -105,7 +105,7 @@ class IndexManagementServiceTest {
                     assertThat(businessException.getErrorCode()).isEqualTo(SearchErrorCode.INDEX_MANAGEMENT_FAILED);
                 });
 
-        assertThat(requests).anyMatch(request ->
+        assertThat(requests).noneMatch(request ->
                 "DELETE".equals(request.getMethod()) && "/items-v2".equals(request.getEndpoint()));
     }
 


### PR DESCRIPTION
## 개요

Gateway BFF 인증 연동 사전 스켈레톤(#506/#507/#508)을 추가하고, Search 인덱스 재생성 안전성/입력 검증 누락 이슈를 함께 보완했습니다.

### 관련 이슈
<!-- "Closes #이슈번호" 형식으로 작성하면 PR 머지 시 이슈가 자동 닫히고 Jira도 Done 전환됩니다 -->
- Related #506
- Closes #507
- Closes #508

### 작업 / 변경 내용
<!-- 무엇을 왜 변경했는지 간단히 -->
- Search 인덱스 재생성 동시성 보호
  - `IndexManagementService`에 baseName 단위 락 추가
  - alias 스위치 실패 시 자동 인덱스 삭제를 중단해 동시성 상황의 오삭제 리스크 차단
- Search 입력 검증 경로 일원화
  - `SearchApi`를 `@Valid @ModelAttribute SearchRequest` 기반으로 전환
  - 컨트롤러에서 DTO 수동 조립 제거
  - 공백 쿼리/음수 가격 요청 400 검증 테스트 추가
- Gateway BFF 인증 스켈레톤
  - `gateway.auth.enabled` 조건부 보안체인(`GatewayBffSecurityConfig`) 추가
  - OAuth2 TokenRelay 기반 Auth/User 라우팅(`GatewayAuthRouteConfig`) 추가
  - OAuth2 설정 분리 파일 `application-bff-auth.yml` 추가(기본 프로필 부팅 영향 제거)
- Gateway JWT/HMAC E2E 자산화
  - `docker/scripts/gateway_jwt_header_verify.sh` 추가
  - `MODULE.md`에 실행 방법/설정 가이드 보강

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
<!-- 리뷰 시 중점적으로 봐주면 좋을 부분, 논의 사항 등 (선택) -->
- 테스트 실행
  - `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:search:test --rerun-tasks`
  - `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:gateways:api-gateway:test --rerun-tasks`
- E2E 실행
  - `./docker/scripts/gateway_jwt_header_verify.sh`
- OAuth2 BFF 스켈레톤 활성화
  - `SPRING_PROFILES_ACTIVE=bff-auth`
  - `GATEWAY_OAUTH2_ISSUER_URI`, `GATEWAY_OAUTH2_CLIENT_ID`, `GATEWAY_OAUTH2_CLIENT_SECRET` 필요
