### PR TITLE
[MZC-646] feat: media worker webp derivative pipeline + search enricher e2e

### DIFF
--- a/docker/scripts/search_enricher_dlq_verify.sh
+++ b/docker/scripts/search_enricher_dlq_verify.sh
@@ -8,6 +8,7 @@ mkdir -p "$LOG_DIR"
 SEARCH_PORT="${SEARCH_PORT:-18388}"
 PRODUCT_PORT="${PRODUCT_PORT:-18384}"
 MEDIA_PORT="${MEDIA_PORT:-18394}"
+WORKER_PORT="${WORKER_PORT:-18395}"
 ELASTICSEARCH_PORT="${ELASTICSEARCH_PORT:-23173}"
 SELLER_ID="${SELLER_ID:-910001}"
 STORE_ID="${STORE_ID:-920001}"
@@ -23,6 +24,7 @@ PIDS=()
 MEDIA_PID=""
 PRODUCT_PID=""
 SEARCH_PID=""
+WORKER_PID=""
 FAILURES=0
 PASSES=0
 
@@ -238,6 +240,30 @@ start_product() {
   PIDS+=("$PRODUCT_PID")
 }
 
+start_worker() {
+  echo "[INFO] starting media-worker on ${WORKER_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      AWS_PROFILE="$AWS_PROFILE_NAME" \
+      AWS_REGION="$AWS_REGION_NAME" \
+      GRADLE_USER_HOME=/tmp/.gradle-codex \
+      SERVER_PORT="$WORKER_PORT" \
+      SNOWFLAKE_WORKER_ID=15 \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      MEDIA_S3_REGION="$AWS_REGION_NAME" \
+      MEDIA_S3_BUCKET="$MEDIA_BUCKET" \
+      MEDIA_S3_KEY_PREFIX="$MEDIA_PREFIX" \
+      MEDIA_CLOUDFRONT_DOMAIN="$MEDIA_DOMAIN" \
+      MEDIA_WORKER_TASK_DISPATCH_FIXED_DELAY_MS=500 \
+      MEDIA_WORKER_TASK_STALE_RECOVERY_FIXED_DELAY_MS=2000 \
+      MEDIA_WORKER_TASK_STALE_PROCESSING_SECONDS=10 \
+      ./gradlew :servers:services:media-worker:bootRun --no-daemon >>"$LOG_DIR/media-worker.log" 2>&1
+  ) &
+  WORKER_PID="$!"
+  PIDS+=("$WORKER_PID")
+}
+
 start_search() {
   echo "[INFO] starting search-service on ${SEARCH_PORT}"
   (
@@ -299,7 +325,7 @@ recreate_search_index() {
 
 reset_data() {
   echo "[INFO] resetting media/product/search data"
-  psql_exec media_db "TRUNCATE TABLE media_links, media_files, processed_events, dead_letter_messages, outbox_messages RESTART IDENTITY CASCADE;"
+  psql_exec media_db "TRUNCATE TABLE media_derivative_task_dlq, media_derivative_tasks, media_derivatives, media_links, media_files, processed_events, dead_letter_messages, outbox_messages RESTART IDENTITY CASCADE;"
   psql_exec product_db "TRUNCATE TABLE item_images, item_goods_links, item_options, shipping_infos, cast_members, seat_grades, performances, item_status_histories, item_media_link_sync_tasks, items, processed_events, dead_letter_messages, outbox_messages RESTART IDENTITY CASCADE;"
   psql_exec search_db "TRUNCATE TABLE search_indexing_failures, search_thumbnail_enrichment_tasks, processed_events, dead_letter_messages, outbox_messages RESTART IDENTITY CASCADE;"
   pass "reset data complete"
@@ -310,14 +336,16 @@ create_media_and_confirm() {
   local label="$2"
   local tmp_file
   tmp_file="$(mktemp)"
-  printf '%s' "${label}-$(date +%s%N)" >"$tmp_file"
+  local png_base64
+  png_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/aWQAAAAASUVORK5CYII='
+  printf '%s' "$png_base64" | openssl base64 -d -A >"$tmp_file"
   local file_size
   file_size="$(wc -c <"$tmp_file" | tr -d ' ')"
 
   local intent_raw intent_body intent_status
   intent_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${MEDIA_PORT}/api/v1/media/upload-intents" \
     -H "Content-Type: application/json" \
-    -d "{\"fileName\":\"${label}.jpg\",\"contentType\":\"image/jpeg\",\"fileSize\":${file_size}}")"
+    -d "{\"fileName\":\"${label}.png\",\"contentType\":\"image/png\",\"fileSize\":${file_size}}")"
   intent_body="$(extract_http_body "$intent_raw")"
   intent_status="$(extract_http_status "$intent_raw")"
   ensure_http_status "${label} upload-intent status" "$intent_status" "200" || return 1
@@ -334,7 +362,7 @@ create_media_and_confirm() {
 
   local put_status
   put_status="$(curl -sS -o /dev/null -w '%{http_code}' -X PUT "$presigned_url" \
-    -H "Content-Type: image/jpeg" \
+    -H "Content-Type: image/png" \
     --data-binary @"$tmp_file")"
   if [[ "$put_status" == "200" || "$put_status" == "204" ]]; then
     pass "${label} presigned upload"
@@ -354,6 +382,32 @@ create_media_and_confirm() {
 
   rm -f "$tmp_file"
   printf -v "$result_var" '%s' "$media_id"
+}
+
+wait_media_derivative_ready() {
+  local media_id="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  while [[ "$elapsed" -lt "$timeout_seconds" ]]; do
+    local task_status derived_key
+    task_status="$(psql_query media_db "SELECT COALESCE(status, '') FROM media_derivative_tasks WHERE media_id=${media_id} ORDER BY created_at DESC LIMIT 1;")"
+    derived_key="$(psql_query media_db "SELECT COALESCE(object_key, '') FROM media_derivatives WHERE media_id=${media_id} AND derivative_profile='THUMBNAIL_WEBP' AND status='READY' ORDER BY media_version DESC, created_at DESC LIMIT 1;")"
+
+    if [[ "$task_status" == "COMPLETED" && -n "$derived_key" ]]; then
+      pass "media derivative task completed (mediaId=${media_id})"
+      if [[ "$derived_key" == *"/derived/"* && "$derived_key" == *.webp ]]; then
+        pass "media derivative object key is webp derived path (mediaId=${media_id})"
+        return 0
+      fi
+      fail "media derivative object key is invalid (mediaId=${media_id}, key=${derived_key})"
+      return 1
+    fi
+
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  fail "media derivative task timeout (mediaId=${media_id})"
+  return 1
 }
 
 create_product_with_thumbnail() {
@@ -407,9 +461,12 @@ wait_search_thumbnail_url() {
   local query="$2"
   local timeout_seconds="$3"
   local elapsed=0
+  local attempt=0
   while [[ "$elapsed" -lt "$timeout_seconds" ]]; do
-    local raw body status success thumb_url thumb_media
-    raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${SEARCH_PORT}/api/v1/search?q=${query}&size=20")"
+    local raw body status success thumb_url thumb_media page_size
+    # Alternate page size during polling to avoid repeatedly reading a stale cache key.
+    page_size=$((20 + (attempt % 2)))
+    raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${SEARCH_PORT}/api/v1/search?q=${query}&size=${page_size}")"
     body="$(extract_http_body "$raw")"
     status="$(extract_http_status "$raw")"
     success="$(echo "$body" | jq -r '.success // false')"
@@ -423,8 +480,39 @@ wait_search_thumbnail_url() {
     fi
     sleep 2
     elapsed=$((elapsed + 2))
+    attempt=$((attempt + 1))
   done
   fail "search thumbnail snapshot timeout (itemId=${item_id})"
+  return 1
+}
+
+wait_search_thumbnail_url_contains() {
+  local item_id="$1"
+  local query="$2"
+  local required_substring="$3"
+  local timeout_seconds="$4"
+  local elapsed=0
+  local attempt=0
+  while [[ "$elapsed" -lt "$timeout_seconds" ]]; do
+    local raw body status success thumb_url page_size
+    # Alternate page size during polling to avoid repeatedly reading a stale cache key.
+    page_size=$((20 + (attempt % 2)))
+    raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${SEARCH_PORT}/api/v1/search?q=${query}&size=${page_size}")"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    success="$(echo "$body" | jq -r '.success // false')"
+    if [[ "$status" == "200" && "$success" == "true" ]]; then
+      thumb_url="$(echo "$body" | jq -r --arg id "$item_id" '.data.items[]? | select((.itemId|tostring)==$id) | .thumbnailUrl // empty' | head -n1)"
+      if [[ -n "$thumb_url" && "$thumb_url" == *"$required_substring"* ]]; then
+        pass "search thumbnail contains '${required_substring}' (itemId=${item_id})"
+        return 0
+      fi
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+    attempt=$((attempt + 1))
+  done
+  fail "search thumbnail missing '${required_substring}' (itemId=${item_id})"
   return 1
 }
 
@@ -471,13 +559,17 @@ run_enricher_e2e_cases() {
   echo "[INFO] case1: search enricher happy path"
   local media1 item1 title1
   create_media_and_confirm media1 "search-e2e-m1" || return 1
+  wait_media_derivative_ready "$media1" 120 || return 1
   create_product_with_thumbnail "$media1" "search-e2e-item1" item1 title1 || return 1
   wait_search_thumbnail_url "$item1" "$title1" 120 || return 1
+  wait_search_thumbnail_url_contains "$item1" "$title1" "/derived/" 120 || return 1
+  wait_search_thumbnail_url_contains "$item1" "$title1" ".webp" 120 || return 1
   wait_search_task_status "$item1" "COMPLETED" 120 || return 1
 
   echo "[INFO] case2: search enricher retry and recovery"
   local media2 item2 title2
   create_media_and_confirm media2 "search-e2e-m2" || return 1
+  wait_media_derivative_ready "$media2" 120 || return 1
   create_product_with_thumbnail "$media2" "search-e2e-item2" item2 title2 || return 1
 
   stop_media
@@ -531,11 +623,13 @@ require_cmd jq
 require_cmd docker
 require_cmd lsof
 require_cmd mktemp
+require_cmd openssl
 require_cmd wc
 
 check_port_free "$SEARCH_PORT"
 check_port_free "$PRODUCT_PORT"
 check_port_free "$MEDIA_PORT"
+check_port_free "$WORKER_PORT"
 
 echo "[INFO] preparing infra"
 (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka mariadb elasticsearch >/dev/null)
@@ -546,10 +640,12 @@ MEDIA_DOMAIN="$(resolve_media_domain)"
 echo "[INFO] media public domain: ${MEDIA_DOMAIN}"
 
 start_media
+start_worker
 start_product
 start_search
 
 wait_health "media-api" "$MEDIA_PORT"
+wait_health "media-worker" "$WORKER_PORT"
 wait_health "product-service" "$PRODUCT_PORT"
 wait_health "search-service" "$SEARCH_PORT"
 

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivative.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivative.java
@@ -1,0 +1,95 @@
+package com.example.media.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(
+        name = "media_derivatives",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_media_derivatives_media_profile_version",
+                        columnNames = {"media_id", "derivative_profile", "media_version"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_media_derivatives_media_profile", columnList = "media_id,derivative_profile"),
+                @Index(name = "idx_media_derivatives_status", columnList = "status")
+        }
+)
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaDerivative extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "derivative_profile", nullable = false, length = 60)
+    private MediaDerivativeProfile derivativeProfile;
+
+    @Column(name = "media_version", nullable = false)
+    private Long mediaVersion;
+
+    @Column(name = "object_key", nullable = false, length = 600)
+    private String objectKey;
+
+    @Column(name = "url_snapshot", length = 1024)
+    private String urlSnapshot;
+
+    @Column(name = "width", nullable = false)
+    private Integer width;
+
+    @Column(name = "height", nullable = false)
+    private Integer height;
+
+    @Column(name = "content_type", nullable = false, length = 120)
+    private String contentType;
+
+    @Column(name = "size", nullable = false)
+    private Long size;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private MediaDerivativeStatus status;
+
+    public static MediaDerivative createReady(Long mediaId,
+                                              MediaDerivativeProfile derivativeProfile,
+                                              Long mediaVersion,
+                                              String objectKey,
+                                              String urlSnapshot,
+                                              int width,
+                                              int height,
+                                              String contentType,
+                                              long size) {
+        MediaDerivative derivative = new MediaDerivative();
+        derivative.mediaId = mediaId;
+        derivative.derivativeProfile = derivativeProfile;
+        derivative.mediaVersion = mediaVersion;
+        derivative.objectKey = objectKey;
+        derivative.urlSnapshot = urlSnapshot;
+        derivative.width = width;
+        derivative.height = height;
+        derivative.contentType = contentType;
+        derivative.size = size;
+        derivative.status = MediaDerivativeStatus.READY;
+        return derivative;
+    }
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeProfile.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeProfile.java
@@ -1,0 +1,5 @@
+package com.example.media.entity;
+
+public enum MediaDerivativeProfile {
+    THUMBNAIL_WEBP
+}

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeStatus.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeStatus.java
@@ -1,0 +1,6 @@
+package com.example.media.entity;
+
+public enum MediaDerivativeStatus {
+    READY,
+    DELETED
+}

--- a/servers/services/media-api/src/main/java/com/example/media/event/MediaConfirmedEvent.java
+++ b/servers/services/media-api/src/main/java/com/example/media/event/MediaConfirmedEvent.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class MediaConfirmedEvent extends DomainEvent {
 
     private static final int SCHEMA_VERSION = 1;
+    private static final long DEFAULT_MEDIA_VERSION = 1L;
 
     private final Long mediaId;
     private final Long uploaderId;
@@ -25,6 +26,7 @@ public class MediaConfirmedEvent extends DomainEvent {
     private final MediaUsageType usageType;
     private final Integer sortOrder;
     private final String mediaUrl;
+    private final Long mediaVersion;
 
     public MediaConfirmedEvent(Long mediaId,
                                Long uploaderId,
@@ -51,6 +53,7 @@ public class MediaConfirmedEvent extends DomainEvent {
         this.usageType = usageType;
         this.sortOrder = sortOrder;
         this.mediaUrl = mediaUrl;
+        this.mediaVersion = DEFAULT_MEDIA_VERSION;
     }
 
     @Override
@@ -74,6 +77,7 @@ public class MediaConfirmedEvent extends DomainEvent {
         payload.put("usageType", usageType != null ? usageType.name() : null);
         payload.put("sortOrder", sortOrder);
         payload.put("mediaUrl", mediaUrl);
+        payload.put("mediaVersion", mediaVersion);
         return payload;
     }
 }

--- a/servers/services/media-api/src/main/java/com/example/media/repository/MediaDerivativeRepository.java
+++ b/servers/services/media-api/src/main/java/com/example/media/repository/MediaDerivativeRepository.java
@@ -1,0 +1,17 @@
+package com.example.media.repository;
+
+import com.example.media.entity.MediaDerivative;
+import com.example.media.entity.MediaDerivativeProfile;
+import com.example.media.entity.MediaDerivativeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MediaDerivativeRepository extends JpaRepository<MediaDerivative, Long> {
+
+    List<MediaDerivative> findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+            List<Long> mediaIds,
+            MediaDerivativeProfile derivativeProfile,
+            MediaDerivativeStatus status
+    );
+}

--- a/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
@@ -2,10 +2,15 @@ package com.example.media.service.query;
 
 import com.example.core.exception.BusinessException;
 import com.example.media.dto.query.response.MediaUrlResponse;
+import com.example.media.entity.MediaDerivative;
+import com.example.media.entity.MediaDerivativeProfile;
+import com.example.media.entity.MediaDerivativeStatus;
 import com.example.media.entity.MediaFile;
 import com.example.media.entity.MediaLink;
 import com.example.media.entity.MediaStatus;
+import com.example.media.entity.MediaUsageType;
 import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaDerivativeRepository;
 import com.example.media.repository.MediaFileRepository;
 import com.example.media.repository.MediaLinkRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +27,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MediaQueryService {
 
+    private static final MediaDerivativeProfile THUMBNAIL_PROFILE = MediaDerivativeProfile.THUMBNAIL_WEBP;
+
     private final MediaFileRepository mediaFileRepository;
     private final MediaLinkRepository mediaLinkRepository;
+    private final MediaDerivativeRepository mediaDerivativeRepository;
     private final MediaUrlPolicyService mediaUrlPolicyService;
 
     @Transactional(readOnly = true)
@@ -35,7 +43,8 @@ public class MediaQueryService {
         validateStatus(mediaFile);
 
         MediaLink link = mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(mediaId).orElse(null);
-        return toMediaUrlResponse(mediaFile, link);
+        MediaDerivative derivative = findThumbnailDerivative(mediaId);
+        return toMediaUrlResponse(mediaFile, link, derivative);
     }
 
     @Transactional(readOnly = true)
@@ -61,11 +70,24 @@ public class MediaQueryService {
                 .stream()
                 .collect(Collectors.toMap(MediaLink::getMediaId, Function.identity(), (left, right) -> left));
 
+        Map<Long, MediaDerivative> latestThumbnailDerivativeByMediaId = mediaDerivativeRepository
+                .findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                        uniqueIds,
+                        THUMBNAIL_PROFILE,
+                        MediaDerivativeStatus.READY
+                )
+                .stream()
+                .collect(Collectors.toMap(MediaDerivative::getMediaId, Function.identity(), (left, right) -> left));
+
         return uniqueIds.stream()
                 .map(mediaFileMap::get)
                 .filter(Objects::nonNull)
                 .filter(mediaFile -> isAccessibleAndReady(mediaFile, userId))
-                .map(mediaFile -> toMediaUrlResponse(mediaFile, latestLinkByMediaId.get(mediaFile.getId())))
+                .map(mediaFile -> toMediaUrlResponse(
+                        mediaFile,
+                        latestLinkByMediaId.get(mediaFile.getId()),
+                        latestThumbnailDerivativeByMediaId.get(mediaFile.getId())
+                ))
                 .toList();
     }
 
@@ -91,20 +113,52 @@ public class MediaQueryService {
         }
     }
 
-    private MediaUrlResponse toMediaUrlResponse(MediaFile mediaFile, MediaLink link) {
+    private MediaDerivative findThumbnailDerivative(Long mediaId) {
+        return mediaDerivativeRepository
+                .findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                        List.of(mediaId),
+                        THUMBNAIL_PROFILE,
+                        MediaDerivativeStatus.READY
+                )
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    private MediaUrlResponse toMediaUrlResponse(MediaFile mediaFile, MediaLink link, MediaDerivative derivative) {
+        String resolvedObjectKey = resolveObjectKey(mediaFile, link, derivative);
+        MediaUsageType resolvedUsageType = resolveUsageType(link, derivative);
         MediaUrlPolicyService.MediaUrlContract urlContract = mediaUrlPolicyService.resolve(
-                mediaFile.getObjectKey(),
-                link != null ? link.getUsageType() : null
+                resolvedObjectKey,
+                resolvedUsageType
         );
         return MediaUrlResponse.builder()
                 .mediaId(mediaFile.getId())
                 .status(mediaFile.getStatus().name())
-                .objectKey(mediaFile.getObjectKey())
+                .objectKey(resolvedObjectKey)
                 .mediaUrl(urlContract.url())
                 .urlAccessType(urlContract.accessType().name())
                 .urlExpiresAt(urlContract.expiresAt())
                 .cacheControl(urlContract.cacheControl())
-                .usageType(link != null ? link.getUsageType().name() : null)
+                .usageType(resolvedUsageType != null ? resolvedUsageType.name() : null)
                 .build();
+    }
+
+    private String resolveObjectKey(MediaFile mediaFile, MediaLink link, MediaDerivative derivative) {
+        if (derivative != null && shouldUseThumbnailDerivative(link)) {
+            return derivative.getObjectKey();
+        }
+        return mediaFile.getObjectKey();
+    }
+
+    private MediaUsageType resolveUsageType(MediaLink link, MediaDerivative derivative) {
+        if (link != null) {
+            return link.getUsageType();
+        }
+        return null;
+    }
+
+    private boolean shouldUseThumbnailDerivative(MediaLink link) {
+        return link != null && link.getUsageType() == MediaUsageType.THUMBNAIL;
     }
 }

--- a/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
@@ -4,12 +4,16 @@ import com.example.core.exception.BusinessException;
 import com.example.media.config.MediaS3Properties;
 import com.example.media.config.MediaUrlAccessType;
 import com.example.media.config.MediaUrlProperties;
+import com.example.media.entity.MediaDerivative;
+import com.example.media.entity.MediaDerivativeProfile;
+import com.example.media.entity.MediaDerivativeStatus;
 import com.example.media.dto.query.response.MediaUrlResponse;
 import com.example.media.entity.MediaFile;
 import com.example.media.entity.MediaLink;
 import com.example.media.entity.MediaOwnerType;
 import com.example.media.entity.MediaUsageType;
 import com.example.media.exception.MediaErrorCode;
+import com.example.media.repository.MediaDerivativeRepository;
 import com.example.media.repository.MediaFileRepository;
 import com.example.media.repository.MediaLinkRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +40,9 @@ class MediaQueryServiceTest {
     @Mock
     private MediaLinkRepository mediaLinkRepository;
 
+    @Mock
+    private MediaDerivativeRepository mediaDerivativeRepository;
+
     private MediaQueryService mediaQueryService;
 
     private MediaUrlProperties mediaUrlProperties;
@@ -50,7 +57,12 @@ class MediaQueryServiceTest {
         mediaUrlProperties.setSignedUrlTtlSeconds(300);
 
         MediaUrlPolicyService mediaUrlPolicyService = new MediaUrlPolicyService(mediaS3Properties, mediaUrlProperties);
-        mediaQueryService = new MediaQueryService(mediaFileRepository, mediaLinkRepository, mediaUrlPolicyService);
+        mediaQueryService = new MediaQueryService(
+                mediaFileRepository,
+                mediaLinkRepository,
+                mediaDerivativeRepository,
+                mediaUrlPolicyService
+        );
     }
 
     @Test
@@ -76,6 +88,11 @@ class MediaQueryServiceTest {
 
         when(mediaFileRepository.findById(101L)).thenReturn(Optional.of(mediaFile));
         when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(101L)).thenReturn(Optional.of(mediaLink));
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                List.of(101L),
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(List.of());
 
         MediaUrlResponse response = mediaQueryService.getMediaUrl(101L, 100L);
 
@@ -110,6 +127,11 @@ class MediaQueryServiceTest {
 
         when(mediaFileRepository.findById(102L)).thenReturn(Optional.of(mediaFile));
         when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(102L)).thenReturn(Optional.empty());
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                List.of(102L),
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(List.of());
 
         MediaUrlResponse response = mediaQueryService.getMediaUrl(102L, 100L);
 
@@ -184,11 +206,74 @@ class MediaQueryServiceTest {
                 .thenReturn(List.of(confirmed, pending));
         when(mediaLinkRepository.findByMediaIdInOrderByMediaIdAscCreatedAtDesc(List.of(201L, 202L, 999L)))
                 .thenReturn(List.of(link));
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                List.of(201L, 202L, 999L),
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(List.of());
 
         List<MediaUrlResponse> responses = mediaQueryService.getMediaUrls(List.of(201L, 202L, 999L), 100L);
 
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getMediaId()).isEqualTo(201L);
         assertThat(responses.get(0).getMediaUrl()).contains("cloudfront.net");
+    }
+
+    @Test
+    void getMediaUrls_prefersReadyThumbnailDerivativeForThumbnailUsage() {
+        MediaFile confirmed = MediaFile.createPending(
+                100L,
+                "ready-derived.jpg",
+                "team2-donmoa-media/raw/2026/01/01/ready-derived.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-derived",
+                LocalDateTime.now().plusMinutes(1)
+        );
+        ReflectionTestUtils.setField(confirmed, "id", 301L);
+        confirmed.confirm(1024L, "image/jpeg", "etag-derived", LocalDateTime.now());
+
+        MediaLink link = MediaLink.create(301L, MediaOwnerType.ITEM, 777L, MediaUsageType.THUMBNAIL, 0);
+        MediaDerivative derivative = createReadyDerivative(
+                301L,
+                "team2-donmoa-media/derived/2026/01/01/ready-derived_thumbnail_webp_v1.webp"
+        );
+
+        when(mediaFileRepository.findAllById(List.of(301L)))
+                .thenReturn(List.of(confirmed));
+        when(mediaLinkRepository.findByMediaIdInOrderByMediaIdAscCreatedAtDesc(List.of(301L)))
+                .thenReturn(List.of(link));
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                List.of(301L),
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(List.of(derivative));
+
+        List<MediaUrlResponse> responses = mediaQueryService.getMediaUrls(List.of(301L), 100L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getObjectKey()).isEqualTo(derivative.getObjectKey());
+        assertThat(responses.get(0).getMediaUrl()).contains("/derived/");
+    }
+
+    private MediaDerivative createReadyDerivative(Long mediaId, String objectKey) {
+        MediaDerivative derivative = MediaDerivative.createReady(
+                mediaId,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                1L,
+                objectKey,
+                "https://cdn.example.com/" + objectKey,
+                640,
+                360,
+                "image/webp",
+                12345L
+        );
+        ReflectionTestUtils.setField(derivative, "id", 9001L);
+        return derivative;
     }
 }

--- a/servers/services/media-worker/build.gradle.kts
+++ b/servers/services/media-worker/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     // AWS SDK
     implementation(platform("software.amazon.awssdk:bom:2.31.77"))
     implementation("software.amazon.awssdk:s3")
+    implementation("com.sksamuel.scrimage:scrimage-webp:4.1.3")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/MediaWorkerApplication.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/MediaWorkerApplication.java
@@ -2,12 +2,16 @@ package com.example.mediaworker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
 @EnableScheduling
 @SpringBootApplication(scanBasePackages = {"com.example.mediaworker", "com.example.api.handler"})
+@EntityScan(basePackages = "com.example.mediaworker")
+@EnableJpaRepositories(basePackages = "com.example.mediaworker")
 public class MediaWorkerApplication {
 
     public static void main(String[] args) {

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerDerivativeProperties.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerDerivativeProperties.java
@@ -1,0 +1,18 @@
+package com.example.mediaworker.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "media.worker.derivative")
+public class MediaWorkerDerivativeProperties {
+
+    private boolean enabled = true;
+    private int thumbnailMaxWidth = 640;
+    private int thumbnailMaxHeight = 640;
+    private float webpQuality = 0.82f;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerS3Config.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerS3Config.java
@@ -1,0 +1,19 @@
+package com.example.mediaworker.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@EnableConfigurationProperties(MediaWorkerS3Properties.class)
+public class MediaWorkerS3Config {
+
+    @Bean
+    public S3Client mediaWorkerS3Client(MediaWorkerS3Properties properties) {
+        return S3Client.builder()
+                .region(Region.of(properties.getRegion()))
+                .build();
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerS3Properties.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerS3Properties.java
@@ -1,0 +1,16 @@
+package com.example.mediaworker.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "media.s3")
+public class MediaWorkerS3Properties {
+
+    private String region = "ap-northeast-2";
+    private String bucket = "team2-donmoa-media-raw";
+    private String keyPrefix = "team2-donmoa-media";
+    private String cloudfrontDomain;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerTaskProperties.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerTaskProperties.java
@@ -1,0 +1,21 @@
+package com.example.mediaworker.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "media.worker.tasks")
+public class MediaWorkerTaskProperties {
+
+    private int batchSize = 20;
+    private int maxRetryCount = 5;
+    private long dispatchFixedDelayMs = 3_000L;
+    private long staleRecoveryFixedDelayMs = 30_000L;
+    private long staleProcessingSeconds = 180L;
+    private long retryInitialDelaySeconds = 5L;
+    private long retryMaxDelaySeconds = 300L;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
@@ -2,6 +2,10 @@ package com.example.mediaworker.consumer;
 
 import com.example.core.util.JsonUtils;
 import com.example.mediaworker.dto.MediaEventMessage;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.service.MediaDerivativeTaskService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -9,7 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class MediaConfirmedEventConsumer {
+
+    private static final long DEFAULT_MEDIA_VERSION = 1L;
+
+    private final MediaDerivativeTaskService mediaDerivativeTaskService;
 
     @KafkaListener(topics = "${media.worker.confirmed-topic:media.confirmed}", groupId = "${media.worker.group-id:media-worker-group}")
     @Transactional
@@ -20,10 +29,18 @@ public class MediaConfirmedEventConsumer {
                 log.warn("[MediaWorker] invalid event payload. payload={}", payload);
                 return;
             }
-            // TODO(#654, #656): 후속 워커 분리 시 ownerType 별 변환 파이프라인으로 라우팅한다.
-            log.info(
-                    "[MediaWorker] confirmed event received. mediaId={}, ownerType={}, ownerId={}, usageType={}, objectKey={}",
+            MediaDerivativeTask task = mediaDerivativeTaskService.enqueuePending(
                     event.getMediaId(),
+                    normalizeMediaVersion(event.getMediaVersion()),
+                    MediaDerivativeProfile.THUMBNAIL_WEBP,
+                    event.getEventId()
+            );
+            log.info(
+                    "[MediaWorker] confirmed event accepted. taskId={}, mediaId={}, profile={}, version={}, ownerType={}, ownerId={}, usageType={}, objectKey={}",
+                    task.getId(),
+                    task.getMediaId(),
+                    task.getDerivativeProfile(),
+                    task.getMediaVersion(),
                     event.getOwnerType(),
                     event.getOwnerId(),
                     event.getUsageType(),
@@ -40,5 +57,12 @@ public class MediaConfirmedEventConsumer {
                 && event.getEventId() != null
                 && event.getEventType() != null
                 && event.getMediaId() != null;
+    }
+
+    private long normalizeMediaVersion(Long mediaVersion) {
+        if (mediaVersion == null || mediaVersion < DEFAULT_MEDIA_VERSION) {
+            return DEFAULT_MEDIA_VERSION;
+        }
+        return mediaVersion;
     }
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/MediaEventMessage.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/MediaEventMessage.java
@@ -22,4 +22,5 @@ public class MediaEventMessage {
     private String usageType;
     private Integer sortOrder;
     private String mediaUrl;
+    private Long mediaVersion;
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivative.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivative.java
@@ -1,0 +1,111 @@
+package com.example.mediaworker.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(
+        name = "media_derivatives",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_media_derivatives_media_profile_version",
+                        columnNames = {"media_id", "derivative_profile", "media_version"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_media_derivatives_media_profile", columnList = "media_id,derivative_profile"),
+                @Index(name = "idx_media_derivatives_status", columnList = "status")
+        }
+)
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaDerivative extends BaseEntity {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "derivative_profile", nullable = false, length = 60)
+    private MediaDerivativeProfile derivativeProfile;
+
+    @Column(name = "media_version", nullable = false)
+    private Long mediaVersion;
+
+    @Column(name = "object_key", nullable = false, length = 600)
+    private String objectKey;
+
+    @Column(name = "url_snapshot", length = 1024)
+    private String urlSnapshot;
+
+    @Column(name = "width", nullable = false)
+    private Integer width;
+
+    @Column(name = "height", nullable = false)
+    private Integer height;
+
+    @Column(name = "content_type", nullable = false, length = 120)
+    private String contentType;
+
+    @Column(name = "size", nullable = false)
+    private Long size;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private MediaDerivativeStatus status;
+
+    public static MediaDerivative createReady(Long mediaId,
+                                              MediaDerivativeProfile derivativeProfile,
+                                              Long mediaVersion,
+                                              String objectKey,
+                                              String urlSnapshot,
+                                              int width,
+                                              int height,
+                                              String contentType,
+                                              long size) {
+        MediaDerivative derivative = new MediaDerivative();
+        derivative.mediaId = mediaId;
+        derivative.derivativeProfile = derivativeProfile;
+        derivative.mediaVersion = mediaVersion;
+        derivative.objectKey = objectKey;
+        derivative.urlSnapshot = urlSnapshot;
+        derivative.width = width;
+        derivative.height = height;
+        derivative.contentType = contentType;
+        derivative.size = size;
+        derivative.status = MediaDerivativeStatus.READY;
+        return derivative;
+    }
+
+    public void replaceWith(String objectKey,
+                            String urlSnapshot,
+                            int width,
+                            int height,
+                            String contentType,
+                            long size) {
+        this.objectKey = objectKey;
+        this.urlSnapshot = urlSnapshot;
+        this.width = width;
+        this.height = height;
+        this.contentType = contentType;
+        this.size = size;
+        this.status = MediaDerivativeStatus.READY;
+        restore();
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeProfile.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeProfile.java
@@ -1,0 +1,5 @@
+package com.example.mediaworker.entity;
+
+public enum MediaDerivativeProfile {
+    THUMBNAIL_WEBP
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeStatus.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeStatus.java
@@ -1,0 +1,6 @@
+package com.example.mediaworker.entity;
+
+public enum MediaDerivativeStatus {
+    READY,
+    DELETED
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTask.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTask.java
@@ -1,0 +1,152 @@
+package com.example.mediaworker.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "media_derivative_tasks",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_media_derivative_tasks_media_profile_version",
+                        columnNames = {"media_id", "derivative_profile", "media_version"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_media_derivative_tasks_status_next_retry", columnList = "status,next_retry_at"),
+                @Index(name = "idx_media_derivative_tasks_status_updated", columnList = "status,updated_at")
+        }
+)
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaDerivativeTask extends BaseEntity {
+
+    private static final int LAST_ERROR_MAX_LENGTH = 500;
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "derivative_profile", nullable = false, length = 60)
+    private MediaDerivativeProfile derivativeProfile;
+
+    @Column(name = "media_version", nullable = false)
+    private Long mediaVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private MediaDerivativeTaskStatus status;
+
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "processing_started_at")
+    private LocalDateTime processingStartedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "source_event_id", length = 120)
+    private String sourceEventId;
+
+    @Column(name = "last_error", length = LAST_ERROR_MAX_LENGTH)
+    private String lastError;
+
+    public static MediaDerivativeTask createPending(Long mediaId,
+                                                    MediaDerivativeProfile derivativeProfile,
+                                                    Long mediaVersion,
+                                                    String sourceEventId) {
+        MediaDerivativeTask task = new MediaDerivativeTask();
+        task.mediaId = mediaId;
+        task.derivativeProfile = derivativeProfile;
+        task.mediaVersion = mediaVersion;
+        task.status = MediaDerivativeTaskStatus.PENDING;
+        task.retryCount = 0;
+        task.sourceEventId = sourceEventId;
+        task.nextRetryAt = null;
+        task.processingStartedAt = null;
+        task.completedAt = null;
+        task.lastError = null;
+        return task;
+    }
+
+    public boolean isTerminal() {
+        return status == MediaDerivativeTaskStatus.COMPLETED || status == MediaDerivativeTaskStatus.FAILED;
+    }
+
+    public void markCompleted(LocalDateTime completedAt) {
+        assertStatus(MediaDerivativeTaskStatus.PROCESSING);
+        this.status = MediaDerivativeTaskStatus.COMPLETED;
+        this.completedAt = completedAt;
+        this.processingStartedAt = null;
+        this.nextRetryAt = null;
+        this.lastError = null;
+    }
+
+    public void scheduleRetry(LocalDateTime nextRetryAt, String errorMessage) {
+        assertStatus(MediaDerivativeTaskStatus.PROCESSING);
+        this.status = MediaDerivativeTaskStatus.PENDING;
+        this.retryCount = this.retryCount == null ? 1 : this.retryCount + 1;
+        this.processingStartedAt = null;
+        this.nextRetryAt = nextRetryAt;
+        this.lastError = truncate(errorMessage);
+    }
+
+    public void markFailed(String errorMessage, LocalDateTime failedAt) {
+        assertStatus(MediaDerivativeTaskStatus.PROCESSING);
+        this.status = MediaDerivativeTaskStatus.FAILED;
+        this.retryCount = this.retryCount == null ? 1 : this.retryCount + 1;
+        this.processingStartedAt = null;
+        this.nextRetryAt = null;
+        this.completedAt = failedAt;
+        this.lastError = truncate(errorMessage);
+    }
+
+    public void recoverFromStaleProcessing(LocalDateTime retryAt, String errorMessage) {
+        assertStatus(MediaDerivativeTaskStatus.PROCESSING);
+        this.status = MediaDerivativeTaskStatus.PENDING;
+        this.processingStartedAt = null;
+        this.nextRetryAt = retryAt;
+        this.lastError = truncate(errorMessage);
+    }
+
+    private void assertStatus(MediaDerivativeTaskStatus expected) {
+        if (this.status != expected) {
+            throw new IllegalStateException(
+                    "Invalid task state transition. expected=" + expected + ", actual=" + this.status
+            );
+        }
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (value.length() <= LAST_ERROR_MAX_LENGTH) {
+            return value;
+        }
+        return value.substring(0, LAST_ERROR_MAX_LENGTH);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTaskDlq.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTaskDlq.java
@@ -1,0 +1,83 @@
+package com.example.mediaworker.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(
+        name = "media_derivative_task_dlq",
+        indexes = {
+                @Index(name = "idx_media_derivative_task_dlq_task_id", columnList = "task_id"),
+                @Index(name = "idx_media_derivative_task_dlq_media_id", columnList = "media_id")
+        }
+)
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaDerivativeTaskDlq extends BaseEntity {
+
+    private static final int MAX_LENGTH = 500;
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "task_id", nullable = false)
+    private Long taskId;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "derivative_profile", nullable = false, length = 60)
+    private MediaDerivativeProfile derivativeProfile;
+
+    @Column(name = "media_version", nullable = false)
+    private Long mediaVersion;
+
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount;
+
+    @Column(name = "error_code", nullable = false, length = 60)
+    private String errorCode;
+
+    @Column(name = "error_message", length = MAX_LENGTH)
+    private String errorMessage;
+
+    @Column(name = "source_event_id", length = 120)
+    private String sourceEventId;
+
+    public static MediaDerivativeTaskDlq fromTask(MediaDerivativeTask task, String errorCode, String errorMessage) {
+        MediaDerivativeTaskDlq dlq = new MediaDerivativeTaskDlq();
+        dlq.taskId = task.getId();
+        dlq.mediaId = task.getMediaId();
+        dlq.derivativeProfile = task.getDerivativeProfile();
+        dlq.mediaVersion = task.getMediaVersion();
+        dlq.retryCount = task.getRetryCount() == null ? 0 : task.getRetryCount();
+        dlq.errorCode = truncate(errorCode);
+        dlq.errorMessage = truncate(errorMessage);
+        dlq.sourceEventId = task.getSourceEventId();
+        return dlq;
+    }
+
+    private static String truncate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (value.length() <= MAX_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_LENGTH);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTaskStatus.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTaskStatus.java
@@ -1,0 +1,8 @@
+package com.example.mediaworker.entity;
+
+public enum MediaDerivativeTaskStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileRecord.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileRecord.java
@@ -1,0 +1,41 @@
+package com.example.mediaworker.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "media_files")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaFileRecord {
+
+    @Id
+    private Long id;
+
+    @Column(name = "bucket_name", nullable = false, length = 120)
+    private String bucketName;
+
+    @Column(name = "object_key", nullable = false, length = 500)
+    private String objectKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private MediaFileStatus status;
+
+    public boolean isReadyForDerivative() {
+        return status == MediaFileStatus.CONFIRMED || status == MediaFileStatus.READY;
+    }
+
+    public void markReady() {
+        status = MediaFileStatus.READY;
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileStatus.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileStatus.java
@@ -1,0 +1,10 @@
+package com.example.mediaworker.entity;
+
+public enum MediaFileStatus {
+    PENDING_UPLOAD,
+    CONFIRMED,
+    READY,
+    FAILED,
+    EXPIRED,
+    DELETED
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeRepository.java
@@ -1,0 +1,16 @@
+package com.example.mediaworker.repository;
+
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MediaDerivativeRepository extends JpaRepository<MediaDerivative, Long> {
+
+    Optional<MediaDerivative> findByMediaIdAndDerivativeProfileAndMediaVersion(
+            Long mediaId,
+            MediaDerivativeProfile derivativeProfile,
+            Long mediaVersion
+    );
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskDlqRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskDlqRepository.java
@@ -1,0 +1,7 @@
+package com.example.mediaworker.repository;
+
+import com.example.mediaworker.entity.MediaDerivativeTaskDlq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaDerivativeTaskDlqRepository extends JpaRepository<MediaDerivativeTaskDlq, Long> {
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskRepository.java
@@ -1,0 +1,89 @@
+package com.example.mediaworker.repository;
+
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface MediaDerivativeTaskRepository extends JpaRepository<MediaDerivativeTask, Long> {
+
+    Optional<MediaDerivativeTask> findByMediaIdAndDerivativeProfileAndMediaVersion(
+            Long mediaId,
+            MediaDerivativeProfile derivativeProfile,
+            Long mediaVersion
+    );
+
+    @Query("""
+            select task
+            from MediaDerivativeTask task
+            where task.status = :status
+              and (task.nextRetryAt is null or task.nextRetryAt <= :baseTime)
+            order by task.createdAt asc
+            """)
+    List<MediaDerivativeTask> findDueTasks(
+            @Param("status") MediaDerivativeTaskStatus status,
+            @Param("baseTime") LocalDateTime baseTime,
+            Pageable pageable
+    );
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+            update MediaDerivativeTask task
+               set task.status = :nextStatus,
+                   task.processingStartedAt = :processingStartedAt,
+                   task.lastError = null
+             where task.id = :taskId
+               and task.status = :expectedStatus
+               and (task.nextRetryAt is null or task.nextRetryAt <= :baseTime)
+            """)
+    int claimDueTask(
+            @Param("taskId") Long taskId,
+            @Param("expectedStatus") MediaDerivativeTaskStatus expectedStatus,
+            @Param("nextStatus") MediaDerivativeTaskStatus nextStatus,
+            @Param("baseTime") LocalDateTime baseTime,
+            @Param("processingStartedAt") LocalDateTime processingStartedAt
+    );
+
+    @Query("""
+            select task
+            from MediaDerivativeTask task
+            where task.status = :status
+              and task.processingStartedAt is not null
+              and task.processingStartedAt <= :staleBefore
+            order by task.processingStartedAt asc
+            """)
+    List<MediaDerivativeTask> findStaleProcessingTasks(
+            @Param("status") MediaDerivativeTaskStatus status,
+            @Param("staleBefore") LocalDateTime staleBefore,
+            Pageable pageable
+    );
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+            update MediaDerivativeTask task
+               set task.status = :nextStatus,
+                   task.processingStartedAt = null,
+                   task.nextRetryAt = :nextRetryAt,
+                   task.lastError = :lastError
+             where task.id = :taskId
+               and task.status = :expectedStatus
+               and task.processingStartedAt is not null
+               and task.processingStartedAt <= :staleBefore
+            """)
+    int recoverStaleTask(
+            @Param("taskId") Long taskId,
+            @Param("expectedStatus") MediaDerivativeTaskStatus expectedStatus,
+            @Param("nextStatus") MediaDerivativeTaskStatus nextStatus,
+            @Param("nextRetryAt") LocalDateTime nextRetryAt,
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("lastError") String lastError
+    );
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
@@ -1,0 +1,7 @@
+package com.example.mediaworker.repository;
+
+import com.example.mediaworker.entity.MediaFileRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaFileRecordRepository extends JpaRepository<MediaFileRecord, Long> {
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/DerivativeImageResult.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/DerivativeImageResult.java
@@ -1,0 +1,10 @@
+package com.example.mediaworker.service;
+
+public record DerivativeImageResult(
+        byte[] bytes,
+        String contentType,
+        String extension,
+        int width,
+        int height
+) {
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureClassifier.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureClassifier.java
@@ -1,0 +1,38 @@
+package com.example.mediaworker.service;
+
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Component
+public class MediaDerivativeFailureClassifier {
+
+    public MediaDerivativeFailureDecision classify(Exception exception, int nextRetryCount, int maxRetryCount) {
+        boolean retriable = isRetriable(exception);
+        if (!retriable) {
+            return new MediaDerivativeFailureDecision(false, MediaDerivativeFailureCode.NON_RETRIABLE_EXCEPTION);
+        }
+        if (nextRetryCount > maxRetryCount) {
+            return new MediaDerivativeFailureDecision(false, MediaDerivativeFailureCode.MAX_RETRY_EXCEEDED);
+        }
+        return new MediaDerivativeFailureDecision(true, MediaDerivativeFailureCode.RETRIABLE_EXCEPTION);
+    }
+
+    private boolean isRetriable(Exception exception) {
+        if (exception == null) {
+            return true;
+        }
+        if (exception instanceof NonRetriableMediaProcessingException || exception instanceof IllegalArgumentException) {
+            return false;
+        }
+        if (exception instanceof S3Exception s3Exception) {
+            int statusCode = s3Exception.statusCode();
+            return statusCode >= 500 || statusCode == 429 || statusCode == 408;
+        }
+        if (exception instanceof SdkClientException || exception instanceof SdkException) {
+            return true;
+        }
+        return true;
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureCode.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureCode.java
@@ -1,0 +1,7 @@
+package com.example.mediaworker.service;
+
+public enum MediaDerivativeFailureCode {
+    RETRIABLE_EXCEPTION,
+    NON_RETRIABLE_EXCEPTION,
+    MAX_RETRY_EXCEEDED
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureDecision.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureDecision.java
@@ -1,0 +1,7 @@
+package com.example.mediaworker.service;
+
+public record MediaDerivativeFailureDecision(
+        boolean retriable,
+        MediaDerivativeFailureCode failureCode
+) {
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeProcessor.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeProcessor.java
@@ -1,0 +1,8 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.entity.MediaDerivativeTask;
+
+public interface MediaDerivativeProcessor {
+
+    void process(MediaDerivativeTask task);
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskScheduler.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskScheduler.java
@@ -1,0 +1,62 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaDerivativeTaskScheduler {
+
+    private final MediaDerivativeTaskService mediaDerivativeTaskService;
+    private final MediaDerivativeProcessor mediaDerivativeProcessor;
+
+    @Scheduled(fixedDelayString = "${media.worker.tasks.dispatch-fixed-delay-ms:3000}")
+    public void dispatchDueTasks() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Long> claimedTaskIds = mediaDerivativeTaskService.claimDueTaskIds(now);
+        if (claimedTaskIds.isEmpty()) {
+            return;
+        }
+
+        for (Long taskId : claimedTaskIds) {
+            processClaimedTask(taskId);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${media.worker.tasks.stale-recovery-fixed-delay-ms:30000}")
+    public void recoverStaleProcessingTasks() {
+        int recoveredCount = mediaDerivativeTaskService.recoverStaleProcessingTasks(LocalDateTime.now());
+        if (recoveredCount > 0) {
+            log.warn("[MediaWorker] recovered stale processing tasks. count={}", recoveredCount);
+        }
+    }
+
+    private void processClaimedTask(Long taskId) {
+        Optional<MediaDerivativeTask> optionalTask = mediaDerivativeTaskService.findById(taskId);
+        if (optionalTask.isEmpty()) {
+            return;
+        }
+        MediaDerivativeTask task = optionalTask.get();
+        try {
+            mediaDerivativeProcessor.process(task);
+            mediaDerivativeTaskService.markCompleted(taskId, LocalDateTime.now());
+        } catch (Exception exception) {
+            log.warn(
+                    "[MediaWorker] derivative processing failed. taskId={}, mediaId={}, profile={}, reason={}",
+                    task.getId(),
+                    task.getMediaId(),
+                    task.getDerivativeProfile(),
+                    exception.getMessage()
+            );
+            mediaDerivativeTaskService.handleFailure(taskId, exception, LocalDateTime.now());
+        }
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskService.java
@@ -1,0 +1,215 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerTaskProperties;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import com.example.mediaworker.entity.MediaDerivativeTaskDlq;
+import com.example.mediaworker.repository.MediaDerivativeTaskRepository;
+import com.example.mediaworker.repository.MediaDerivativeTaskDlqRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaDerivativeTaskService {
+
+    private static final long MIN_MEDIA_VERSION = 1L;
+    private static final String STALE_PROCESSING_ERROR = "stale processing timeout";
+
+    private final MediaDerivativeTaskRepository mediaDerivativeTaskRepository;
+    private final MediaDerivativeTaskDlqRepository mediaDerivativeTaskDlqRepository;
+    private final MediaWorkerTaskProperties mediaWorkerTaskProperties;
+    private final MediaDerivativeFailureClassifier failureClassifier;
+
+    @Transactional
+    public MediaDerivativeTask enqueuePending(Long mediaId,
+                                              Long mediaVersion,
+                                              MediaDerivativeProfile derivativeProfile,
+                                              String sourceEventId) {
+        if (mediaId == null || mediaId <= 0) {
+            throw new IllegalArgumentException("mediaId must be positive");
+        }
+        if (derivativeProfile == null) {
+            throw new IllegalArgumentException("derivativeProfile is required");
+        }
+        long normalizedVersion = normalizeMediaVersion(mediaVersion);
+
+        Optional<MediaDerivativeTask> existing = mediaDerivativeTaskRepository
+                .findByMediaIdAndDerivativeProfileAndMediaVersion(mediaId, derivativeProfile, normalizedVersion);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        MediaDerivativeTask pendingTask = MediaDerivativeTask.createPending(
+                mediaId,
+                derivativeProfile,
+                normalizedVersion,
+                sourceEventId
+        );
+        try {
+            return mediaDerivativeTaskRepository.save(pendingTask);
+        } catch (DataIntegrityViolationException duplicate) {
+            // 동일 키(mediaId + profile + version) 동시 생성 경쟁 시 재조회로 멱등 처리한다.
+            return mediaDerivativeTaskRepository.findByMediaIdAndDerivativeProfileAndMediaVersion(
+                            mediaId,
+                            derivativeProfile,
+                            normalizedVersion
+                    )
+                    .orElseThrow(() -> duplicate);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MediaDerivativeTask> findById(Long taskId) {
+        return mediaDerivativeTaskRepository.findById(taskId);
+    }
+
+    @Transactional
+    public List<Long> claimDueTaskIds(LocalDateTime now) {
+        int batchSize = Math.max(1, mediaWorkerTaskProperties.getBatchSize());
+        List<MediaDerivativeTask> dueTasks = mediaDerivativeTaskRepository.findDueTasks(
+                MediaDerivativeTaskStatus.PENDING,
+                now,
+                PageRequest.of(0, batchSize)
+        );
+
+        List<Long> claimedTaskIds = new ArrayList<>();
+        for (MediaDerivativeTask dueTask : dueTasks) {
+            int updatedRows = mediaDerivativeTaskRepository.claimDueTask(
+                    dueTask.getId(),
+                    MediaDerivativeTaskStatus.PENDING,
+                    MediaDerivativeTaskStatus.PROCESSING,
+                    now,
+                    now
+            );
+            if (updatedRows == 1) {
+                claimedTaskIds.add(dueTask.getId());
+            }
+        }
+        return claimedTaskIds;
+    }
+
+    @Transactional
+    public int recoverStaleProcessingTasks(LocalDateTime now) {
+        int batchSize = Math.max(1, mediaWorkerTaskProperties.getBatchSize());
+        LocalDateTime staleBefore = now.minusSeconds(Math.max(1L, mediaWorkerTaskProperties.getStaleProcessingSeconds()));
+
+        List<MediaDerivativeTask> staleTasks = mediaDerivativeTaskRepository.findStaleProcessingTasks(
+                MediaDerivativeTaskStatus.PROCESSING,
+                staleBefore,
+                PageRequest.of(0, batchSize)
+        );
+
+        int recoveredCount = 0;
+        for (MediaDerivativeTask staleTask : staleTasks) {
+            int updatedRows = mediaDerivativeTaskRepository.recoverStaleTask(
+                    staleTask.getId(),
+                    MediaDerivativeTaskStatus.PROCESSING,
+                    MediaDerivativeTaskStatus.PENDING,
+                    now,
+                    staleBefore,
+                    STALE_PROCESSING_ERROR
+            );
+            if (updatedRows == 1) {
+                recoveredCount++;
+            }
+        }
+        return recoveredCount;
+    }
+
+    @Transactional
+    public void markCompleted(Long taskId, LocalDateTime completedAt) {
+        mediaDerivativeTaskRepository.findById(taskId).ifPresent(task -> {
+            if (task.getStatus() == MediaDerivativeTaskStatus.COMPLETED) {
+                return;
+            }
+            if (task.getStatus() != MediaDerivativeTaskStatus.PROCESSING) {
+                log.warn(
+                        "[MediaWorker] skip complete. taskId={}, status={}",
+                        task.getId(),
+                        task.getStatus()
+                );
+                return;
+            }
+            task.markCompleted(completedAt);
+        });
+    }
+
+    @Transactional
+    public void handleFailure(Long taskId, Exception exception, LocalDateTime now) {
+        mediaDerivativeTaskRepository.findById(taskId).ifPresent(task -> {
+            if (task.getStatus() != MediaDerivativeTaskStatus.PROCESSING) {
+                log.warn(
+                        "[MediaWorker] skip failure handling. taskId={}, status={}",
+                        task.getId(),
+                        task.getStatus()
+                );
+                return;
+            }
+
+            String errorMessage = buildErrorMessage(exception);
+            int nextRetryCount = task.getRetryCount() == null ? 1 : task.getRetryCount() + 1;
+            MediaDerivativeFailureDecision decision = failureClassifier.classify(
+                    exception,
+                    nextRetryCount,
+                    mediaWorkerTaskProperties.getMaxRetryCount()
+            );
+            if (!decision.retriable()) {
+                task.markFailed(errorMessage, now);
+                mediaDerivativeTaskDlqRepository.save(
+                        MediaDerivativeTaskDlq.fromTask(task, decision.failureCode().name(), errorMessage)
+                );
+                return;
+            }
+
+            long backoffSeconds = calculateBackoffSeconds(nextRetryCount);
+            task.scheduleRetry(now.plusSeconds(backoffSeconds), errorMessage);
+        });
+    }
+
+    private long normalizeMediaVersion(Long mediaVersion) {
+        if (mediaVersion == null || mediaVersion < MIN_MEDIA_VERSION) {
+            return MIN_MEDIA_VERSION;
+        }
+        return mediaVersion;
+    }
+
+    private String buildErrorMessage(Exception exception) {
+        if (exception == null) {
+            return "unknown worker exception";
+        }
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return exception.getClass().getSimpleName();
+        }
+        return exception.getClass().getSimpleName() + ": " + message;
+    }
+
+    private long calculateBackoffSeconds(int retryCount) {
+        long initialDelay = Math.max(1L, mediaWorkerTaskProperties.getRetryInitialDelaySeconds());
+        long maxDelay = Math.max(initialDelay, mediaWorkerTaskProperties.getRetryMaxDelaySeconds());
+        long delay = initialDelay;
+
+        for (int attempt = 1; attempt < retryCount; attempt++) {
+            if (delay >= maxDelay) {
+                return maxDelay;
+            }
+            if (delay > maxDelay / 2) {
+                return maxDelay;
+            }
+            delay = delay * 2;
+        }
+        return Math.min(delay, maxDelay);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/NonRetriableMediaProcessingException.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/NonRetriableMediaProcessingException.java
@@ -1,0 +1,12 @@
+package com.example.mediaworker.service;
+
+public class NonRetriableMediaProcessingException extends RuntimeException {
+
+    public NonRetriableMediaProcessingException(String message) {
+        super(message);
+    }
+
+    public NonRetriableMediaProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/NoopMediaDerivativeProcessor.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/NoopMediaDerivativeProcessor.java
@@ -1,0 +1,24 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "media.worker.derivative", name = "enabled", havingValue = "false")
+public class NoopMediaDerivativeProcessor implements MediaDerivativeProcessor {
+
+    @Override
+    public void process(MediaDerivativeTask task) {
+        log.info(
+                "[MediaWorker] processed derivative task(no-op). taskId={}, mediaId={}, profile={}, version={}, retryCount={}",
+                task.getId(),
+                task.getMediaId(),
+                task.getDerivativeProfile(),
+                task.getMediaVersion(),
+                task.getRetryCount()
+        );
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/S3MediaDerivativeProcessor.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/S3MediaDerivativeProcessor.java
@@ -1,0 +1,259 @@
+package com.example.mediaworker.service;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.webp.WebpWriter;
+import com.example.mediaworker.config.MediaWorkerDerivativeProperties;
+import com.example.mediaworker.config.MediaWorkerS3Properties;
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.entity.MediaFileStatus;
+import com.example.mediaworker.repository.MediaDerivativeRepository;
+import com.example.mediaworker.repository.MediaFileRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import javax.imageio.ImageIO;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Locale;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "media.worker.derivative", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class S3MediaDerivativeProcessor implements MediaDerivativeProcessor {
+
+    private final S3Client mediaWorkerS3Client;
+    private final MediaWorkerS3Properties mediaWorkerS3Properties;
+    private final MediaWorkerDerivativeProperties derivativeProperties;
+    private final MediaFileRecordRepository mediaFileRecordRepository;
+    private final MediaDerivativeRepository mediaDerivativeRepository;
+
+    @Override
+    @Transactional
+    public void process(MediaDerivativeTask task) {
+        if (!derivativeProperties.isEnabled()) {
+            return;
+        }
+
+        MediaFileRecord mediaFileRecord = mediaFileRecordRepository.findById(task.getMediaId())
+                .orElseThrow(() -> new NonRetriableMediaProcessingException("media file not found: " + task.getMediaId()));
+        if (!mediaFileRecord.isReadyForDerivative()) {
+            throw new NonRetriableMediaProcessingException("media file is not ready for derivative: " + task.getMediaId());
+        }
+
+        ResponseBytes<GetObjectResponse> sourceBytes = mediaWorkerS3Client.getObjectAsBytes(
+                GetObjectRequest.builder()
+                        .bucket(mediaFileRecord.getBucketName())
+                        .key(mediaFileRecord.getObjectKey())
+                        .build()
+        );
+
+        BufferedImage sourceImage = decodeImage(sourceBytes.asByteArray());
+        DerivativeImageResult derivativeImage = toThumbnailImage(sourceImage);
+        String objectKey = buildDerivativeObjectKey(mediaFileRecord.getObjectKey(), task, derivativeImage.extension());
+        uploadDerivative(mediaFileRecord.getBucketName(), objectKey, derivativeImage);
+
+        String urlSnapshot = buildBaseUrl(objectKey);
+        MediaDerivative derivative = mediaDerivativeRepository
+                .findByMediaIdAndDerivativeProfileAndMediaVersion(
+                        task.getMediaId(),
+                        task.getDerivativeProfile(),
+                        task.getMediaVersion()
+                )
+                .orElseGet(() -> MediaDerivative.createReady(
+                        task.getMediaId(),
+                        task.getDerivativeProfile(),
+                        task.getMediaVersion(),
+                        objectKey,
+                        urlSnapshot,
+                        derivativeImage.width(),
+                        derivativeImage.height(),
+                        derivativeImage.contentType(),
+                        derivativeImage.bytes().length
+                ));
+
+        derivative.replaceWith(
+                objectKey,
+                urlSnapshot,
+                derivativeImage.width(),
+                derivativeImage.height(),
+                derivativeImage.contentType(),
+                derivativeImage.bytes().length
+        );
+        mediaDerivativeRepository.save(derivative);
+
+        if (mediaFileRecord.getStatus() == MediaFileStatus.CONFIRMED) {
+            mediaFileRecord.markReady();
+        }
+    }
+
+    private BufferedImage decodeImage(byte[] bytes) {
+        try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
+            BufferedImage sourceImage = ImageIO.read(input);
+            if (sourceImage == null) {
+                throw new NonRetriableMediaProcessingException("unsupported or corrupted source image");
+            }
+            return sourceImage;
+        } catch (IOException e) {
+            throw new NonRetriableMediaProcessingException("failed to decode image", e);
+        }
+    }
+
+    private DerivativeImageResult toThumbnailImage(BufferedImage sourceImage) {
+        int sourceWidth = sourceImage.getWidth();
+        int sourceHeight = sourceImage.getHeight();
+        int[] targetSize = calculateTargetSize(
+                sourceWidth,
+                sourceHeight,
+                derivativeProperties.getThumbnailMaxWidth(),
+                derivativeProperties.getThumbnailMaxHeight()
+        );
+
+        BufferedImage resized = new BufferedImage(targetSize[0], targetSize[1], BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = resized.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.drawImage(sourceImage, 0, 0, targetSize[0], targetSize[1], null);
+        } finally {
+            graphics.dispose();
+        }
+
+        return encodeImage(resized);
+    }
+
+    private int[] calculateTargetSize(int sourceWidth, int sourceHeight, int maxWidth, int maxHeight) {
+        if (sourceWidth <= 0 || sourceHeight <= 0) {
+            throw new NonRetriableMediaProcessingException("invalid source image size");
+        }
+        double widthRatio = (double) Math.max(1, maxWidth) / sourceWidth;
+        double heightRatio = (double) Math.max(1, maxHeight) / sourceHeight;
+        double ratio = Math.min(1.0d, Math.min(widthRatio, heightRatio));
+        int targetWidth = Math.max(1, (int) Math.round(sourceWidth * ratio));
+        int targetHeight = Math.max(1, (int) Math.round(sourceHeight * ratio));
+        return new int[]{targetWidth, targetHeight};
+    }
+
+    private DerivativeImageResult encodeImage(BufferedImage image) {
+        int quality = toWebpQuality(derivativeProperties.getWebpQuality());
+        try {
+            byte[] encoded = ImmutableImage.fromAwt(image)
+                    .forWriter(WebpWriter.DEFAULT.withQ(quality))
+                    .bytes();
+            return new DerivativeImageResult(
+                    encoded,
+                    "image/webp",
+                    "webp",
+                    image.getWidth(),
+                    image.getHeight()
+            );
+        } catch (IOException | RuntimeException e) {
+            throw new NonRetriableMediaProcessingException("failed to encode webp image", e);
+        }
+    }
+
+    private int toWebpQuality(float value) {
+        float clamped = Math.max(0.1f, Math.min(1.0f, value));
+        return Math.round(clamped * 100.0f);
+    }
+
+    private String buildDerivativeObjectKey(String sourceObjectKey, MediaDerivativeTask task, String extension) {
+        String normalized = sourceObjectKey == null ? "" : sourceObjectKey.trim();
+        String baseName = normalized;
+        int extensionIndex = baseName.lastIndexOf('.');
+        if (extensionIndex > 0) {
+            baseName = baseName.substring(0, extensionIndex);
+        }
+
+        String derivedPrefix;
+        if (normalized.contains("/raw/")) {
+            derivedPrefix = normalized.replace("/raw/", "/derived/");
+            if (extensionIndex > 0) {
+                derivedPrefix = derivedPrefix.substring(0, derivedPrefix.lastIndexOf('.'));
+            }
+        } else {
+            LocalDate now = LocalDate.now();
+            derivedPrefix = trimSlash(mediaWorkerS3Properties.getKeyPrefix()) + "/derived/"
+                    + now.getYear() + "/" + now.getMonthValue() + "/" + now.getDayOfMonth()
+                    + "/" + sanitize(task.getMediaId() + "_" + baseName);
+        }
+
+        String profileSegment = task.getDerivativeProfile().name().toLowerCase(Locale.ROOT);
+        return derivedPrefix
+                + "_"
+                + profileSegment
+                + "_v"
+                + task.getMediaVersion()
+                + "."
+                + extension;
+    }
+
+    private void uploadDerivative(String bucketName, String objectKey, DerivativeImageResult derivativeImage) {
+        mediaWorkerS3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(objectKey)
+                        .contentType(derivativeImage.contentType())
+                        .contentLength((long) derivativeImage.bytes().length)
+                        .build(),
+                RequestBody.fromBytes(derivativeImage.bytes())
+        );
+    }
+
+    private String buildBaseUrl(String objectKey) {
+        if (!StringUtils.hasText(objectKey)) {
+            return null;
+        }
+        if (StringUtils.hasText(mediaWorkerS3Properties.getCloudfrontDomain())) {
+            String domain = mediaWorkerS3Properties.getCloudfrontDomain().trim();
+            if (domain.endsWith("/")) {
+                domain = domain.substring(0, domain.length() - 1);
+            }
+            return domain + "/" + objectKey;
+        }
+        return "https://" + mediaWorkerS3Properties.getBucket().trim()
+                + ".s3."
+                + mediaWorkerS3Properties.getRegion().trim()
+                + ".amazonaws.com/"
+                + objectKey;
+    }
+
+    private String trimSlash(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        String result = value.trim();
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private String sanitize(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "media";
+        }
+        return value.replaceAll("[^a-zA-Z0-9/_-]", "_");
+    }
+}

--- a/servers/services/media-worker/src/main/resources/application.yml
+++ b/servers/services/media-worker/src/main/resources/application.yml
@@ -27,9 +27,27 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
 
 media:
+  s3:
+    region: ${MEDIA_S3_REGION:ap-northeast-2}
+    bucket: ${MEDIA_S3_BUCKET:team2-donmoa-media-raw}
+    key-prefix: ${MEDIA_S3_KEY_PREFIX:team2-donmoa-media}
+    cloudfront-domain: ${MEDIA_CLOUDFRONT_DOMAIN:}
   worker:
     group-id: ${MEDIA_WORKER_GROUP_ID:media-worker-group}
     confirmed-topic: ${MEDIA_CONFIRMED_TOPIC:media.confirmed}
+    derivative:
+      enabled: ${MEDIA_WORKER_DERIVATIVE_ENABLED:true}
+      thumbnail-max-width: ${MEDIA_WORKER_DERIVATIVE_THUMBNAIL_MAX_WIDTH:640}
+      thumbnail-max-height: ${MEDIA_WORKER_DERIVATIVE_THUMBNAIL_MAX_HEIGHT:640}
+      webp-quality: ${MEDIA_WORKER_DERIVATIVE_WEBP_QUALITY:0.82}
+    tasks:
+      batch-size: ${MEDIA_WORKER_TASK_BATCH_SIZE:20}
+      max-retry-count: ${MEDIA_WORKER_TASK_MAX_RETRY_COUNT:5}
+      dispatch-fixed-delay-ms: ${MEDIA_WORKER_TASK_DISPATCH_FIXED_DELAY_MS:3000}
+      stale-recovery-fixed-delay-ms: ${MEDIA_WORKER_TASK_STALE_RECOVERY_FIXED_DELAY_MS:30000}
+      stale-processing-seconds: ${MEDIA_WORKER_TASK_STALE_PROCESSING_SECONDS:180}
+      retry-initial-delay-seconds: ${MEDIA_WORKER_TASK_RETRY_INITIAL_DELAY_SECONDS:5}
+      retry-max-delay-seconds: ${MEDIA_WORKER_TASK_RETRY_MAX_DELAY_SECONDS:300}
 
 app:
   security:

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/entity/MediaDerivativeTaskTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/entity/MediaDerivativeTaskTest.java
@@ -1,0 +1,54 @@
+package com.example.mediaworker.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+class MediaDerivativeTaskTest {
+
+    @Test
+    void markCompleted_requiresProcessingStatus() {
+        MediaDerivativeTask task = MediaDerivativeTask.createPending(1L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-1");
+
+        assertThatThrownBy(() -> task.markCompleted(LocalDateTime.now()))
+                .isInstanceOf(IllegalStateException.class);
+
+        setField(task, "status", MediaDerivativeTaskStatus.PROCESSING);
+        LocalDateTime completedAt = LocalDateTime.now();
+        task.markCompleted(completedAt);
+
+        assertThat(task.getStatus()).isEqualTo(MediaDerivativeTaskStatus.COMPLETED);
+        assertThat(task.getCompletedAt()).isEqualTo(completedAt);
+    }
+
+    @Test
+    void scheduleRetry_movesToPendingAndIncrementsRetryCount() {
+        MediaDerivativeTask task = MediaDerivativeTask.createPending(2L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-2");
+        setField(task, "status", MediaDerivativeTaskStatus.PROCESSING);
+
+        LocalDateTime retryAt = LocalDateTime.now().plusSeconds(30);
+        task.scheduleRetry(retryAt, "temporary failure");
+
+        assertThat(task.getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
+        assertThat(task.getRetryCount()).isEqualTo(1);
+        assertThat(task.getNextRetryAt()).isEqualTo(retryAt);
+    }
+
+    @Test
+    void markFailed_setsTerminalStatus() {
+        MediaDerivativeTask task = MediaDerivativeTask.createPending(3L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-3");
+        setField(task, "status", MediaDerivativeTaskStatus.PROCESSING);
+
+        LocalDateTime failedAt = LocalDateTime.now();
+        task.markFailed("non-retriable failure", failedAt);
+
+        assertThat(task.getStatus()).isEqualTo(MediaDerivativeTaskStatus.FAILED);
+        assertThat(task.getRetryCount()).isEqualTo(1);
+        assertThat(task.getCompletedAt()).isEqualTo(failedAt);
+        assertThat(task.isTerminal()).isTrue();
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeFailureClassifierTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeFailureClassifierTest.java
@@ -1,0 +1,59 @@
+package com.example.mediaworker.service;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MediaDerivativeFailureClassifierTest {
+
+    private final MediaDerivativeFailureClassifier classifier = new MediaDerivativeFailureClassifier();
+
+    @Test
+    void classify_nonRetriableException_returnsNonRetriableDecision() {
+        MediaDerivativeFailureDecision decision = classifier.classify(
+                new NonRetriableMediaProcessingException("broken image"),
+                1,
+                3
+        );
+
+        assertThat(decision.retriable()).isFalse();
+        assertThat(decision.failureCode()).isEqualTo(MediaDerivativeFailureCode.NON_RETRIABLE_EXCEPTION);
+    }
+
+    @Test
+    void classify_retriableWithinLimit_returnsRetriableDecision() {
+        MediaDerivativeFailureDecision decision = classifier.classify(
+                new RuntimeException("temporary network"),
+                1,
+                3
+        );
+
+        assertThat(decision.retriable()).isTrue();
+        assertThat(decision.failureCode()).isEqualTo(MediaDerivativeFailureCode.RETRIABLE_EXCEPTION);
+    }
+
+    @Test
+    void classify_retriableOverLimit_returnsMaxRetryDecision() {
+        MediaDerivativeFailureDecision decision = classifier.classify(
+                new RuntimeException("temporary network"),
+                4,
+                3
+        );
+
+        assertThat(decision.retriable()).isFalse();
+        assertThat(decision.failureCode()).isEqualTo(MediaDerivativeFailureCode.MAX_RETRY_EXCEEDED);
+    }
+
+    @Test
+    void classify_s3ServerError_isRetriable() {
+        S3Exception s3Exception = (S3Exception) S3Exception.builder()
+                .message("server error")
+                .statusCode(503)
+                .build();
+
+        MediaDerivativeFailureDecision decision = classifier.classify(s3Exception, 1, 3);
+
+        assertThat(decision.retriable()).isTrue();
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskSchedulerTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskSchedulerTest.java
@@ -1,0 +1,84 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaDerivativeTaskSchedulerTest {
+
+    @Mock
+    private MediaDerivativeTaskService mediaDerivativeTaskService;
+
+    @Mock
+    private MediaDerivativeProcessor mediaDerivativeProcessor;
+
+    @Test
+    void dispatchDueTasks_onSuccess_marksCompleted() {
+        MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
+                mediaDerivativeTaskService,
+                mediaDerivativeProcessor
+        );
+        MediaDerivativeTask processingTask = MediaDerivativeTask.createPending(1L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-1");
+        ReflectionTestUtils.setField(processingTask, "id", 101L);
+        ReflectionTestUtils.setField(processingTask, "status", MediaDerivativeTaskStatus.PROCESSING);
+
+        when(mediaDerivativeTaskService.claimDueTaskIds(any(LocalDateTime.class))).thenReturn(List.of(101L));
+        when(mediaDerivativeTaskService.findById(101L)).thenReturn(Optional.of(processingTask));
+
+        scheduler.dispatchDueTasks();
+
+        verify(mediaDerivativeProcessor).process(processingTask);
+        verify(mediaDerivativeTaskService).markCompleted(eq(101L), any(LocalDateTime.class));
+        verify(mediaDerivativeTaskService, never()).handleFailure(eq(101L), any(Exception.class), any(LocalDateTime.class));
+    }
+
+    @Test
+    void dispatchDueTasks_onFailure_handlesRetryPath() {
+        MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
+                mediaDerivativeTaskService,
+                mediaDerivativeProcessor
+        );
+        MediaDerivativeTask processingTask = MediaDerivativeTask.createPending(2L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-2");
+        ReflectionTestUtils.setField(processingTask, "id", 102L);
+        ReflectionTestUtils.setField(processingTask, "status", MediaDerivativeTaskStatus.PROCESSING);
+
+        when(mediaDerivativeTaskService.claimDueTaskIds(any(LocalDateTime.class))).thenReturn(List.of(102L));
+        when(mediaDerivativeTaskService.findById(102L)).thenReturn(Optional.of(processingTask));
+        doThrow(new RuntimeException("processing failed")).when(mediaDerivativeProcessor).process(processingTask);
+
+        scheduler.dispatchDueTasks();
+
+        verify(mediaDerivativeTaskService).handleFailure(eq(102L), any(Exception.class), any(LocalDateTime.class));
+        verify(mediaDerivativeTaskService, never()).markCompleted(eq(102L), any(LocalDateTime.class));
+    }
+
+    @Test
+    void recoverStaleProcessingTasks_invokesRecoveryService() {
+        MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
+                mediaDerivativeTaskService,
+                mediaDerivativeProcessor
+        );
+        when(mediaDerivativeTaskService.recoverStaleProcessingTasks(any(LocalDateTime.class))).thenReturn(1);
+
+        scheduler.recoverStaleProcessingTasks();
+
+        verify(mediaDerivativeTaskService).recoverStaleProcessingTasks(any(LocalDateTime.class));
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskServiceTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskServiceTest.java
@@ -1,0 +1,174 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerTaskProperties;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import com.example.mediaworker.repository.MediaDerivativeTaskRepository;
+import com.example.mediaworker.repository.MediaDerivativeTaskDlqRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaDerivativeTaskServiceTest {
+
+    @Mock
+    private MediaDerivativeTaskRepository mediaDerivativeTaskRepository;
+
+    @Mock
+    private MediaDerivativeTaskDlqRepository mediaDerivativeTaskDlqRepository;
+
+    @Mock
+    private MediaDerivativeFailureClassifier failureClassifier;
+
+    private MediaWorkerTaskProperties properties;
+    private MediaDerivativeTaskService mediaDerivativeTaskService;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MediaWorkerTaskProperties();
+        properties.setBatchSize(10);
+        properties.setMaxRetryCount(2);
+        properties.setRetryInitialDelaySeconds(5);
+        properties.setRetryMaxDelaySeconds(60);
+        mediaDerivativeTaskService = new MediaDerivativeTaskService(
+                mediaDerivativeTaskRepository,
+                mediaDerivativeTaskDlqRepository,
+                properties,
+                failureClassifier
+        );
+    }
+
+    @Test
+    void enqueuePending_createsNewTaskWhenAbsent() {
+        when(mediaDerivativeTaskRepository.findByMediaIdAndDerivativeProfileAndMediaVersion(1L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L))
+                .thenReturn(Optional.empty());
+        when(mediaDerivativeTaskRepository.save(any(MediaDerivativeTask.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        MediaDerivativeTask task = mediaDerivativeTaskService.enqueuePending(
+                1L,
+                null,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                "event-1"
+        );
+
+        assertThat(task.getMediaId()).isEqualTo(1L);
+        assertThat(task.getMediaVersion()).isEqualTo(1L);
+        assertThat(task.getDerivativeProfile()).isEqualTo(MediaDerivativeProfile.THUMBNAIL_WEBP);
+        assertThat(task.getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
+        assertThat(task.getRetryCount()).isEqualTo(0);
+    }
+
+    @Test
+    void enqueuePending_whenConcurrentDuplicateInsert_returnsExistingTask() {
+        MediaDerivativeTask existing = MediaDerivativeTask.createPending(2L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-a");
+        ReflectionTestUtils.setField(existing, "id", 200L);
+
+        when(mediaDerivativeTaskRepository.findByMediaIdAndDerivativeProfileAndMediaVersion(2L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(existing));
+        when(mediaDerivativeTaskRepository.save(any(MediaDerivativeTask.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        MediaDerivativeTask task = mediaDerivativeTaskService.enqueuePending(
+                2L,
+                1L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                "event-b"
+        );
+
+        assertThat(task.getId()).isEqualTo(200L);
+        assertThat(task.getMediaId()).isEqualTo(2L);
+    }
+
+    @Test
+    void enqueuePending_rejectsInvalidMediaId() {
+        assertThatThrownBy(() -> mediaDerivativeTaskService.enqueuePending(
+                0L,
+                1L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                "event-invalid"
+        )).isInstanceOf(IllegalArgumentException.class);
+
+        verify(mediaDerivativeTaskRepository, never()).save(any(MediaDerivativeTask.class));
+    }
+
+    @Test
+    void claimDueTaskIds_returnsOnlySuccessfullyClaimedTasks() {
+        LocalDateTime now = LocalDateTime.now();
+        MediaDerivativeTask due1 = MediaDerivativeTask.createPending(10L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-10");
+        ReflectionTestUtils.setField(due1, "id", 101L);
+        MediaDerivativeTask due2 = MediaDerivativeTask.createPending(11L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-11");
+        ReflectionTestUtils.setField(due2, "id", 102L);
+
+        when(mediaDerivativeTaskRepository.findDueTasks(eq(MediaDerivativeTaskStatus.PENDING), eq(now), any(Pageable.class)))
+                .thenReturn(List.of(due1, due2));
+        when(mediaDerivativeTaskRepository.claimDueTask(101L, MediaDerivativeTaskStatus.PENDING, MediaDerivativeTaskStatus.PROCESSING, now, now))
+                .thenReturn(1);
+        when(mediaDerivativeTaskRepository.claimDueTask(102L, MediaDerivativeTaskStatus.PENDING, MediaDerivativeTaskStatus.PROCESSING, now, now))
+                .thenReturn(0);
+
+        List<Long> claimedTaskIds = mediaDerivativeTaskService.claimDueTaskIds(now);
+
+        assertThat(claimedTaskIds).containsExactly(101L);
+    }
+
+    @Test
+    void handleFailure_schedulesRetryBeforeMaxCount() {
+        LocalDateTime now = LocalDateTime.now();
+        MediaDerivativeTask processing = MediaDerivativeTask.createPending(20L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-20");
+        ReflectionTestUtils.setField(processing, "status", MediaDerivativeTaskStatus.PROCESSING);
+        ReflectionTestUtils.setField(processing, "id", 201L);
+
+        when(mediaDerivativeTaskRepository.findById(201L)).thenReturn(Optional.of(processing));
+        when(failureClassifier.classify(any(), eq(1), eq(properties.getMaxRetryCount())))
+                .thenReturn(new MediaDerivativeFailureDecision(true, MediaDerivativeFailureCode.RETRIABLE_EXCEPTION));
+
+        mediaDerivativeTaskService.handleFailure(201L, new RuntimeException("temporary"), now);
+
+        assertThat(processing.getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
+        assertThat(processing.getRetryCount()).isEqualTo(1);
+        assertThat(processing.getNextRetryAt()).isAfter(now.minusSeconds(1));
+        assertThat(processing.getLastError()).contains("RuntimeException");
+        verify(mediaDerivativeTaskDlqRepository, never()).save(any());
+    }
+
+    @Test
+    void handleFailure_marksFailedWhenRetryExceeded() {
+        LocalDateTime now = LocalDateTime.now();
+        properties.setMaxRetryCount(0);
+        MediaDerivativeTask processing = MediaDerivativeTask.createPending(21L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-21");
+        ReflectionTestUtils.setField(processing, "status", MediaDerivativeTaskStatus.PROCESSING);
+        ReflectionTestUtils.setField(processing, "id", 202L);
+
+        when(mediaDerivativeTaskRepository.findById(202L)).thenReturn(Optional.of(processing));
+        when(failureClassifier.classify(any(), eq(1), eq(properties.getMaxRetryCount())))
+                .thenReturn(new MediaDerivativeFailureDecision(false, MediaDerivativeFailureCode.MAX_RETRY_EXCEEDED));
+
+        mediaDerivativeTaskService.handleFailure(202L, new RuntimeException("boom"), now);
+
+        assertThat(processing.getStatus()).isEqualTo(MediaDerivativeTaskStatus.FAILED);
+        assertThat(processing.getRetryCount()).isEqualTo(1);
+        assertThat(processing.getCompletedAt()).isEqualTo(now);
+        verify(mediaDerivativeTaskDlqRepository).save(any());
+    }
+}


### PR DESCRIPTION
## 개요
Media Worker에 파생 썸네일(WebP) 처리 파이프라인을 도입하고, Search Enricher 연계 E2E 검증을 강화했습니다.

### 관련 이슈
- Closes #677

### 작업 / 변경 내용
- Media Worker 파생 처리 상태머신/멱등/재시도/DLQ 엔티티 및 서비스 추가
- `media.confirmed` 이벤트 소비 후 `THUMBNAIL_WEBP` 파생 생성(강제 WebP 인코딩)으로 fallback 제거
- Media API 조회 경로에 파생 썸네일 스냅샷 조회 지원
- Search enricher 통합 E2E 스크립트 보강
  - media-worker 포함 기동/헬스체크
  - 실제 PNG 업로드 후 파생 결과(`/derived/*.webp`) 검증
  - retry/recovery + DLQ 시나리오 검증
  - index recreate 재시도 및 폴링 안정성(캐시 키 고정 회피) 보강

### 테스트 / 체크리스트
- [x] 로컬에서 빌드/테스트 확인 (`./gradlew :servers:services:media-worker:test :servers:services:media-api:test`)
- [x] Search enricher + DLQ E2E 확인 (`bash docker/scripts/search_enricher_dlq_verify.sh`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 이전 WebP 라이브러리의 macOS arm64 네이티브 호환성 이슈를 피하기 위해 `com.sksamuel.scrimage:scrimage-webp` 기반으로 인코딩 경로를 고정했습니다.
