### PR TITLE
feat: [MZC-625] CloudFront 기반 미디어 URL 계약/캐시 정책 정리

### DIFF
--- a/servers/services/media-api/docs/cache-versioning-policy.md
+++ b/servers/services/media-api/docs/cache-versioning-policy.md
@@ -1,0 +1,30 @@
+# CloudFront Cache / Versioning Strategy
+
+## Cache-Control 기준
+
+### 썸네일(변경 빈도 낮음)
+- 권장: `public, max-age=31536000, immutable`
+- 이유: 파일 교체 대신 경로 버저닝으로 새 키를 발급하면 강한 캐시가 유리
+
+### 원본/상세 이미지(변경 가능성 존재)
+- 권장: `public, max-age=604800, stale-while-revalidate=60`
+- 이유: 과도한 재검증을 줄이면서도 변경 반영 지연을 제한
+
+## 버저닝 전략
+
+### 원칙
+- 동일 논리 자산이 변경되면 **동일 키 재사용 금지**
+- 새 object key를 발급해 캐시를 자연 전환한다.
+
+### 현재 구현 포인트
+- 업로드 키가 `UUID + 원본 파일명` 구조이므로 기본적으로 경로 버저닝 효과를 가진다.
+- invalidation 없이도 신규 키 조회 시 최신 자산을 즉시 사용할 수 있다.
+
+## Invalidation 최소화 원칙
+- 운영 중 대량 invalidation은 비용/지연이 커서 기본 정책으로 두지 않는다.
+- 예외적으로 동일 키를 강제로 대체한 경우에만 좁은 path 단위 invalidation을 수행한다.
+
+## 캐시 반영 검증 방법
+1. 동일 리소스 재조회 시 `Age` 헤더 증가 확인(캐시 히트)
+2. 신규 키 발급 후 조회 시 즉시 최신 파일 확인(캐시 미스 후 저장)
+3. 필요 시 `curl -I https://<cloudfront-domain>/<key>`로 `Cache-Control` 응답 확인

--- a/servers/services/media-api/docs/cloudfront-oac-policy.md
+++ b/servers/services/media-api/docs/cloudfront-oac-policy.md
@@ -1,0 +1,54 @@
+# CloudFront OAC + S3 Private Policy
+
+## 목표
+- S3 버킷은 private로 유지한다.
+- 조회는 CloudFront 경로만 허용한다.
+- 직접 S3 URL 접근은 차단한다.
+
+## 구성 기준
+
+### 1) S3 퍼블릭 접근 차단
+- S3 Bucket `Block Public Access` 4개 옵션 모두 `ON`
+- Bucket ACL 사용 안 함(Object Ownership: Bucket owner enforced 권장)
+
+### 2) CloudFront Origin Access Control(OAC)
+- Origin: `team2-donmoa-media-raw` S3 bucket
+- Origin Access: OAC 사용
+- Signing behavior: `Sign requests (always)`
+
+### 3) S3 Bucket Policy 예시
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudFrontServicePrincipalReadOnly",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::team2-donmoa-media-raw/*",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudfront::<ACCOUNT_ID>:distribution/<DISTRIBUTION_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+## 운영 검증 시나리오
+
+### 시나리오 A: 직접 S3 URL 차단 확인
+1. `https://team2-donmoa-media-raw.s3.ap-northeast-2.amazonaws.com/<key>` 호출
+2. `403 AccessDenied` 확인
+
+### 시나리오 B: CloudFront URL 허용 확인
+1. `https://<distribution-domain>/<key>` 호출
+2. `200` + 정상 컨텐츠 확인
+
+### 시나리오 C: OAC 우회 차단 확인
+1. 임의 IAM principal로 `GetObject` 호출
+2. CloudFront `SourceArn` 조건 미충족으로 실패 확인

