### PR TITLE
feat: add elasticsearch infra and item price sync for search

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,12 +6,15 @@ This directory contains Docker Compose configuration for running the Project03 b
 
 | Service | Port | Description |
 |---------|------|-------------|
-| PostgreSQL | 5432 | Main database (auth_db, user_db, test_db) |
+| PostgreSQL | 5432 | Main database (service-specific DBs) |
+| MariaDB | 3306 | Chat persistence |
 | Redis | 6379 | Caching layer |
+| Elasticsearch | 23173 | Search index engine |
 | Kafka | 29092 | Event streaming (localhost access) |
 | Kafka | 9092 | Event streaming (inter-container) |
 | Zookeeper | 2181 | Kafka coordination |
 | Zipkin | 9411 | Distributed tracing UI |
+| MailHog | 1025 / 8025 | Local SMTP + UI |
 
 ## Quick Start
 
@@ -55,10 +58,18 @@ docker-compose down -v
 
 ## Database Setup
 
-The PostgreSQL init script automatically creates three databases:
-- `auth_db` - Authentication service database
-- `user_db` - User service database
-- `test_db` - Test server database
+The PostgreSQL init script automatically creates service databases:
+- `auth_db`
+- `user_db`
+- `test_db`
+- `product_db`
+- `stock_db`
+- `funding_db`
+- `sales_db`
+- `hotdeal_db`
+- `search_db`
+- `notification_db`
+- `chat_db`
 
 All databases have the `uuid-ossp` extension enabled.
 
@@ -169,6 +180,23 @@ cp .env.example .env
 
 Default values are suitable for local development.
 
+### Security signing key (Gateway HMAC headers)
+
+For Gateway -> service signed headers (`X-Nonce`, `X-Timestamp`, `X-Signature`), set a shared signing key:
+
+```bash
+openssl rand -base64 48 | tr -d '\n'
+```
+
+Set the generated value to:
+
+```bash
+APP_SECURITY_CONTEXT_SIGNING_KEY=<generated-base64-key>
+APP_SECURITY_CONTEXT_MAX_AGE_MILLIS=300000
+```
+
+Both Gateway and consumer services (for example Chat) must use the same key.
+
 ## Troubleshooting
 
 ### Services not starting
@@ -222,13 +250,18 @@ docker exec project03-redis redis-cli ping
 
 # Kafka
 docker exec project03-kafka kafka-topics --bootstrap-server localhost:9092 --list
