### PR TITLE
feat: [MZC-629] 업로드 확정 무결성/멱등 + media-api/media-worker 분리

### DIFF
--- a/servers/services/media-api/build.gradle.kts
+++ b/servers/services/media-api/build.gradle.kts
@@ -1,0 +1,49 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+    implementation(project(":libs:core:pagination"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // Security
+    implementation(project(":libs:security:security-starter"))
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // AWS SDK
+    implementation(platform("software.amazon.awssdk:bom:2.31.77"))
+    implementation("software.amazon.awssdk:s3")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database runtime
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/media-api/docs/cleanup-policy.md
+++ b/servers/services/media-api/docs/cleanup-policy.md
@@ -1,0 +1,40 @@
+# Media Cleanup Policy
+
+## 목적
+- 미확정(`PENDING_UPLOAD`) 상태로 남은 업로드를 주기적으로 정리해 스토리지 누수를 방지한다.
+- DB 상태와 S3 객체 사이의 불일치 시나리오를 운영 중에 안전하게 흡수한다.
+
+## TTL 기준
+- 기준 컬럼: `media_files.upload_token_expires_at`
+- 만료 조건: `status = PENDING_UPLOAD` 이고 `upload_token_expires_at < now`
+- 기본 배치 크기: `100` (`media.cleanup.batch-size`)
+
+## 처리 절차
+1. 만료 대상을 배치 단위로 조회한다.
+2. DB 상태를 `EXPIRED`로 전이한다.
+3. `media.cleanup.delete-object-enabled=true` 인 경우에만 S3 `DeleteObject`를 시도한다.
+4. 결과를 로그로 남긴다.
+   - `expired`: 만료 전이 건수
+   - `deletedObjects`: S3 삭제 성공 건수
+   - `deleteFailed`: S3 삭제 실패 건수
+
+## DB/S3 불일치 대응
+- DB에만 있고 S3 객체가 없는 경우:
+  - 상태 전이만 수행하고, 삭제 호출 실패는 경고 로그로 기록한다.
+- S3에만 있고 DB가 없는 경우:
+  - 애플리케이션 스케줄러가 찾을 수 없으므로 S3 Lifecycle 정책으로 정리한다.
+
+## S3 Lifecycle vs 스케줄러 역할 분리
+- 스케줄러:
+  - DB 상태 정합성 유지 (`PENDING_UPLOAD -> EXPIRED`)
+  - 필요한 경우 선택적으로 객체 삭제 시도
+- S3 Lifecycle:
+  - DB와 무관한 orphan/raw 객체 정리의 최종 안전망
+  - 운영 환경에서 대량 정리에 유리
+
+## 권장 운영값
+- 개발/스테이징:
+  - `media.cleanup.delete-object-enabled=true` (빠른 검증 목적)
+- 운영:
+  - 초기엔 `false`로 두고 Lifecycle 정책을 주 정리 수단으로 운영
+  - 필요 시 점진적으로 `true` 전환

--- a/servers/services/media-api/src/main/java/com/example/media/MediaApplication.java
+++ b/servers/services/media-api/src/main/java/com/example/media/MediaApplication.java
@@ -1,0 +1,20 @@
+package com.example.media;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableAsync
+@EnableScheduling
+@SpringBootApplication(scanBasePackages = {"com.example.media", "com.example.api.handler"})
+@EntityScan(basePackages = "com.example.media")
+@EnableJpaRepositories(basePackages = "com.example.media")
+public class MediaApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MediaApplication.class, args);
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/config/MediaCleanupProperties.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/MediaCleanupProperties.java
@@ -1,0 +1,14 @@
+package com.example.media.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "media.cleanup")
+public class MediaCleanupProperties {
+
+    private int batchSize = 100;
+    private boolean deleteObjectEnabled = false;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/config/MediaS3Properties.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/MediaS3Properties.java
@@ -1,0 +1,18 @@
+package com.example.media.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "media.s3")
+public class MediaS3Properties {
+
+    private String region = "ap-northeast-2";
+    private String bucket = "team2-donmoa-media-raw";
+    private String keyPrefix = "team2-donmoa-media";
+    private long presignedPutTtlSeconds = 300;
+    private long maxFileSizeBytes = 52_428_800;
+    private String cloudfrontDomain;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/config/S3ClientConfig.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/S3ClientConfig.java
@@ -1,0 +1,30 @@
+package com.example.media.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@EnableConfigurationProperties({MediaS3Properties.class, MediaCleanupProperties.class})
+public class S3ClientConfig {
+
+    @Bean
+    public S3Client s3Client(MediaS3Properties properties) {
+        return S3Client.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(MediaS3Properties properties) {
+        return S3Presigner.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/controller/api/command/MediaCommandApi.java
+++ b/servers/services/media-api/src/main/java/com/example/media/controller/api/command/MediaCommandApi.java
@@ -1,0 +1,31 @@
+package com.example.media.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.media.dto.command.request.UploadConfirmRequest;
+import com.example.media.dto.command.request.UploadIntentRequest;
+import com.example.media.dto.command.response.UploadConfirmResponse;
+import com.example.media.dto.command.response.UploadIntentResponse;
+import com.example.security.gateway.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Media Command", description = "미디어 업로드 의도 생성 및 업로드 확정 API")
+public interface MediaCommandApi {
+
+    @Operation(summary = "업로드 의도 생성(Presigned PUT + uploadToken 발급)")
+    @PostMapping("/upload-intents")
+    ApiResponse<UploadIntentResponse> createUploadIntent(
+            @Valid @RequestBody UploadIntentRequest request,
+            @CurrentUserId(required = false) Long userId
+    );
+
+    @Operation(summary = "업로드 확정(HeadObject 검증 + 멱등 처리)")
+    @PostMapping("/confirm")
+    ApiResponse<UploadConfirmResponse> confirmUpload(
+            @Valid @RequestBody UploadConfirmRequest request,
+            @CurrentUserId(required = false) Long userId
+    );
+}

--- a/servers/services/media-api/src/main/java/com/example/media/controller/command/MediaCommandController.java
+++ b/servers/services/media-api/src/main/java/com/example/media/controller/command/MediaCommandController.java
@@ -1,0 +1,30 @@
+package com.example.media.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.media.controller.api.command.MediaCommandApi;
+import com.example.media.dto.command.request.UploadConfirmRequest;
+import com.example.media.dto.command.request.UploadIntentRequest;
+import com.example.media.dto.command.response.UploadConfirmResponse;
+import com.example.media.dto.command.response.UploadIntentResponse;
+import com.example.media.service.command.MediaCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/media")
+@RequiredArgsConstructor
+public class MediaCommandController implements MediaCommandApi {
+
+    private final MediaCommandService mediaCommandService;
+
+    @Override
+    public ApiResponse<UploadIntentResponse> createUploadIntent(UploadIntentRequest request, Long userId) {
+        return ApiResponse.success(mediaCommandService.createUploadIntent(request, userId));
+    }
+
+    @Override
+    public ApiResponse<UploadConfirmResponse> confirmUpload(UploadConfirmRequest request, Long userId) {
+        return ApiResponse.success(mediaCommandService.confirmUpload(request, userId));
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/dto/command/request/UploadConfirmRequest.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/command/request/UploadConfirmRequest.java
@@ -1,0 +1,27 @@
+package com.example.media.dto.command.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UploadConfirmRequest {
+
+    @NotNull
+    private Long mediaId;
+
+    @NotBlank
+    private String uploadToken;
+
+    private String ownerType;
+
+    private Long ownerId;
+
+    private String usageType;
+
+    @Min(0)
+    private Integer sortOrder;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/dto/command/request/UploadIntentRequest.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/command/request/UploadIntentRequest.java
@@ -1,0 +1,29 @@
+package com.example.media.dto.command.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UploadIntentRequest {
+
+    @NotBlank
+    private String fileName;
+
+    @NotBlank
+    private String contentType;
+
+    @Min(1)
+    private long fileSize;
+
+    private String ownerType;
+
+    private Long ownerId;
+
+    private String usageType;
+
+    @Min(0)
+    private Integer sortOrder;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadConfirmResponse.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadConfirmResponse.java
@@ -1,0 +1,22 @@
+package com.example.media.dto.command.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UploadConfirmResponse {
+
+    private Long mediaId;
+    private String status;
+    private String objectKey;
+    private Long fileSize;
+    private String contentType;
+    private String etag;
+    private String mediaUrl;
+    private Long linkId;
+    private String ownerType;
+    private Long ownerId;
+    private String usageType;
+    private Integer sortOrder;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadIntentResponse.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadIntentResponse.java
@@ -1,0 +1,21 @@
+package com.example.media.dto.command.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class UploadIntentResponse {
+
+    private Long mediaId;
+    private String presignedUrl;
+    private String objectKey;
+    private String uploadToken;
+    private Instant expiresAt;
+    private String ownerType;
+    private Long ownerId;
+    private String usageType;
+    private Integer sortOrder;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaFile.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaFile.java
@@ -1,0 +1,167 @@
+package com.example.media.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "media_files", indexes = {
+        @Index(name = "idx_media_files_status", columnList = "status"),
+        @Index(name = "idx_media_files_uploader_id", columnList = "uploader_id"),
+        @Index(name = "idx_media_files_token_expires", columnList = "upload_token_expires_at")
+})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaFile extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "uploader_id")
+    private Long uploaderId;
+
+    @Column(name = "original_file_name", nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(name = "object_key", nullable = false, unique = true, length = 500)
+    private String objectKey;
+
+    @Column(name = "bucket_name", nullable = false, length = 120)
+    private String bucketName;
+
+    @Column(name = "requested_content_type", nullable = false, length = 100)
+    private String requestedContentType;
+
+    @Column(name = "requested_file_size", nullable = false)
+    private Long requestedFileSize;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "requested_owner_type", length = 40)
+    private MediaOwnerType requestedOwnerType;
+
+    @Column(name = "requested_owner_id")
+    private Long requestedOwnerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "requested_usage_type", length = 40)
+    private MediaUsageType requestedUsageType;
+
+    @Column(name = "requested_sort_order")
+    private Integer requestedSortOrder;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "etag", length = 128)
+    private String etag;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private MediaStatus status;
+
+    @Column(name = "upload_token", nullable = false, length = 100)
+    private String uploadToken;
+
+    @Column(name = "upload_token_expires_at", nullable = false)
+    private LocalDateTime uploadTokenExpiresAt;
+
+    @Column(name = "token_used_at")
+    private LocalDateTime tokenUsedAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "last_error_reason", length = 500)
+    private String lastErrorReason;
+
+    public static MediaFile createPending(Long uploaderId,
+                                          String originalFileName,
+                                          String objectKey,
+                                          String bucketName,
+                                          String requestedContentType,
+                                          Long requestedFileSize,
+                                          MediaOwnerType requestedOwnerType,
+                                          Long requestedOwnerId,
+                                          MediaUsageType requestedUsageType,
+                                          Integer requestedSortOrder,
+                                          String uploadToken,
+                                          LocalDateTime uploadTokenExpiresAt) {
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.uploaderId = uploaderId;
+        mediaFile.originalFileName = originalFileName;
+        mediaFile.objectKey = objectKey;
+        mediaFile.bucketName = bucketName;
+        mediaFile.requestedContentType = requestedContentType;
+        mediaFile.requestedFileSize = requestedFileSize;
+        mediaFile.requestedOwnerType = requestedOwnerType;
+        mediaFile.requestedOwnerId = requestedOwnerId;
+        mediaFile.requestedUsageType = requestedUsageType;
+        mediaFile.requestedSortOrder = requestedSortOrder;
+        mediaFile.status = MediaStatus.PENDING_UPLOAD;
+        mediaFile.uploadToken = uploadToken;
+        mediaFile.uploadTokenExpiresAt = uploadTokenExpiresAt;
+        return mediaFile;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        if (uploaderId == null || userId == null) {
+            return false;
+        }
+        return uploaderId.equals(userId);
+    }
+
+    public boolean hasSameUploadToken(String token) {
+        return uploadToken != null && uploadToken.equals(token);
+    }
+
+    public boolean isUploadTokenExpired(LocalDateTime now) {
+        return uploadTokenExpiresAt == null || uploadTokenExpiresAt.isBefore(now);
+    }
+
+    public boolean isAlreadyConfirmed() {
+        return status == MediaStatus.CONFIRMED || status == MediaStatus.READY;
+    }
+
+    public void confirm(long actualFileSize, String actualContentType, String actualEtag, LocalDateTime confirmedAt) {
+        this.fileSize = actualFileSize;
+        this.contentType = actualContentType;
+        this.etag = actualEtag;
+        this.status = MediaStatus.CONFIRMED;
+        this.confirmedAt = confirmedAt;
+        this.tokenUsedAt = confirmedAt;
+        this.lastErrorReason = null;
+    }
+
+    public void markFailed(String reason) {
+        this.status = MediaStatus.FAILED;
+        this.lastErrorReason = reason;
+    }
+
+    public void markExpired() {
+        this.status = MediaStatus.EXPIRED;
+    }
+
+    public void markReady() {
+        this.status = MediaStatus.READY;
+    }
+
+    public void markDeleted() {
+        this.status = MediaStatus.DELETED;
+        softDelete();
+    }
+
+    public boolean hasRequestedBinding() {
+        return requestedOwnerType != null && requestedOwnerId != null;
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaLink.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaLink.java
@@ -1,0 +1,70 @@
+package com.example.media.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "media_links", indexes = {
+        @Index(name = "idx_media_links_media_id", columnList = "media_id"),
+        @Index(name = "idx_media_links_owner_usage_sort", columnList = "owner_type,owner_id,usage_type,sort_order"),
+        @Index(name = "idx_media_links_owner_type_id", columnList = "owner_type,owner_id")
+})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaLink extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "owner_type", nullable = false, length = 40)
+    private MediaOwnerType ownerType;
+
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "usage_type", nullable = false, length = 40)
+    private MediaUsageType usageType;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    public static MediaLink create(Long mediaId,
+                                   MediaOwnerType ownerType,
+                                   Long ownerId,
+                                   MediaUsageType usageType,
+                                   int sortOrder) {
+        MediaLink link = new MediaLink();
+        link.mediaId = mediaId;
+        link.ownerType = ownerType;
+        link.ownerId = ownerId;
+        link.usageType = usageType;
+        link.sortOrder = sortOrder;
+        return link;
+    }
+
+    public boolean matchesMedia(Long targetMediaId) {
+        return mediaId != null && mediaId.equals(targetMediaId);
+    }
+
+    public void updateSortOrder(int newSortOrder) {
+        this.sortOrder = newSortOrder;
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaOwnerType.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaOwnerType.java
@@ -1,0 +1,24 @@
+package com.example.media.entity;
+
+import java.util.Locale;
+
+public enum MediaOwnerType {
+    USER_PROFILE,
+    ITEM,
+    POST,
+    CHAT_MESSAGE,
+    FUNDING,
+    HOT_DEAL,
+    COMMENT;
+
+    public static MediaOwnerType fromNullable(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim()
+                .replace('-', '_')
+                .replace(' ', '_')
+                .toUpperCase(Locale.ROOT);
+        return MediaOwnerType.valueOf(normalized);
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaStatus.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaStatus.java
@@ -1,0 +1,10 @@
+package com.example.media.entity;
+
+public enum MediaStatus {
+    PENDING_UPLOAD,
+    CONFIRMED,
+    READY,
+    FAILED,
+    EXPIRED,
+    DELETED
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaUsageType.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaUsageType.java
@@ -1,0 +1,23 @@
+package com.example.media.entity;
+
+import java.util.Locale;
+
+public enum MediaUsageType {
+    PROFILE,
+    THUMBNAIL,
+    GALLERY,
+    CONTENT,
+    ATTACHMENT,
+    VIDEO;
+
+    public static MediaUsageType fromNullable(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim()
+                .replace('-', '_')
+                .replace(' ', '_')
+                .toUpperCase(Locale.ROOT);
+        return MediaUsageType.valueOf(normalized);
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/event/MediaConfirmedEvent.java
+++ b/servers/services/media-api/src/main/java/com/example/media/event/MediaConfirmedEvent.java
@@ -1,0 +1,79 @@
+package com.example.media.event;
+
+import com.example.event.DomainEvent;
+import com.example.media.entity.MediaOwnerType;
+import com.example.media.entity.MediaUsageType;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class MediaConfirmedEvent extends DomainEvent {
+
+    private static final int SCHEMA_VERSION = 1;
+
+    private final Long mediaId;
+    private final Long uploaderId;
+    private final String bucketName;
+    private final String objectKey;
+    private final String contentType;
+    private final Long fileSize;
+    private final String etag;
+    private final MediaOwnerType ownerType;
+    private final Long ownerId;
+    private final MediaUsageType usageType;
+    private final Integer sortOrder;
+    private final String mediaUrl;
+
+    public MediaConfirmedEvent(Long mediaId,
+                               Long uploaderId,
+                               String bucketName,
+                               String objectKey,
+                               String contentType,
+                               Long fileSize,
+                               String etag,
+                               MediaOwnerType ownerType,
+                               Long ownerId,
+                               MediaUsageType usageType,
+                               Integer sortOrder,
+                               String mediaUrl) {
+        super("media.confirmed");
+        this.mediaId = mediaId;
+        this.uploaderId = uploaderId;
+        this.bucketName = bucketName;
+        this.objectKey = objectKey;
+        this.contentType = contentType;
+        this.fileSize = fileSize;
+        this.etag = etag;
+        this.ownerType = ownerType;
+        this.ownerId = ownerId;
+        this.usageType = usageType;
+        this.sortOrder = sortOrder;
+        this.mediaUrl = mediaUrl;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "MEDIA_CONFIRMED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("schemaVersion", SCHEMA_VERSION);
+        payload.put("mediaId", mediaId);
+        payload.put("uploaderId", uploaderId);
+        payload.put("bucketName", bucketName);
+        payload.put("objectKey", objectKey);
+        payload.put("contentType", contentType);
+        payload.put("fileSize", fileSize);
+        payload.put("etag", etag);
+        payload.put("ownerType", ownerType != null ? ownerType.name() : null);
+        payload.put("ownerId", ownerId);
+        payload.put("usageType", usageType != null ? usageType.name() : null);
+        payload.put("sortOrder", sortOrder);
+        payload.put("mediaUrl", mediaUrl);
+        return payload;
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/exception/MediaErrorCode.java
+++ b/servers/services/media-api/src/main/java/com/example/media/exception/MediaErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.media.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaErrorCode implements DomainErrorCode {
+
+    MEDIA_NOT_FOUND("MEDIA-001", "미디어 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_MEDIA_REQUEST("MEDIA-002", "미디어 요청 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    FILE_SIZE_EXCEEDED("MEDIA-003", "허용 가능한 파일 크기를 초과했습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_UPLOAD_TOKEN("MEDIA-004", "업로드 확정 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    EXPIRED_UPLOAD_TOKEN("MEDIA-005", "업로드 확정 토큰이 만료되었습니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN_MEDIA_ACCESS("MEDIA-006", "미디어 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    MEDIA_S3_PRESIGN_FAILED("MEDIA-007", "S3 업로드 URL 발급에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    MEDIA_S3_OBJECT_NOT_FOUND("MEDIA-008", "S3 업로드 객체를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEDIA_S3_HEAD_FAILED("MEDIA-009", "S3 객체 검증 처리에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    INVALID_MEDIA_BINDING("MEDIA-010", "미디어 소유자/용도 바인딩 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    MEDIA_S3_METADATA_MISMATCH("MEDIA-011", "업로드 객체 메타데이터가 요청값과 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/repository/MediaFileRepository.java
+++ b/servers/services/media-api/src/main/java/com/example/media/repository/MediaFileRepository.java
@@ -1,0 +1,14 @@
+package com.example.media.repository;
+
+import com.example.media.entity.MediaFile;
+import com.example.media.entity.MediaStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
+
+    List<MediaFile> findByStatusAndUploadTokenExpiresAtBefore(MediaStatus status, LocalDateTime baseTime, Pageable pageable);
+}

--- a/servers/services/media-api/src/main/java/com/example/media/repository/MediaLinkRepository.java
+++ b/servers/services/media-api/src/main/java/com/example/media/repository/MediaLinkRepository.java
@@ -1,0 +1,25 @@
+package com.example.media.repository;
+
+import com.example.media.entity.MediaLink;
+import com.example.media.entity.MediaOwnerType;
+import com.example.media.entity.MediaUsageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MediaLinkRepository extends JpaRepository<MediaLink, Long> {
+
+    Optional<MediaLink> findByMediaIdAndOwnerTypeAndOwnerIdAndUsageType(
+            Long mediaId,
+            MediaOwnerType ownerType,
+            Long ownerId,
+            MediaUsageType usageType
+    );
+
+    List<MediaLink> findByOwnerTypeAndOwnerIdAndUsageTypeOrderBySortOrderAscCreatedAtAsc(
+            MediaOwnerType ownerType,
+            Long ownerId,
+            MediaUsageType usageType
+    );
+}

--- a/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCleanupScheduler.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.example.media.service.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaCleanupScheduler {
+
+    private final MediaCommandService mediaCommandService;
+
+    @Scheduled(cron = "${media.cleanup.cron:0 */10 * * * *}")
+    public void expirePendingUploads() {
+        MediaCommandService.ExpireResult result = mediaCommandService.expirePendingUploads();
+        if (result.expiredCount() > 0 || result.deleteFailedCount() > 0) {
+            log.info(
+                    "[MediaCleanup] expired={}, deletedObjects={}, deleteFailed={}",
+                    result.expiredCount(),
+                    result.deletedObjectCount(),
+                    result.deleteFailedCount()
+            );
+        }
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
@@ -1,0 +1,498 @@
+package com.example.media.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.media.config.MediaCleanupProperties;
+import com.example.media.config.MediaS3Properties;
+import com.example.media.dto.command.request.UploadConfirmRequest;
+import com.example.media.dto.command.request.UploadIntentRequest;
+import com.example.media.dto.command.response.UploadConfirmResponse;
+import com.example.media.dto.command.response.UploadIntentResponse;
+import com.example.media.entity.MediaFile;
+import com.example.media.entity.MediaLink;
+import com.example.media.entity.MediaOwnerType;
+import com.example.media.entity.MediaStatus;
+import com.example.media.entity.MediaUsageType;
+import com.example.media.event.MediaConfirmedEvent;
+import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaFileRepository;
+import com.example.media.repository.MediaLinkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaCommandService {
+
+    private final MediaFileRepository mediaFileRepository;
+    private final MediaLinkRepository mediaLinkRepository;
+    private final MediaS3Properties mediaS3Properties;
+    private final MediaCleanupProperties mediaCleanupProperties;
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public UploadIntentResponse createUploadIntent(UploadIntentRequest request, Long userId) {
+        if (request.getFileSize() > mediaS3Properties.getMaxFileSizeBytes()) {
+            throw new BusinessException(MediaErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        MediaBinding requestedBinding = resolveBinding(
+                request.getOwnerType(),
+                request.getOwnerId(),
+                request.getUsageType(),
+                request.getSortOrder()
+        );
+
+        String objectKey = buildObjectKey(request.getFileName());
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusSeconds(mediaS3Properties.getPresignedPutTtlSeconds());
+        String uploadToken = UUID.randomUUID().toString();
+
+        MediaFile mediaFile = MediaFile.createPending(
+                userId,
+                request.getFileName(),
+                objectKey,
+                mediaS3Properties.getBucket(),
+                request.getContentType(),
+                request.getFileSize(),
+                requestedBinding != null ? requestedBinding.ownerType() : null,
+                requestedBinding != null ? requestedBinding.ownerId() : null,
+                requestedBinding != null ? requestedBinding.usageType() : null,
+                requestedBinding != null ? requestedBinding.sortOrder() : null,
+                uploadToken,
+                expiresAt
+        );
+        MediaFile saved = mediaFileRepository.save(mediaFile);
+
+        String presignedUrl = createPresignedPutUrl(objectKey, request.getContentType(), request.getFileSize());
+
+        return UploadIntentResponse.builder()
+                .mediaId(saved.getId())
+                .objectKey(objectKey)
+                .presignedUrl(presignedUrl)
+                .uploadToken(uploadToken)
+                .expiresAt(expiresAt.toInstant(ZoneOffset.UTC))
+                .ownerType(requestedBinding != null ? requestedBinding.ownerType().name() : null)
+                .ownerId(requestedBinding != null ? requestedBinding.ownerId() : null)
+                .usageType(requestedBinding != null ? requestedBinding.usageType().name() : null)
+                .sortOrder(requestedBinding != null ? requestedBinding.sortOrder() : null)
+                .build();
+    }
+
+    @Transactional
+    public UploadConfirmResponse confirmUpload(UploadConfirmRequest request, Long userId) {
+        MediaFile mediaFile = mediaFileRepository.findById(request.getMediaId())
+                .orElseThrow(() -> new BusinessException(MediaErrorCode.MEDIA_NOT_FOUND));
+
+        validateUploaderAccess(userId, mediaFile);
+
+        MediaBinding requestBinding = resolveBinding(
+                request.getOwnerType(),
+                request.getOwnerId(),
+                request.getUsageType(),
+                request.getSortOrder()
+        );
+        MediaBinding effectiveBinding = requestBinding != null ? requestBinding : resolveRequestedBinding(mediaFile);
+
+        if (mediaFile.isAlreadyConfirmed()) {
+            MediaLink existingOrNewLink = upsertMediaLink(mediaFile, effectiveBinding);
+            log.info("[MediaConfirm] idempotent confirm hit. mediaId={}, status={}", mediaFile.getId(), mediaFile.getStatus());
+            return toConfirmResponse(mediaFile, existingOrNewLink);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (!mediaFile.hasSameUploadToken(request.getUploadToken())) {
+            throw new BusinessException(MediaErrorCode.INVALID_UPLOAD_TOKEN);
+        }
+        if (mediaFile.isUploadTokenExpired(now)) {
+            mediaFile.markExpired();
+            throw new BusinessException(MediaErrorCode.EXPIRED_UPLOAD_TOKEN);
+        }
+
+        HeadObjectResponse headObjectResponse = readS3HeadObject(mediaFile);
+        validateS3Metadata(mediaFile, headObjectResponse);
+        mediaFile.confirm(
+                headObjectResponse.contentLength(),
+                normalizeContentType(headObjectResponse.contentType(), mediaFile.getRequestedContentType()),
+                normalizeEtag(headObjectResponse.eTag()),
+                now
+        );
+
+        MediaFile saved = mediaFileRepository.save(mediaFile);
+        MediaLink mediaLink = upsertMediaLink(saved, effectiveBinding);
+        publishConfirmedEvent(saved, mediaLink);
+        log.info(
+                "[MediaConfirm] confirm success. mediaId={}, objectKey={}, fileSize={}, ownerType={}, ownerId={}, usageType={}",
+                saved.getId(),
+                saved.getObjectKey(),
+                saved.getFileSize(),
+                mediaLink != null ? mediaLink.getOwnerType() : null,
+                mediaLink != null ? mediaLink.getOwnerId() : null,
+                mediaLink != null ? mediaLink.getUsageType() : null
+        );
+        return toConfirmResponse(saved, mediaLink);
+    }
+
+    @Transactional
+    public ExpireResult expirePendingUploads() {
+        LocalDateTime now = LocalDateTime.now();
+        int batchSize = Math.max(1, mediaCleanupProperties.getBatchSize());
+
+        List<MediaFile> targets = mediaFileRepository.findByStatusAndUploadTokenExpiresAtBefore(
+                MediaStatus.PENDING_UPLOAD,
+                now,
+                PageRequest.of(0, batchSize)
+        );
+        int deletedObjectCount = 0;
+        int deleteFailedCount = 0;
+
+        for (MediaFile target : targets) {
+            target.markExpired();
+            if (mediaCleanupProperties.isDeleteObjectEnabled()) {
+                if (deleteS3ObjectQuietly(target)) {
+                    deletedObjectCount++;
+                } else {
+                    deleteFailedCount++;
+                }
+            }
+        }
+        return new ExpireResult(targets.size(), deletedObjectCount, deleteFailedCount);
+    }
+
+    private void validateUploaderAccess(Long userId, MediaFile mediaFile) {
+        if (userId != null && mediaFile.getUploaderId() != null && !mediaFile.isOwnedBy(userId)) {
+            throw new BusinessException(MediaErrorCode.FORBIDDEN_MEDIA_ACCESS);
+        }
+    }
+
+    private MediaBinding resolveRequestedBinding(MediaFile mediaFile) {
+        if (!mediaFile.hasRequestedBinding()) {
+            return null;
+        }
+        return new MediaBinding(
+                mediaFile.getRequestedOwnerType(),
+                mediaFile.getRequestedOwnerId(),
+                mediaFile.getRequestedUsageType() != null ? mediaFile.getRequestedUsageType() : MediaUsageType.ATTACHMENT,
+                mediaFile.getRequestedSortOrder()
+        );
+    }
+
+    private MediaBinding resolveBinding(String ownerTypeValue, Long ownerId, String usageTypeValue, Integer sortOrder) {
+        boolean hasOwnerType = StringUtils.hasText(ownerTypeValue);
+        boolean hasOwnerId = ownerId != null;
+        boolean hasUsageType = StringUtils.hasText(usageTypeValue);
+        boolean hasSortOrder = sortOrder != null;
+
+        if (!hasOwnerType && !hasOwnerId && !hasUsageType && !hasSortOrder) {
+            return null;
+        }
+        if (!hasOwnerType || !hasOwnerId) {
+            throw new BusinessException(MediaErrorCode.INVALID_MEDIA_BINDING);
+        }
+        if (sortOrder != null && sortOrder < 0) {
+            throw new BusinessException(MediaErrorCode.INVALID_MEDIA_BINDING);
+        }
+
+        try {
+            MediaOwnerType ownerType = MediaOwnerType.fromNullable(ownerTypeValue);
+            MediaUsageType usageType = MediaUsageType.fromNullable(usageTypeValue);
+            if (ownerType == null) {
+                throw new BusinessException(MediaErrorCode.INVALID_MEDIA_BINDING);
+            }
+            return new MediaBinding(
+                    ownerType,
+                    ownerId,
+                    usageType != null ? usageType : MediaUsageType.ATTACHMENT,
+                    sortOrder
+            );
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(MediaErrorCode.INVALID_MEDIA_BINDING, e);
+        }
+    }
+
+    private MediaLink upsertMediaLink(MediaFile mediaFile, MediaBinding binding) {
+        if (binding == null) {
+            return null;
+        }
+        List<MediaLink> links = mediaLinkRepository.findByOwnerTypeAndOwnerIdAndUsageTypeOrderBySortOrderAscCreatedAtAsc(
+                binding.ownerType(),
+                binding.ownerId(),
+                binding.usageType()
+        );
+
+        MediaLink target = links.stream()
+                .filter(link -> link.matchesMedia(mediaFile.getId()))
+                .findFirst()
+                .orElse(null);
+
+        if (target == null) {
+            target = MediaLink.create(
+                    mediaFile.getId(),
+                    binding.ownerType(),
+                    binding.ownerId(),
+                    binding.usageType(),
+                    links.size()
+            );
+            links.add(target);
+        }
+
+        if (binding.sortOrder() != null) {
+            links.remove(target);
+            int targetIndex = Math.max(0, Math.min(binding.sortOrder(), links.size()));
+            links.add(targetIndex, target);
+        }
+
+        for (int i = 0; i < links.size(); i++) {
+            links.get(i).updateSortOrder(i);
+        }
+        mediaLinkRepository.saveAll(links);
+        return target;
+    }
+
+    private void publishConfirmedEvent(MediaFile mediaFile, MediaLink mediaLink) {
+        eventPublisher.publish(
+                new MediaConfirmedEvent(
+                        mediaFile.getId(),
+                        mediaFile.getUploaderId(),
+                        mediaFile.getBucketName(),
+                        mediaFile.getObjectKey(),
+                        mediaFile.getContentType(),
+                        mediaFile.getFileSize(),
+                        mediaFile.getEtag(),
+                        mediaLink != null ? mediaLink.getOwnerType() : null,
+                        mediaLink != null ? mediaLink.getOwnerId() : null,
+                        mediaLink != null ? mediaLink.getUsageType() : null,
+                        mediaLink != null ? mediaLink.getSortOrder() : null,
+                        buildMediaUrl(mediaFile.getObjectKey())
+                ),
+                EventMetadata.of("MediaFile", String.valueOf(mediaFile.getId()))
+        );
+    }
+
+    private HeadObjectResponse readS3HeadObject(MediaFile mediaFile) {
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(mediaFile.getBucketName())
+                    .key(mediaFile.getObjectKey())
+                    .build();
+            return s3Client.headObject(headObjectRequest);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                mediaFile.markFailed("S3 object not found");
+                throw new BusinessException(MediaErrorCode.MEDIA_S3_OBJECT_NOT_FOUND);
+            }
+            mediaFile.markFailed("S3 headObject failed: " + e.getMessage());
+            throw new BusinessException(MediaErrorCode.MEDIA_S3_HEAD_FAILED, e);
+        } catch (SdkException e) {
+            mediaFile.markFailed("S3 client error: " + e.getMessage());
+            throw new BusinessException(MediaErrorCode.MEDIA_S3_HEAD_FAILED, e);
+        }
+    }
+
+    private void validateS3Metadata(MediaFile mediaFile, HeadObjectResponse headObjectResponse) {
+        Long expectedSize = mediaFile.getRequestedFileSize();
+        Long actualSize = headObjectResponse.contentLength();
+        if (expectedSize != null && actualSize != null && !expectedSize.equals(actualSize)) {
+            mediaFile.markFailed("S3 size mismatch. expected=" + expectedSize + ", actual=" + actualSize);
+            log.warn(
+                    "[MediaConfirm] metadata mismatch(size). mediaId={}, objectKey={}, expectedSize={}, actualSize={}",
+                    mediaFile.getId(),
+                    mediaFile.getObjectKey(),
+                    expectedSize,
+                    actualSize
+            );
+            throw new BusinessException(MediaErrorCode.MEDIA_S3_METADATA_MISMATCH);
+        }
+
+        String expectedContentType = normalizeMediaTypeForCompare(mediaFile.getRequestedContentType());
+        String actualContentType = normalizeMediaTypeForCompare(headObjectResponse.contentType());
+        if (expectedContentType != null && actualContentType != null && !expectedContentType.equals(actualContentType)) {
+            mediaFile.markFailed("S3 contentType mismatch. expected=" + expectedContentType + ", actual=" + actualContentType);
+            log.warn(
+                    "[MediaConfirm] metadata mismatch(contentType). mediaId={}, objectKey={}, expectedType={}, actualType={}",
+                    mediaFile.getId(),
+                    mediaFile.getObjectKey(),
+                    expectedContentType,
+                    actualContentType
+            );
+            throw new BusinessException(MediaErrorCode.MEDIA_S3_METADATA_MISMATCH);
+        }
+    }
+
+    private boolean deleteS3ObjectQuietly(MediaFile mediaFile) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(mediaFile.getBucketName())
+                    .key(mediaFile.getObjectKey())
+                    .build();
+            s3Client.deleteObject(request);
+            return true;
+        } catch (Exception e) {
+            log.warn(
+                    "[MediaCleanup] S3 object delete failed. mediaId={}, objectKey={}, reason={}",
+                    mediaFile.getId(),
+                    mediaFile.getObjectKey(),
+                    e.getMessage()
+            );
+            return false;
+        }
+    }
+
+    private String createPresignedPutUrl(String objectKey, String contentType, long contentLength) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(mediaS3Properties.getBucket())
+                    .key(objectKey)
+                    .contentType(contentType)
+                    .contentLength(contentLength)
+                    .build();
+
+            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(mediaS3Properties.getPresignedPutTtlSeconds()))
+                    .putObjectRequest(putObjectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+            URL url = presignedPutObjectRequest.url();
+            return url.toString();
+        } catch (Exception e) {
+            throw new BusinessException(MediaErrorCode.MEDIA_S3_PRESIGN_FAILED, e);
+        }
+    }
+
+    private String buildObjectKey(String originalFileName) {
+        String safeFileName = sanitizeFileName(originalFileName);
+        LocalDate today = LocalDate.now();
+        String randomId = UUID.randomUUID().toString();
+        String prefix = trimSlash(mediaS3Properties.getKeyPrefix());
+
+        return String.format(
+                Locale.ROOT,
+                "%s/raw/%04d/%02d/%02d/%s_%s",
+                prefix,
+                today.getYear(),
+                today.getMonthValue(),
+                today.getDayOfMonth(),
+                randomId,
+                safeFileName
+        );
+    }
+
+    private String sanitizeFileName(String fileName) {
+        if (!StringUtils.hasText(fileName)) {
+            throw new BusinessException(MediaErrorCode.INVALID_MEDIA_REQUEST);
+        }
+
+        String normalized = fileName.trim().replaceAll("\\s+", "-");
+        normalized = normalized.replaceAll("[^a-zA-Z0-9._-]", "_");
+        if (normalized.length() > 120) {
+            return normalized.substring(normalized.length() - 120);
+        }
+        return normalized;
+    }
+
+    private String trimSlash(String value) {
+        String result = value;
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+
+    private String normalizeContentType(String actual, String fallback) {
+        return StringUtils.hasText(actual) ? actual : fallback;
+    }
+
+    private String normalizeMediaTypeForCompare(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        int semicolonIndex = normalized.indexOf(';');
+        if (semicolonIndex >= 0) {
+            normalized = normalized.substring(0, semicolonIndex).trim();
+        }
+        return normalized;
+    }
+
+    private String normalizeEtag(String etag) {
+        if (!StringUtils.hasText(etag)) {
+            return null;
+        }
+        return etag.replace("\"", "");
+    }
+
+    private UploadConfirmResponse toConfirmResponse(MediaFile mediaFile, MediaLink mediaLink) {
+        return UploadConfirmResponse.builder()
+                .mediaId(mediaFile.getId())
+                .status(mediaFile.getStatus().name())
+                .objectKey(mediaFile.getObjectKey())
+                .fileSize(mediaFile.getFileSize())
+                .contentType(mediaFile.getContentType())
+                .etag(mediaFile.getEtag())
+                .mediaUrl(buildMediaUrl(mediaFile.getObjectKey()))
+                .linkId(mediaLink != null ? mediaLink.getId() : null)
+                .ownerType(mediaLink != null ? mediaLink.getOwnerType().name() : null)
+                .ownerId(mediaLink != null ? mediaLink.getOwnerId() : null)
+                .usageType(mediaLink != null ? mediaLink.getUsageType().name() : null)
+                .sortOrder(mediaLink != null ? mediaLink.getSortOrder() : null)
+                .build();
+    }
+
+    private String buildMediaUrl(String objectKey) {
+        if (!StringUtils.hasText(mediaS3Properties.getCloudfrontDomain())) {
+            return null;
+        }
+        String domain = mediaS3Properties.getCloudfrontDomain().trim();
+        if (domain.endsWith("/")) {
+            domain = domain.substring(0, domain.length() - 1);
+        }
+        return domain + "/" + objectKey;
+    }
+
+    private record MediaBinding(
+            MediaOwnerType ownerType,
+            Long ownerId,
+            MediaUsageType usageType,
+            Integer sortOrder
+    ) {
+    }
+
+    public record ExpireResult(
+            int expiredCount,
+            int deletedObjectCount,
+            int deleteFailedCount
+    ) {
+    }
+}

--- a/servers/services/media-api/src/main/resources/application.yml
+++ b/servers/services/media-api/src/main/resources/application.yml
@@ -1,0 +1,96 @@
+server:
+  port: ${SERVER_PORT:8094}
+
+spring:
+  application:
+    name: media-api
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/media_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: media-service-group
+      auto-offset-reset: earliest
+
+media:
+  s3:
+    # 로컬 개발 시 AWS_PROFILE=mzc 권장
+    region: ${MEDIA_S3_REGION:ap-northeast-2}
+    bucket: ${MEDIA_S3_BUCKET:team2-donmoa-media-raw}
+    key-prefix: ${MEDIA_S3_KEY_PREFIX:team2-donmoa-media}
+    presigned-put-ttl-seconds: ${MEDIA_S3_PRESIGNED_PUT_TTL_SECONDS:300}
+    max-file-size-bytes: ${MEDIA_MAX_FILE_SIZE_BYTES:52428800}
+    cloudfront-domain: ${MEDIA_CLOUDFRONT_DOMAIN:}
+  cleanup:
+    cron: ${MEDIA_CLEANUP_CRON:0 */10 * * * *}
+    batch-size: ${MEDIA_CLEANUP_BATCH_SIZE:100}
+    # true로 켜면 스케줄러가 EXPIRED 전이와 함께 S3 객체 삭제를 시도한다.
+    # false면 상태 전이만 수행하고 객체 정리는 S3 Lifecycle 정책에 맡긴다.
+    delete-object-enabled: ${MEDIA_CLEANUP_DELETE_OBJECT_ENABLED:false}
+
+app:
+  security:
+    context:
+      signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}
+      max-age-millis: ${APP_SECURITY_CONTEXT_MAX_AGE_MILLIS:300000}
+
+  gateway-security:
+    enabled: ${APP_GATEWAY_SECURITY_ENABLED:true}
+    gateway-auth-enabled: ${APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED:true}
+    internal-auth-header: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
+    internal-auth-token: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}
+    user-id-header: ${APP_GATEWAY_SECURITY_USER_ID_HEADER:X-User-Id}
+    required-paths:
+      - /api/v1/media/**
+    excluded-paths:
+      - /actuator/**
+      - /v3/api-docs/**
+      - /swagger-ui/**
+
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:10}
+
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Media Service API"
+    version: "1.0.0"
+    description: |
+      미디어 업로드 의도 생성/확정/조회 처리 서비스
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    software.amazon.awssdk: INFO

--- a/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
@@ -1,0 +1,256 @@
+package com.example.media.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventPublisher;
+import com.example.media.config.MediaCleanupProperties;
+import com.example.media.config.MediaS3Properties;
+import com.example.media.dto.command.request.UploadConfirmRequest;
+import com.example.media.dto.command.response.UploadConfirmResponse;
+import com.example.media.entity.MediaFile;
+import com.example.media.entity.MediaLink;
+import com.example.media.entity.MediaOwnerType;
+import com.example.media.entity.MediaUsageType;
+import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaFileRepository;
+import com.example.media.repository.MediaLinkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaCommandServiceTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private MediaLinkRepository mediaLinkRepository;
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    private MediaS3Properties mediaS3Properties;
+    private MediaCleanupProperties mediaCleanupProperties;
+
+    private MediaCommandService mediaCommandService;
+
+    @BeforeEach
+    void setUp() {
+        mediaS3Properties = new MediaS3Properties();
+        mediaS3Properties.setBucket("team2-donmoa-media-raw");
+        mediaS3Properties.setKeyPrefix("team2-donmoa-media");
+        mediaS3Properties.setPresignedPutTtlSeconds(300);
+        mediaS3Properties.setMaxFileSizeBytes(50_000_000L);
+        mediaS3Properties.setCloudfrontDomain("https://d111111abcdef8.cloudfront.net");
+
+        mediaCleanupProperties = new MediaCleanupProperties();
+        mediaCleanupProperties.setBatchSize(100);
+        mediaCleanupProperties.setDeleteObjectEnabled(false);
+
+        mediaCommandService = new MediaCommandService(
+                mediaFileRepository,
+                mediaLinkRepository,
+                mediaS3Properties,
+                mediaCleanupProperties,
+                s3Presigner,
+                s3Client,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void confirmUpload_withRequestedBinding_createsLinkAndPublishesEvent() {
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                MediaOwnerType.ITEM,
+                200L,
+                MediaUsageType.GALLERY,
+                null,
+                "upload-token-1",
+                LocalDateTime.now().plusMinutes(5)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 1L);
+
+        UploadConfirmRequest request = new UploadConfirmRequest();
+        ReflectionTestUtils.setField(request, "mediaId", 1L);
+        ReflectionTestUtils.setField(request, "uploadToken", "upload-token-1");
+
+        when(mediaFileRepository.findById(1L)).thenReturn(Optional.of(mediaFile));
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder()
+                .contentLength(1024L)
+                .contentType("image/jpeg")
+                .eTag("\"etag-1\"")
+                .build());
+        when(mediaFileRepository.save(any(MediaFile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(mediaLinkRepository.findByOwnerTypeAndOwnerIdAndUsageTypeOrderBySortOrderAscCreatedAtAsc(
+                MediaOwnerType.ITEM, 200L, MediaUsageType.GALLERY
+        )).thenReturn(new ArrayList<>());
+        when(mediaLinkRepository.saveAll(anyList())).thenAnswer(invocation -> {
+            List<MediaLink> links = invocation.getArgument(0);
+            long seq = 10L;
+            for (MediaLink link : links) {
+                if (link.getId() == null) {
+                    ReflectionTestUtils.setField(link, "id", seq++);
+                }
+            }
+            return links;
+        });
+
+        UploadConfirmResponse response = mediaCommandService.confirmUpload(request, 100L);
+
+        assertThat(response.getStatus()).isEqualTo("CONFIRMED");
+        assertThat(response.getOwnerType()).isEqualTo("ITEM");
+        assertThat(response.getOwnerId()).isEqualTo(200L);
+        assertThat(response.getUsageType()).isEqualTo("GALLERY");
+        assertThat(response.getSortOrder()).isEqualTo(0);
+        assertThat(response.getLinkId()).isNotNull();
+        verify(eventPublisher).publish(any(), any());
+    }
+
+    @Test
+    void confirmUpload_whenMetadataMismatch_marksFailedAndThrows() {
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-mismatch.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-mismatch.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                MediaOwnerType.ITEM,
+                200L,
+                MediaUsageType.GALLERY,
+                null,
+                "upload-token-2",
+                LocalDateTime.now().plusMinutes(5)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 2L);
+
+        UploadConfirmRequest request = new UploadConfirmRequest();
+        ReflectionTestUtils.setField(request, "mediaId", 2L);
+        ReflectionTestUtils.setField(request, "uploadToken", "upload-token-2");
+
+        when(mediaFileRepository.findById(2L)).thenReturn(Optional.of(mediaFile));
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder()
+                .contentLength(2048L)
+                .contentType("image/jpeg")
+                .eTag("\"etag-2\"")
+                .build());
+
+        assertThatThrownBy(() -> mediaCommandService.confirmUpload(request, 100L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MediaErrorCode.MEDIA_S3_METADATA_MISMATCH);
+
+        assertThat(mediaFile.getStatus().name()).isEqualTo("FAILED");
+        verify(eventPublisher, never()).publish(any(), any());
+        verify(mediaFileRepository, never()).save(any(MediaFile.class));
+    }
+
+    @Test
+    void confirmUpload_whenAlreadyConfirmed_doesNotHeadObjectAgain() {
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample3.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample3.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                2048L,
+                MediaOwnerType.ITEM,
+                200L,
+                MediaUsageType.THUMBNAIL,
+                0,
+                "upload-token-3",
+                LocalDateTime.now().plusMinutes(5)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 31L);
+        mediaFile.confirm(2048L, "image/jpeg", "etag-3", LocalDateTime.now());
+
+        UploadConfirmRequest request = new UploadConfirmRequest();
+        ReflectionTestUtils.setField(request, "mediaId", 31L);
+        ReflectionTestUtils.setField(request, "uploadToken", "upload-token-3");
+        ReflectionTestUtils.setField(request, "ownerType", "ITEM");
+        ReflectionTestUtils.setField(request, "ownerId", 200L);
+        ReflectionTestUtils.setField(request, "usageType", "THUMBNAIL");
+        ReflectionTestUtils.setField(request, "sortOrder", 0);
+
+        when(mediaFileRepository.findById(31L)).thenReturn(Optional.of(mediaFile));
+        when(mediaLinkRepository.findByOwnerTypeAndOwnerIdAndUsageTypeOrderBySortOrderAscCreatedAtAsc(
+                MediaOwnerType.ITEM, 200L, MediaUsageType.THUMBNAIL
+        )).thenReturn(new ArrayList<>());
+        when(mediaLinkRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UploadConfirmResponse response = mediaCommandService.confirmUpload(request, 100L);
+
+        assertThat(response.getStatus()).isEqualTo("CONFIRMED");
+        verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+        verify(eventPublisher, never()).publish(any(), any());
+        verify(mediaFileRepository, never()).save(any(MediaFile.class));
+    }
+
+    @Test
+    void expirePendingUploads_whenDeleteEnabled_marksExpiredAndDeletesObject() {
+        mediaCleanupProperties.setBatchSize(2);
+        mediaCleanupProperties.setDeleteObjectEnabled(true);
+
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-expire.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-expire.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                512L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-expire",
+                LocalDateTime.now().minusMinutes(10)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 41L);
+
+        when(mediaFileRepository.findByStatusAndUploadTokenExpiresAtBefore(
+                any(), any(), any(Pageable.class)
+        )).thenReturn(List.of(mediaFile));
+
+        MediaCommandService.ExpireResult result = mediaCommandService.expirePendingUploads();
+
+        assertThat(result.expiredCount()).isEqualTo(1);
+        assertThat(result.deletedObjectCount()).isEqualTo(1);
+        assertThat(result.deleteFailedCount()).isEqualTo(0);
+        assertThat(mediaFile.getStatus().name()).isEqualTo("EXPIRED");
+        verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+}

--- a/servers/services/media-worker/build.gradle.kts
+++ b/servers/services/media-worker/build.gradle.kts
@@ -1,0 +1,39 @@
+dependencies {
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+
+    // API
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // Security
+    implementation(project(":libs:security:security-starter"))
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // AWS SDK
+    implementation(platform("software.amazon.awssdk:bom:2.31.77"))
+    implementation("software.amazon.awssdk:s3")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database runtime
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/MediaWorkerApplication.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/MediaWorkerApplication.java
@@ -1,0 +1,16 @@
+package com.example.mediaworker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableAsync
+@EnableScheduling
+@SpringBootApplication(scanBasePackages = {"com.example.mediaworker", "com.example.api.handler"})
+public class MediaWorkerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MediaWorkerApplication.class, args);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
@@ -1,0 +1,44 @@
+package com.example.mediaworker.consumer;
+
+import com.example.core.util.JsonUtils;
+import com.example.mediaworker.dto.MediaEventMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class MediaConfirmedEventConsumer {
+
+    @KafkaListener(topics = "${media.worker.confirmed-topic:media.confirmed}", groupId = "${media.worker.group-id:media-worker-group}")
+    @Transactional
+    public void consume(String payload) {
+        try {
+            MediaEventMessage event = JsonUtils.fromJson(payload, MediaEventMessage.class);
+            if (!isValid(event)) {
+                log.warn("[MediaWorker] invalid event payload. payload={}", payload);
+                return;
+            }
+            // TODO(#654, #656): 후속 워커 분리 시 ownerType 별 변환 파이프라인으로 라우팅한다.
+            log.info(
+                    "[MediaWorker] confirmed event received. mediaId={}, ownerType={}, ownerId={}, usageType={}, objectKey={}",
+                    event.getMediaId(),
+                    event.getOwnerType(),
+                    event.getOwnerId(),
+                    event.getUsageType(),
+                    event.getObjectKey()
+            );
+        } catch (Exception e) {
+            log.error("[MediaWorker] event consume failed. payload={}", payload, e);
+            throw e;
+        }
+    }
+
+    private boolean isValid(MediaEventMessage event) {
+        return event != null
+                && event.getEventId() != null
+                && event.getEventType() != null
+                && event.getMediaId() != null;
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/MediaEventMessage.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/MediaEventMessage.java
@@ -1,0 +1,25 @@
+package com.example.mediaworker.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MediaEventMessage {
+
+    private Integer schemaVersion;
+    private String eventId;
+    private String eventType;
+    private Long mediaId;
+    private Long uploaderId;
+    private String bucketName;
+    private String objectKey;
+    private String contentType;
+    private Long fileSize;
+    private String etag;
+    private String ownerType;
+    private Long ownerId;
+    private String usageType;
+    private Integer sortOrder;
+    private String mediaUrl;
+}

--- a/servers/services/media-worker/src/main/resources/application.yml
+++ b/servers/services/media-worker/src/main/resources/application.yml
@@ -1,0 +1,51 @@
+server:
+  port: ${SERVER_PORT:8095}
+
+spring:
+  application:
+    name: media-worker
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/media_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+
+media:
+  worker:
+    group-id: ${MEDIA_WORKER_GROUP_ID:media-worker-group}
+    confirmed-topic: ${MEDIA_CONFIRMED_TOPIC:media.confirmed}
+
+app:
+  security:
+    context:
+      signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}
+      max-age-millis: ${APP_SECURITY_CONTEXT_MAX_AGE_MILLIS:300000}
+
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:11}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,8 @@ include("servers:services:funding")
 include("servers:services:notification")
 include("servers:services:sales")
 include("servers:services:hot-deal")
+include("servers:services:media-api")
+include("servers:services:media-worker")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## 개요

미디어 서비스를 `media-api`/`media-worker` 2개 모듈로 분리하고,
업로드 확정 경로의 무결성 검증/멱등/TTL 정리 정책을 스토리 범위(#654~#657)에 맞춰 구현했습니다.

### 관련 이슈
- Related #654
- Related #655
- Related #656
- Related #657

### 작업 / 변경 내용
- `media-api` 신규 모듈 추가
- Presigned 발급 시 `uploadToken` 포함 응답 추가
- 업로드 확정 시 S3 `HeadObject` 실측 검증(size/contentType) + 멱등 처리
- 확정 성공 시 `media.confirmed` 도메인 이벤트 발행(outbox 경유)
- 미확정 업로드 TTL 만료 스케줄러 추가(`PENDING_UPLOAD -> EXPIRED`)
- TTL 정리 시 선택적 S3 객체 삭제 옵션(`media.cleanup.delete-object-enabled`) 추가
- TTL 정책 문서 추가: `servers/services/media-api/docs/cleanup-policy.md`
- `media-worker` 신규 모듈 추가 및 `media.confirmed` 소비 스텁 연결

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

실행한 검증:
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:media-api:test :servers:services:media-worker:test --no-daemon`

### 참고사항
- 이 PR은 epic 브랜치 적재용이며, 이슈 자동 Close 키워드는 epic -> develop PR에서 일괄 반영 예정입니다.