--- a/servers/services/media-api/docs/url-contract.md
+++ b/servers/services/media-api/docs/url-contract.md
@@ -1,0 +1,33 @@
+# Media URL Contract
+
+## API 응답 계약
+`UploadConfirmResponse`는 아래 URL 관련 필드를 포함한다.
+
+- `mediaUrl`: 클라이언트가 조회에 사용하는 URL(CloudFront 도메인 기준)
+- `urlAccessType`: `PUBLIC` | `SIGNED_URL` | `SIGNED_COOKIE`
+- `urlExpiresAt`: `SIGNED_URL` 정책일 때 만료 시각(UTC), 그 외는 `null`
+- `cacheControl`: 추천 캐시 정책 문자열
+
+## 정책 규칙
+
+### 접근 정책
+- 기본값: `PUBLIC`
+- 민감 자산(예: 사용자 원본, 제한 공개 영상): `SIGNED_URL` 또는 `SIGNED_COOKIE`
+- 설정 위치: `media.url.access-type`
+
+### 만료/재발급
+- `SIGNED_URL`일 때 `media.url.signed-url-ttl-seconds`로 만료 시각을 계산한다.
+- 만료 이후에는 재발급 API(추후 추가) 또는 재확정 조회 플로우로 URL을 갱신한다.
+
+### 캐시
+- 썸네일: `media.url.thumbnail-cache-control`
+- 그 외: `media.url.default-cache-control`
+
+## 클라이언트 가이드
+1. `urlAccessType=PUBLIC`: 만료 처리 없이 일반 캐시 정책을 따른다.
+2. `urlAccessType=SIGNED_URL`: `urlExpiresAt` 1~2분 전부터 선제 재요청한다.
+3. `urlAccessType=SIGNED_COOKIE`: 앱 세션/쿠키 만료를 우선 확인하고, 필요 시 재로그인 또는 쿠키 재발급을 수행한다.
+
+## 참고
+- 현재 구현은 계약 필드와 정책 매핑을 제공한다.
+- CloudFront 서명 키 기반의 실제 Signed URL/쿠키 발급은 후속 태스크에서 연결한다.

--- a/servers/services/media-api/src/main/java/com/example/media/config/MediaUrlAccessType.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/MediaUrlAccessType.java
@@ -1,0 +1,7 @@
+package com.example.media.config;
+
+public enum MediaUrlAccessType {
+    PUBLIC,
+    SIGNED_URL,
+    SIGNED_COOKIE
+}

--- a/servers/services/media-api/src/main/java/com/example/media/config/MediaUrlProperties.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/MediaUrlProperties.java
@@ -1,0 +1,16 @@
+package com.example.media.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "media.url")
+public class MediaUrlProperties {
+
+    private MediaUrlAccessType accessType = MediaUrlAccessType.PUBLIC;
+    private long signedUrlTtlSeconds = 300;
+    private String defaultCacheControl = "public, max-age=604800, stale-while-revalidate=60";
+    private String thumbnailCacheControl = "public, max-age=31536000, immutable";
+}

