### PR TITLE
feat: [MZC-632] 미확정 업로드 cleanup 메트릭/알림 기준 추가

### DIFF
--- a/servers/services/media-api/docs/cleanup-policy.md
+++ b/servers/services/media-api/docs/cleanup-policy.md
@@ -38,3 +38,18 @@
 - 운영:
   - 초기엔 `false`로 두고 Lifecycle 정책을 주 정리 수단으로 운영
   - 필요 시 점진적으로 `true` 전환
+
+## 메트릭/알림 기준
+- `media.cleanup.duration`
+  - 스케줄러 1회 실행 시간
+- `media.cleanup.expired.total`
+  - 만료 전이 누적 건수
+- `media.cleanup.s3.delete.total{result=success|failure}`
+  - S3 삭제 성공/실패 누적 건수
+- `media.cleanup.alerts.total{type=delete_failure}`
+  - 삭제 실패 경고 누적 건수
+
+권장 알림:
+1. `media.cleanup.alerts.total`가 5분 동안 1 이상 증가하면 경고
+2. `media.cleanup.s3.delete.total{result=failure}` / `success` 비율이 10% 초과 시 경고
+3. `media.cleanup.duration` P95가 스케줄 간격의 50%를 초과하면 경고

--- a/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCleanupScheduler.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/command/MediaCleanupScheduler.java
@@ -1,9 +1,12 @@
 package com.example.media.service.command;
 
+import com.example.media.service.metrics.MediaCleanupMetricsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
 
 @Slf4j
 @Component
@@ -11,10 +14,16 @@ import org.springframework.stereotype.Component;
 public class MediaCleanupScheduler {
 
     private final MediaCommandService mediaCommandService;
+    private final MediaCleanupMetricsService mediaCleanupMetricsService;
 
     @Scheduled(cron = "${media.cleanup.cron:0 */10 * * * *}")
     public void expirePendingUploads() {
+        long startNanos = System.nanoTime();
         MediaCommandService.ExpireResult result = mediaCommandService.expirePendingUploads();
+        mediaCleanupMetricsService.record(
+                result,
+                Duration.ofNanos(System.nanoTime() - startNanos)
+        );
         if (result.expiredCount() > 0 || result.deleteFailedCount() > 0) {
             log.info(
                     "[MediaCleanup] expired={}, deletedObjects={}, deleteFailed={}",

--- a/servers/services/media-api/src/main/java/com/example/media/service/metrics/MediaCleanupMetricsService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/metrics/MediaCleanupMetricsService.java
@@ -1,0 +1,52 @@
+package com.example.media.service.metrics;
+
+import com.example.media.service.command.MediaCommandService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaCleanupMetricsService {
+
+    private final MeterRegistry meterRegistry;
+
+    public void record(MediaCommandService.ExpireResult result, Duration duration) {
+        Timer.builder("media.cleanup.duration")
+                .description("Media cleanup scheduler duration")
+                .register(meterRegistry)
+                .record(duration);
+
+        incrementIfPositive("media.cleanup.expired.total", result.expiredCount());
+        incrementIfPositive("media.cleanup.s3.delete.total", "result", "success", result.deletedObjectCount());
+        incrementIfPositive("media.cleanup.s3.delete.total", "result", "failure", result.deleteFailedCount());
+
+        if (result.deleteFailedCount() > 0) {
+            meterRegistry.counter("media.cleanup.alerts.total", "type", "delete_failure").increment();
+            log.warn(
+                    "[MediaCleanupAlert] delete failures detected. deleteFailed={}, expired={}",
+                    result.deleteFailedCount(),
+                    result.expiredCount()
+            );
+        }
+    }
+
+    private void incrementIfPositive(String metricName, int count) {
+        if (count <= 0) {
+            return;
+        }
+        meterRegistry.counter(metricName).increment(count);
+    }
+
+    private void incrementIfPositive(String metricName, String tagKey, String tagValue, int count) {
+        if (count <= 0) {
+            return;
+        }
+        meterRegistry.counter(metricName, tagKey, tagValue).increment(count);
+    }
+}

--- a/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCleanupSchedulerTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/command/MediaCleanupSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.example.media.service.command;
+
+import com.example.media.service.metrics.MediaCleanupMetricsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaCleanupSchedulerTest {
+
+    @Mock
+    private MediaCommandService mediaCommandService;
+
+    @Mock
+    private MediaCleanupMetricsService mediaCleanupMetricsService;
+
+    @InjectMocks
+    private MediaCleanupScheduler mediaCleanupScheduler;
+
+    @Test
+    void expirePendingUploads_recordsCleanupMetrics() {
+        when(mediaCommandService.expirePendingUploads())
+                .thenReturn(new MediaCommandService.ExpireResult(3, 2, 1));
+
+        mediaCleanupScheduler.expirePendingUploads();
+
+        verify(mediaCommandService).expirePendingUploads();
+        verify(mediaCleanupMetricsService).record(any(MediaCommandService.ExpireResult.class), any());
+    }
+}


### PR DESCRIPTION
## 개요

`#657`의 메트릭/알림 기준 요구를 반영해 미디어 cleanup 스케줄러 관측성을 추가했습니다.

### 관련 이슈
- Related #657
- Related #654

### 작업 / 변경 내용
- cleanup 메트릭 수집 서비스 추가
  - `MediaCleanupMetricsService`
  - `media.cleanup.duration`
  - `media.cleanup.expired.total`
  - `media.cleanup.s3.delete.total{result=success|failure}`
  - `media.cleanup.alerts.total{type=delete_failure}`
- `MediaCleanupScheduler`에 실행시간/결과 메트릭 기록 연동
- cleanup 정책 문서에 알림 기준 추가
  - 실패율/지연 기반 권장 경보 조건 정의
- 스케줄러 단위 테스트 추가
  - `MediaCleanupSchedulerTest`

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

실행한 검증:
- `env GRADLE_USER_HOME=/tmp/.gradle-codex ./gradlew :servers:services:media-api:test :servers:services:media-worker:test --no-daemon`

### 참고사항
- 이 PR은 epic 적재용이며, 이슈 자동 Close는 epic -> develop PR에서 일괄 반영 예정입니다.