+
+# Elasticsearch
+curl -fsS http://localhost:23173/_cluster/health
 ```
 
 ## Data Persistence
 
 Data is persisted in Docker volumes:
 - `postgres-data` - PostgreSQL data
+- `mariadb-data` - MariaDB data
 - `redis-data` - Redis data
+- `elasticsearch-data` - Elasticsearch index data
 - `kafka-data` - Kafka logs and data
 - `zookeeper-data` - Zookeeper data
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # ─── PostgreSQL ───────────────────────────────────────────
   postgres:
@@ -57,6 +55,30 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - project03-network
+
+  # ─── Elasticsearch ────────────────────────────
+  elasticsearch:
+    build:
+      context: ./elasticsearch
+    image: project03-elasticsearch:8.18.8-nori
+    container_name: project03-elasticsearch
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.enrollment.enabled: "false"
+      xpack.license.self_generated.type: basic
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+    ports:
+      - "${ELASTICSEARCH_PORT:-23173}:9200"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health | grep -E '\"status\":\"(green|yellow)\"' > /dev/null"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
     networks:
       - project03-network
 
@@ -141,6 +163,7 @@ volumes:
   postgres-data:
   mariadb-data:
   redis-data:
+  elasticsearch-data:
   zookeeper-data:
   kafka-data:
 

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch analysis-nori

--- a/docker/init-scripts/postgres/01-init.sql
+++ b/docker/init-scripts/postgres/01-init.sql
@@ -11,6 +11,7 @@ CREATE DATABASE stock_db;
 CREATE DATABASE funding_db;
 CREATE DATABASE sales_db;
 CREATE DATABASE hotdeal_db;
+CREATE DATABASE search_db;
 CREATE DATABASE notification_db;
 CREATE DATABASE chat_db;
 
@@ -44,6 +45,10 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- hotdeal_db 초기 설정
 \c hotdeal_db;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- search_db 초기 설정
+\c search_db;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- notification_db 초기 설정

--- a/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
+++ b/servers/services/product/src/main/java/com/example/product/event/ItemCreatedEvent.java
@@ -13,15 +13,17 @@ public class ItemCreatedEvent extends DomainEvent {
     private final Long itemId;
     private final String title;
     private final String itemType;
+    private final Long price;
     private final Long sellerId;
     private final List<StockItemInfo> stockItems;
 
-    public ItemCreatedEvent(Long itemId, String title, String itemType, Long sellerId,
+    public ItemCreatedEvent(Long itemId, String title, String itemType, Long price, Long sellerId,
                             List<StockItemInfo> stockItems) {
         super("item-events");
         this.itemId = itemId;
         this.title = title;
         this.itemType = itemType;
+        this.price = price;
         this.sellerId = sellerId;
         this.stockItems = stockItems != null ? stockItems : List.of();
     }
@@ -37,6 +39,7 @@ public class ItemCreatedEvent extends DomainEvent {
         payload.put("itemId", itemId);
         payload.put("title", title);
         payload.put("itemType", itemType);
+        payload.put("price", price);
         payload.put("sellerId", sellerId);
         payload.put("stockItems", stockItems.stream()
                 .map(si -> Map.of(

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -60,7 +60,7 @@ public class GoodsCommandService {
                 .toList();
 
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), item.getPrice(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds);

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -65,7 +65,7 @@ public class PerformanceCommandService {
                 .toList();
 
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), item.getPrice(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers);

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -55,7 +55,7 @@ public class ProductCommandService {
                 .toList();
 
         eventPublisher.publish(
-                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), sellerId, stockItems),
+                new ItemCreatedEvent(item.getId(), item.getTitle(), item.getItemType().name(), item.getPrice(), sellerId, stockItems),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
         return GoodsDetailResponse.of(item, options, shippingInfo, List.of());

--- a/servers/services/search/src/test/java/com/example/search/consumer/ItemEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/ItemEventConsumerTest.java
@@ -52,6 +52,7 @@ class ItemEventConsumerTest {
                   "itemId": 101,
                   "title": "아이폰 케이스",
                   "itemType": "GOODS",
+                  "price": 25000,
                   "stockItems": [
                     {"type": "GOODS", "referenceId": 1, "totalQuantity": 3},
                     {"type": "GOODS", "referenceId": 2, "totalQuantity": 7}
@@ -61,7 +62,7 @@ class ItemEventConsumerTest {
 
         itemEventConsumer.consume(message);
 
-        verify(searchIndexingService).indexItem(101L, "아이폰 케이스", "GOODS", "GOODS", null, null, 10);
+        verify(searchIndexingService).indexItem(101L, "아이폰 케이스", "GOODS", "GOODS", 25000L, null, 10);
         verify(searchResultCacheService).evictAll();
     }
 


### PR DESCRIPTION
## 개요

검색/채팅 연동 검증에 필요한 인프라 보강(Elasticsearch Nori)과, 상품 생성 이벤트의 가격 필드 전달을 반영했습니다.

### 관련 이슈
<!-- "Closes #이슈번호" 형식으로 작성하면 PR 머지 시 이슈가 자동 닫히고 Jira도 Done 전환됩니다 -->
- Related #506

### 작업 / 변경 내용
<!-- 무엇을 왜 변경했는지 간단히 -->
- Docker 인프라에 Elasticsearch(analysis-nori 포함) 이미지/서비스 추가
  - `docker/elasticsearch/Dockerfile` 추가
  - `docker/docker-compose.yml`에 `elasticsearch` 서비스 및 볼륨 추가
  - 기본 외부 포트 `23173` 매핑
- PostgreSQL 초기화 스크립트에 `search_db` 생성/확장 적용
- Product 도메인 `ItemCreatedEvent`에 `price` 필드 추가 및 발행부 반영
  - `GoodsCommandService`, `PerformanceCommandService`, `ProductCommandService`
- Search 소비 테스트를 이벤트 스키마(`price`) 기준으로 업데이트

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
<!-- 리뷰 시 중점적으로 봐주면 좋을 부분, 논의 사항 등 (선택) -->
- 실행한 검증
  - `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:product:test --rerun-tasks`
  - `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:search:test --rerun-tasks`