--- a/servers/services/media-api/src/main/java/com/example/media/config/S3ClientConfig.java
+++ b/servers/services/media-api/src/main/java/com/example/media/config/S3ClientConfig.java
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-@EnableConfigurationProperties({MediaS3Properties.class, MediaCleanupProperties.class})
+@EnableConfigurationProperties({MediaS3Properties.class, MediaCleanupProperties.class, MediaUrlProperties.class})
 public class S3ClientConfig {
 
     @Bean

--- a/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadConfirmResponse.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/command/response/UploadConfirmResponse.java
@@ -3,6 +3,8 @@ package com.example.media.dto.command.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.Instant;
+
 @Getter
 @Builder
 public class UploadConfirmResponse {
@@ -14,6 +16,9 @@ public class UploadConfirmResponse {
     private String contentType;
     private String etag;
     private String mediaUrl;
+    private String urlAccessType;
+    private Instant urlExpiresAt;
+    private String cacheControl;
     private Long linkId;
     private String ownerType;
     private Long ownerId;

--- a/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
@@ -5,6 +5,8 @@ import com.example.event.EventMetadata;
 import com.example.event.EventPublisher;
 import com.example.media.config.MediaCleanupProperties;
 import com.example.media.config.MediaS3Properties;
+import com.example.media.config.MediaUrlAccessType;
+import com.example.media.config.MediaUrlProperties;
 import com.example.media.dto.command.request.UploadConfirmRequest;
 import com.example.media.dto.command.request.UploadIntentRequest;
 import com.example.media.dto.command.response.UploadConfirmResponse;
@@ -54,6 +56,7 @@ public class MediaCommandService {
     private final MediaLinkRepository mediaLinkRepository;
     private final MediaS3Properties mediaS3Properties;
     private final MediaCleanupProperties mediaCleanupProperties;
+    private final MediaUrlProperties mediaUrlProperties;
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
     private final EventPublisher eventPublisher;
@@ -454,6 +457,10 @@ public class MediaCommandService {
     }
 
     private UploadConfirmResponse toConfirmResponse(MediaFile mediaFile, MediaLink mediaLink) {
+        MediaUrlContract urlContract = buildMediaUrlContract(
+                mediaFile.getObjectKey(),
+                mediaLink != null ? mediaLink.getUsageType() : null
+        );
         return UploadConfirmResponse.builder()
                 .mediaId(mediaFile.getId())
                 .status(mediaFile.getStatus().name())
@@ -461,7 +468,10 @@ public class MediaCommandService {
                 .fileSize(mediaFile.getFileSize())
                 .contentType(mediaFile.getContentType())
                 .etag(mediaFile.getEtag())
-                .mediaUrl(buildMediaUrl(mediaFile.getObjectKey()))
+                .mediaUrl(urlContract.url())
+                .urlAccessType(urlContract.accessType().name())
+                .urlExpiresAt(urlContract.expiresAt())
+                .cacheControl(urlContract.cacheControl())
                 .linkId(mediaLink != null ? mediaLink.getId() : null)
                 .ownerType(mediaLink != null ? mediaLink.getOwnerType().name() : null)
                 .ownerId(mediaLink != null ? mediaLink.getOwnerId() : null)
@@ -481,6 +491,20 @@ public class MediaCommandService {
         return domain + "/" + objectKey;
     }
 
+    private MediaUrlContract buildMediaUrlContract(String objectKey, MediaUsageType usageType) {
+        String baseUrl = buildMediaUrl(objectKey);
+        MediaUrlAccessType accessType = mediaUrlProperties.getAccessType();
+        Instant expiresAt = null;
+        if (accessType == MediaUrlAccessType.SIGNED_URL) {
+            expiresAt = Instant.now().plusSeconds(Math.max(1, mediaUrlProperties.getSignedUrlTtlSeconds()));
+        }
+        String cacheControl = usageType == MediaUsageType.THUMBNAIL
+                ? mediaUrlProperties.getThumbnailCacheControl()
+                : mediaUrlProperties.getDefaultCacheControl();
+
+        return new MediaUrlContract(baseUrl, accessType, expiresAt, cacheControl);
+    }
+
     private record MediaBinding(
             MediaOwnerType ownerType,
             Long ownerId,
@@ -493,6 +517,14 @@ public class MediaCommandService {
             int expiredCount,
             int deletedObjectCount,
             int deleteFailedCount
+    ) {
+    }
+
+    private record MediaUrlContract(
+            String url,
+            MediaUrlAccessType accessType,
+            Instant expiresAt,
+            String cacheControl
     ) {
     }
 }

--- a/servers/services/media-api/src/main/resources/application.yml
+++ b/servers/services/media-api/src/main/resources/application.yml
@@ -50,6 +50,11 @@ media:
     # true로 켜면 스케줄러가 EXPIRED 전이와 함께 S3 객체 삭제를 시도한다.
     # false면 상태 전이만 수행하고 객체 정리는 S3 Lifecycle 정책에 맡긴다.
     delete-object-enabled: ${MEDIA_CLEANUP_DELETE_OBJECT_ENABLED:false}
+  url:
+    access-type: ${MEDIA_URL_ACCESS_TYPE:PUBLIC}
+    signed-url-ttl-seconds: ${MEDIA_URL_SIGNED_URL_TTL_SECONDS:300}
+    default-cache-control: ${MEDIA_URL_DEFAULT_CACHE_CONTROL:public, max-age=604800, stale-while-revalidate=60}
+    thumbnail-cache-control: ${MEDIA_URL_THUMBNAIL_CACHE_CONTROL:public, max-age=31536000, immutable}
 
 app:
   security:

--- a/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
@@ -4,6 +4,8 @@ import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
 import com.example.media.config.MediaCleanupProperties;
 import com.example.media.config.MediaS3Properties;
+import com.example.media.config.MediaUrlAccessType;
+import com.example.media.config.MediaUrlProperties;
 import com.example.media.dto.command.request.UploadConfirmRequest;
 import com.example.media.dto.command.response.UploadConfirmResponse;
 import com.example.media.entity.MediaFile;
@@ -59,6 +61,7 @@ class MediaCommandServiceTest {
 
     private MediaS3Properties mediaS3Properties;
     private MediaCleanupProperties mediaCleanupProperties;
+    private MediaUrlProperties mediaUrlProperties;
 
     private MediaCommandService mediaCommandService;
 
@@ -75,11 +78,16 @@ class MediaCommandServiceTest {
         mediaCleanupProperties.setBatchSize(100);
         mediaCleanupProperties.setDeleteObjectEnabled(false);
 
+        mediaUrlProperties = new MediaUrlProperties();
+        mediaUrlProperties.setAccessType(MediaUrlAccessType.PUBLIC);
+        mediaUrlProperties.setSignedUrlTtlSeconds(300);
+
         mediaCommandService = new MediaCommandService(
                 mediaFileRepository,
                 mediaLinkRepository,
                 mediaS3Properties,
                 mediaCleanupProperties,
+                mediaUrlProperties,
                 s3Presigner,
                 s3Client,
                 eventPublisher
@@ -137,6 +145,9 @@ class MediaCommandServiceTest {
         assertThat(response.getUsageType()).isEqualTo("GALLERY");
         assertThat(response.getSortOrder()).isEqualTo(0);
         assertThat(response.getLinkId()).isNotNull();
+        assertThat(response.getUrlAccessType()).isEqualTo("PUBLIC");
+        assertThat(response.getUrlExpiresAt()).isNull();
+        assertThat(response.getCacheControl()).isEqualTo(mediaUrlProperties.getDefaultCacheControl());
         verify(eventPublisher).publish(any(), any());
     }
 
@@ -215,9 +226,49 @@ class MediaCommandServiceTest {
         UploadConfirmResponse response = mediaCommandService.confirmUpload(request, 100L);
 
         assertThat(response.getStatus()).isEqualTo("CONFIRMED");
+        assertThat(response.getUrlAccessType()).isEqualTo("PUBLIC");
         verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
         verify(eventPublisher, never()).publish(any(), any());
         verify(mediaFileRepository, never()).save(any(MediaFile.class));
+    }
+
+    @Test
+    void confirmUpload_withSignedUrlPolicy_setsExpiration() {
+        mediaUrlProperties.setAccessType(MediaUrlAccessType.SIGNED_URL);
+        mediaUrlProperties.setSignedUrlTtlSeconds(60);
+
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-signed.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-signed.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-signed",
+                LocalDateTime.now().plusMinutes(5)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 51L);
+
+        UploadConfirmRequest request = new UploadConfirmRequest();
+        ReflectionTestUtils.setField(request, "mediaId", 51L);
+        ReflectionTestUtils.setField(request, "uploadToken", "upload-token-signed");
+
+        when(mediaFileRepository.findById(51L)).thenReturn(Optional.of(mediaFile));
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder()
+                .contentLength(1024L)
+                .contentType("image/jpeg")
+                .eTag("\"etag-signed\"")
+                .build());
+        when(mediaFileRepository.save(any(MediaFile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UploadConfirmResponse response = mediaCommandService.confirmUpload(request, 100L);
+
+        assertThat(response.getUrlAccessType()).isEqualTo("SIGNED_URL");
+        assertThat(response.getUrlExpiresAt()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## 개요

CloudFront 기반 조회 정책 스토리(#650)와 하위 태스크(#651~#653)에 맞춰
미디어 URL 계약 필드와 운영 정책 문서를 추가했습니다.

### 관련 이슈
- Related #650
- Related #651
- Related #652
- Related #653

### 작업 / 변경 내용
- `UploadConfirmResponse` URL 계약 확장
  - `urlAccessType`, `urlExpiresAt`, `cacheControl`
- URL 정책 설정 추가
  - `media.url.access-type` (`PUBLIC`/`SIGNED_URL`/`SIGNED_COOKIE`)
  - `media.url.signed-url-ttl-seconds`
  - `media.url.default-cache-control`
  - `media.url.thumbnail-cache-control`
- URL 계약 매핑 로직 반영 (`MediaCommandService`)
- 운영/정책 문서 추가
  - `servers/services/media-api/docs/cloudfront-oac-policy.md`
  - `servers/services/media-api/docs/url-contract.md`
  - `servers/services/media-api/docs/cache-versioning-policy.md`

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

실행한 검증:
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:media-api:test :servers:services:media-worker:test --no-daemon`

### 참고사항
- 이 PR은 epic 적재용입니다. 이슈 자동 Close 키워드는 epic -> develop PR에서 일괄 반영 예정입니다.
- `SIGNED_URL`/`SIGNED_COOKIE`의 실제 CloudFront 서명 키 연동은 후속 구현 태스크로 분리합니다.
