### PR TITLE
feat: [MZC-627] 미디어 URL 재조회/재발급 API 추가

### DIFF
--- a/servers/services/media-api/docs/url-contract.md
+++ b/servers/services/media-api/docs/url-contract.md
@@ -8,6 +8,10 @@
 - `urlExpiresAt`: `SIGNED_URL` 정책일 때 만료 시각(UTC), 그 외는 `null`
 - `cacheControl`: 추천 캐시 정책 문자열
 
+추가로 재조회/재발급 용도로 아래 API를 제공한다.
+- `GET /api/v1/media/{mediaId}/url`
+- 응답: `MediaUrlResponse` (동일 URL 계약 필드 포함)
+
 ## 정책 규칙
 
 ### 접근 정책
@@ -17,7 +21,7 @@
 
 ### 만료/재발급
 - `SIGNED_URL`일 때 `media.url.signed-url-ttl-seconds`로 만료 시각을 계산한다.
-- 만료 이후에는 재발급 API(추후 추가) 또는 재확정 조회 플로우로 URL을 갱신한다.
+- 만료 이후에는 `GET /api/v1/media/{mediaId}/url` 호출로 URL 정보를 재발급한다.
 
 ### 캐시
 - 썸네일: `media.url.thumbnail-cache-control`
@@ -29,5 +33,5 @@
 3. `urlAccessType=SIGNED_COOKIE`: 앱 세션/쿠키 만료를 우선 확인하고, 필요 시 재로그인 또는 쿠키 재발급을 수행한다.
 
 ## 참고
-- 현재 구현은 계약 필드와 정책 매핑을 제공한다.
+- 현재 구현은 계약 필드/정책 매핑과 재발급 조회 API를 제공한다.
 - CloudFront 서명 키 기반의 실제 Signed URL/쿠키 발급은 후속 태스크에서 연결한다.

--- a/servers/services/media-api/src/main/java/com/example/media/controller/api/query/MediaQueryApi.java
+++ b/servers/services/media-api/src/main/java/com/example/media/controller/api/query/MediaQueryApi.java
@@ -1,0 +1,20 @@
+package com.example.media.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.media.dto.query.response.MediaUrlResponse;
+import com.example.security.gateway.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Media Query", description = "미디어 URL 조회/재발급 API")
+public interface MediaQueryApi {
+
+    @Operation(summary = "미디어 URL 조회/재발급")
+    @GetMapping("/{mediaId}/url")
+    ApiResponse<MediaUrlResponse> getMediaUrl(
+            @PathVariable Long mediaId,
+            @CurrentUserId(required = false) Long userId
+    );
+}

--- a/servers/services/media-api/src/main/java/com/example/media/controller/query/MediaQueryController.java
+++ b/servers/services/media-api/src/main/java/com/example/media/controller/query/MediaQueryController.java
@@ -1,0 +1,22 @@
+package com.example.media.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.media.controller.api.query.MediaQueryApi;
+import com.example.media.dto.query.response.MediaUrlResponse;
+import com.example.media.service.query.MediaQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/media")
+@RequiredArgsConstructor
+public class MediaQueryController implements MediaQueryApi {
+
+    private final MediaQueryService mediaQueryService;
+
+    @Override
+    public ApiResponse<MediaUrlResponse> getMediaUrl(Long mediaId, Long userId) {
+        return ApiResponse.success(mediaQueryService.getMediaUrl(mediaId, userId));
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/dto/query/response/MediaUrlResponse.java
+++ b/servers/services/media-api/src/main/java/com/example/media/dto/query/response/MediaUrlResponse.java
@@ -1,0 +1,20 @@
+package com.example.media.dto.query.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class MediaUrlResponse {
+
+    private Long mediaId;
+    private String status;
+    private String objectKey;
+    private String mediaUrl;
+    private String urlAccessType;
+    private Instant urlExpiresAt;
+    private String cacheControl;
+    private String usageType;
+}

--- a/servers/services/media-api/src/main/java/com/example/media/exception/MediaErrorCode.java
+++ b/servers/services/media-api/src/main/java/com/example/media/exception/MediaErrorCode.java
@@ -19,7 +19,8 @@ public enum MediaErrorCode implements DomainErrorCode {
     MEDIA_S3_OBJECT_NOT_FOUND("MEDIA-008", "S3 업로드 객체를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     MEDIA_S3_HEAD_FAILED("MEDIA-009", "S3 객체 검증 처리에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     INVALID_MEDIA_BINDING("MEDIA-010", "미디어 소유자/용도 바인딩 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    MEDIA_S3_METADATA_MISMATCH("MEDIA-011", "업로드 객체 메타데이터가 요청값과 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+    MEDIA_S3_METADATA_MISMATCH("MEDIA-011", "업로드 객체 메타데이터가 요청값과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    MEDIA_NOT_READY("MEDIA-012", "미디어가 조회 가능한 상태가 아닙니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/servers/services/media-api/src/main/java/com/example/media/repository/MediaLinkRepository.java
+++ b/servers/services/media-api/src/main/java/com/example/media/repository/MediaLinkRepository.java
@@ -22,4 +22,6 @@ public interface MediaLinkRepository extends JpaRepository<MediaLink, Long> {
             Long ownerId,
             MediaUsageType usageType
     );
+
+    Optional<MediaLink> findTopByMediaIdOrderByCreatedAtDesc(Long mediaId);
 }

--- a/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCommandService.java
@@ -5,8 +5,6 @@ import com.example.event.EventMetadata;
 import com.example.event.EventPublisher;
 import com.example.media.config.MediaCleanupProperties;
 import com.example.media.config.MediaS3Properties;
-import com.example.media.config.MediaUrlAccessType;
-import com.example.media.config.MediaUrlProperties;
 import com.example.media.dto.command.request.UploadConfirmRequest;
 import com.example.media.dto.command.request.UploadIntentRequest;
 import com.example.media.dto.command.response.UploadConfirmResponse;
@@ -20,6 +18,7 @@ import com.example.media.event.MediaConfirmedEvent;
 import com.example.media.exception.MediaErrorCode;
 import com.example.media.repository.MediaFileRepository;
 import com.example.media.repository.MediaLinkRepository;
+import com.example.media.service.query.MediaUrlPolicyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -56,7 +55,7 @@ public class MediaCommandService {
     private final MediaLinkRepository mediaLinkRepository;
     private final MediaS3Properties mediaS3Properties;
     private final MediaCleanupProperties mediaCleanupProperties;
-    private final MediaUrlProperties mediaUrlProperties;
+    private final MediaUrlPolicyService mediaUrlPolicyService;
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
     private final EventPublisher eventPublisher;
@@ -294,7 +293,7 @@ public class MediaCommandService {
                         mediaLink != null ? mediaLink.getOwnerId() : null,
                         mediaLink != null ? mediaLink.getUsageType() : null,
                         mediaLink != null ? mediaLink.getSortOrder() : null,
-                        buildMediaUrl(mediaFile.getObjectKey())
+                        mediaUrlPolicyService.buildBaseUrl(mediaFile.getObjectKey())
                 ),
                 EventMetadata.of("MediaFile", String.valueOf(mediaFile.getId()))
         );
@@ -457,7 +456,7 @@ public class MediaCommandService {
     }
 
     private UploadConfirmResponse toConfirmResponse(MediaFile mediaFile, MediaLink mediaLink) {
-        MediaUrlContract urlContract = buildMediaUrlContract(
+        MediaUrlPolicyService.MediaUrlContract urlContract = mediaUrlPolicyService.resolve(
                 mediaFile.getObjectKey(),
                 mediaLink != null ? mediaLink.getUsageType() : null
         );
@@ -480,31 +479,6 @@ public class MediaCommandService {
                 .build();
     }
 
-    private String buildMediaUrl(String objectKey) {
-        if (!StringUtils.hasText(mediaS3Properties.getCloudfrontDomain())) {
-            return null;
-        }
-        String domain = mediaS3Properties.getCloudfrontDomain().trim();
-        if (domain.endsWith("/")) {
-            domain = domain.substring(0, domain.length() - 1);
-        }
-        return domain + "/" + objectKey;
-    }
-
-    private MediaUrlContract buildMediaUrlContract(String objectKey, MediaUsageType usageType) {
-        String baseUrl = buildMediaUrl(objectKey);
-        MediaUrlAccessType accessType = mediaUrlProperties.getAccessType();
-        Instant expiresAt = null;
-        if (accessType == MediaUrlAccessType.SIGNED_URL) {
-            expiresAt = Instant.now().plusSeconds(Math.max(1, mediaUrlProperties.getSignedUrlTtlSeconds()));
-        }
-        String cacheControl = usageType == MediaUsageType.THUMBNAIL
-                ? mediaUrlProperties.getThumbnailCacheControl()
-                : mediaUrlProperties.getDefaultCacheControl();
-
-        return new MediaUrlContract(baseUrl, accessType, expiresAt, cacheControl);
-    }
-
     private record MediaBinding(
             MediaOwnerType ownerType,
             Long ownerId,
@@ -517,14 +491,6 @@ public class MediaCommandService {
             int expiredCount,
             int deletedObjectCount,
             int deleteFailedCount
-    ) {
-    }
-
-    private record MediaUrlContract(
-            String url,
-            MediaUrlAccessType accessType,
-            Instant expiresAt,
-            String cacheControl
     ) {
     }
 }

--- a/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
@@ -1,0 +1,60 @@
+package com.example.media.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.media.dto.query.response.MediaUrlResponse;
+import com.example.media.entity.MediaFile;
+import com.example.media.entity.MediaLink;
+import com.example.media.entity.MediaStatus;
+import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaFileRepository;
+import com.example.media.repository.MediaLinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MediaQueryService {
+
+    private final MediaFileRepository mediaFileRepository;
+    private final MediaLinkRepository mediaLinkRepository;
+    private final MediaUrlPolicyService mediaUrlPolicyService;
+
+    @Transactional(readOnly = true)
+    public MediaUrlResponse getMediaUrl(Long mediaId, Long userId) {
+        MediaFile mediaFile = mediaFileRepository.findById(mediaId)
+                .orElseThrow(() -> new BusinessException(MediaErrorCode.MEDIA_NOT_FOUND));
+
+        validateAccess(mediaFile, userId);
+        validateStatus(mediaFile);
+
+        MediaLink link = mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(mediaId).orElse(null);
+        MediaUrlPolicyService.MediaUrlContract urlContract = mediaUrlPolicyService.resolve(
+                mediaFile.getObjectKey(),
+                link != null ? link.getUsageType() : null
+        );
+
+        return MediaUrlResponse.builder()
+                .mediaId(mediaFile.getId())
+                .status(mediaFile.getStatus().name())
+                .objectKey(mediaFile.getObjectKey())
+                .mediaUrl(urlContract.url())
+                .urlAccessType(urlContract.accessType().name())
+                .urlExpiresAt(urlContract.expiresAt())
+                .cacheControl(urlContract.cacheControl())
+                .usageType(link != null ? link.getUsageType().name() : null)
+                .build();
+    }
+
+    private void validateAccess(MediaFile mediaFile, Long userId) {
+        if (userId != null && mediaFile.getUploaderId() != null && !mediaFile.isOwnedBy(userId)) {
+            throw new BusinessException(MediaErrorCode.FORBIDDEN_MEDIA_ACCESS);
+        }
+    }
+
+    private void validateStatus(MediaFile mediaFile) {
+        if (mediaFile.getStatus() != MediaStatus.CONFIRMED && mediaFile.getStatus() != MediaStatus.READY) {
+            throw new BusinessException(MediaErrorCode.MEDIA_NOT_READY);
+        }
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/service/query/MediaUrlPolicyService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/query/MediaUrlPolicyService.java
@@ -1,0 +1,51 @@
+package com.example.media.service.query;
+
+import com.example.media.config.MediaS3Properties;
+import com.example.media.config.MediaUrlAccessType;
+import com.example.media.config.MediaUrlProperties;
+import com.example.media.entity.MediaUsageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class MediaUrlPolicyService {
+
+    private final MediaS3Properties mediaS3Properties;
+    private final MediaUrlProperties mediaUrlProperties;
+
+    public MediaUrlContract resolve(String objectKey, MediaUsageType usageType) {
+        String url = buildBaseUrl(objectKey);
+        MediaUrlAccessType accessType = mediaUrlProperties.getAccessType();
+        Instant expiresAt = null;
+        if (accessType == MediaUrlAccessType.SIGNED_URL) {
+            expiresAt = Instant.now().plusSeconds(Math.max(1, mediaUrlProperties.getSignedUrlTtlSeconds()));
+        }
+        String cacheControl = usageType == MediaUsageType.THUMBNAIL
+                ? mediaUrlProperties.getThumbnailCacheControl()
+                : mediaUrlProperties.getDefaultCacheControl();
+        return new MediaUrlContract(url, accessType, expiresAt, cacheControl);
+    }
+
+    public String buildBaseUrl(String objectKey) {
+        if (!StringUtils.hasText(mediaS3Properties.getCloudfrontDomain())) {
+            return null;
+        }
+        String domain = mediaS3Properties.getCloudfrontDomain().trim();
+        if (domain.endsWith("/")) {
+            domain = domain.substring(0, domain.length() - 1);
+        }
+        return domain + "/" + objectKey;
+    }
+
+    public record MediaUrlContract(
+            String url,
+            MediaUrlAccessType accessType,
+            Instant expiresAt,
+            String cacheControl
+    ) {
+    }
+}

--- a/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCommandServiceTest.java
@@ -15,6 +15,7 @@ import com.example.media.entity.MediaUsageType;
 import com.example.media.exception.MediaErrorCode;
 import com.example.media.repository.MediaFileRepository;
 import com.example.media.repository.MediaLinkRepository;
+import com.example.media.service.query.MediaUrlPolicyService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +63,7 @@ class MediaCommandServiceTest {
     private MediaS3Properties mediaS3Properties;
     private MediaCleanupProperties mediaCleanupProperties;
     private MediaUrlProperties mediaUrlProperties;
+    private MediaUrlPolicyService mediaUrlPolicyService;
 
     private MediaCommandService mediaCommandService;
 
@@ -81,13 +83,14 @@ class MediaCommandServiceTest {
         mediaUrlProperties = new MediaUrlProperties();
         mediaUrlProperties.setAccessType(MediaUrlAccessType.PUBLIC);
         mediaUrlProperties.setSignedUrlTtlSeconds(300);
+        mediaUrlPolicyService = new MediaUrlPolicyService(mediaS3Properties, mediaUrlProperties);
 
         mediaCommandService = new MediaCommandService(
                 mediaFileRepository,
                 mediaLinkRepository,
                 mediaS3Properties,
                 mediaCleanupProperties,
-                mediaUrlProperties,
+                mediaUrlPolicyService,
                 s3Presigner,
                 s3Client,
                 eventPublisher

--- a/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
@@ -1,0 +1,144 @@
+package com.example.media.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.media.config.MediaS3Properties;
+import com.example.media.config.MediaUrlAccessType;
+import com.example.media.config.MediaUrlProperties;
+import com.example.media.dto.query.response.MediaUrlResponse;
+import com.example.media.entity.MediaFile;
+import com.example.media.entity.MediaLink;
+import com.example.media.entity.MediaOwnerType;
+import com.example.media.entity.MediaUsageType;
+import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaFileRepository;
+import com.example.media.repository.MediaLinkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaQueryServiceTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private MediaLinkRepository mediaLinkRepository;
+
+    private MediaQueryService mediaQueryService;
+
+    private MediaUrlProperties mediaUrlProperties;
+
+    @BeforeEach
+    void setUp() {
+        MediaS3Properties mediaS3Properties = new MediaS3Properties();
+        mediaS3Properties.setCloudfrontDomain("https://d111111abcdef8.cloudfront.net");
+
+        mediaUrlProperties = new MediaUrlProperties();
+        mediaUrlProperties.setAccessType(MediaUrlAccessType.PUBLIC);
+        mediaUrlProperties.setSignedUrlTtlSeconds(300);
+
+        MediaUrlPolicyService mediaUrlPolicyService = new MediaUrlPolicyService(mediaS3Properties, mediaUrlProperties);
+        mediaQueryService = new MediaQueryService(mediaFileRepository, mediaLinkRepository, mediaUrlPolicyService);
+    }
+
+    @Test
+    void getMediaUrl_returnsPublicUrlForConfirmedMedia() {
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-query.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-query.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-query",
+                LocalDateTime.now().plusMinutes(1)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 101L);
+        mediaFile.confirm(1024L, "image/jpeg", "etag-query", LocalDateTime.now());
+
+        MediaLink mediaLink = MediaLink.create(101L, MediaOwnerType.ITEM, 200L, MediaUsageType.THUMBNAIL, 0);
+
+        when(mediaFileRepository.findById(101L)).thenReturn(Optional.of(mediaFile));
+        when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(101L)).thenReturn(Optional.of(mediaLink));
+
+        MediaUrlResponse response = mediaQueryService.getMediaUrl(101L, 100L);
+
+        assertThat(response.getMediaId()).isEqualTo(101L);
+        assertThat(response.getUrlAccessType()).isEqualTo("PUBLIC");
+        assertThat(response.getMediaUrl()).contains("cloudfront.net");
+        assertThat(response.getUsageType()).isEqualTo("THUMBNAIL");
+        assertThat(response.getUrlExpiresAt()).isNull();
+    }
+
+    @Test
+    void getMediaUrl_withSignedUrlPolicy_setsExpiresAt() {
+        mediaUrlProperties.setAccessType(MediaUrlAccessType.SIGNED_URL);
+        mediaUrlProperties.setSignedUrlTtlSeconds(60);
+
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-signed-query.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-signed-query.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-query2",
+                LocalDateTime.now().plusMinutes(1)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 102L);
+        mediaFile.confirm(1024L, "image/jpeg", "etag-query2", LocalDateTime.now());
+
+        when(mediaFileRepository.findById(102L)).thenReturn(Optional.of(mediaFile));
+        when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(102L)).thenReturn(Optional.empty());
+
+        MediaUrlResponse response = mediaQueryService.getMediaUrl(102L, 100L);
+
+        assertThat(response.getUrlAccessType()).isEqualTo("SIGNED_URL");
+        assertThat(response.getUrlExpiresAt()).isNotNull();
+    }
+
+    @Test
+    void getMediaUrl_whenMediaNotReady_throwsConflict() {
+        MediaFile mediaFile = MediaFile.createPending(
+                100L,
+                "sample-pending.jpg",
+                "team2-donmoa-media/raw/2026/01/01/sample-pending.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-query3",
+                LocalDateTime.now().plusMinutes(1)
+        );
+        ReflectionTestUtils.setField(mediaFile, "id", 103L);
+
+        when(mediaFileRepository.findById(103L)).thenReturn(Optional.of(mediaFile));
+
+        assertThatThrownBy(() -> mediaQueryService.getMediaUrl(103L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MediaErrorCode.MEDIA_NOT_READY);
+    }
+}


### PR DESCRIPTION
## 개요

`#652` 요구사항(만료/재발급 API 또는 전략 정의)을 코드로 구체화하기 위해,
미디어 URL 재조회/재발급 API를 추가하고 URL 정책 계산 로직을 공통화했습니다.

### 관련 이슈
- Related #652
- Related #650

### 작업 / 변경 내용
- `GET /api/v1/media/{mediaId}/url` API 추가
  - `MediaQueryApi`, `MediaQueryController`, `MediaQueryService`
- URL 정책 계산 공통 서비스 분리
  - `MediaUrlPolicyService` (command/query 공통 사용)
- 조회 가능 상태 검증 추가
  - `CONFIRMED`/`READY`만 조회 허용, 그 외 `MEDIA_NOT_READY` 반환
- 최신 링크(usageType) 기반 URL 계약 응답
  - `MediaUrlResponse` DTO 추가
- 문서 업데이트
  - `servers/services/media-api/docs/url-contract.md` (재발급 API 명시)

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

실행한 검증:
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:media-api:test :servers:services:media-worker:test --no-daemon`

### 참고사항
- 이 PR은 epic 적재용이며, 이슈 자동 Close 키워드는 epic -> develop PR에서 일괄 반영 예정입니다.
