### PR TITLE
[MZC-647] feat: gateway search thumbnail fallback by mediaId

### DIFF
--- a/docker/scripts/gateway_search_fallback_e2e_verify.sh
+++ b/docker/scripts/gateway_search_fallback_e2e_verify.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/gateway_search_fallback_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+GW_PORT="${GW_PORT:-18573}"
+SEARCH_PORT="${SEARCH_PORT:-18588}"
+MEDIA_PORT="${MEDIA_PORT:-18594}"
+ELASTICSEARCH_PORT="${ELASTICSEARCH_PORT:-23173}"
+
+AWS_PROFILE_NAME="${AWS_PROFILE:-mzc}"
+AWS_REGION_NAME="${AWS_REGION:-ap-northeast-2}"
+MEDIA_BUCKET="${MEDIA_BUCKET:-team2-donmoa-media-raw}"
+MEDIA_PREFIX="${MEDIA_PREFIX:-team2-donmoa-media}"
+CF_COMMENT="${CF_DISTRIBUTION_COMMENT:-team2-donmoa-media}"
+MEDIA_CLOUDFRONT_DOMAIN="${MEDIA_CLOUDFRONT_DOMAIN:-}"
+
+INTERNAL_AUTH_TOKEN="${INTERNAL_AUTH_TOKEN:-gw-search-fallback-token}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex}"
+
+PIDS=()
+FAILURES=0
+PASSES=0
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  local body="${4:-}"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+    return 0
+  fi
+  fail "$label (expected=${expected}, actual=${actual})"
+  if [[ -n "$body" ]]; then
+    echo "[DEBUG] ${label} response body=${body}"
+  fi
+  return 1
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+    return 0
+  fi
+  local code message
+  code="$(echo "$body" | jq -r '.error.code // "UNKNOWN"')"
+  message="$(echo "$body" | jq -r '.error.message // ""')"
+  fail "$label (code=${code}, message=${message})"
+  return 1
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port ${port} is already in use"
+    return 1
+  fi
+  pass "port ${port} is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..120}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "$name health is UP"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "$name health timeout (port=${port})"
+  return 1
+}
+
+wait_gateway_ready() {
+  for _ in {1..120}; do
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 \
+      "http://127.0.0.1:${GW_PORT}/bff/v1/search?q=ready-check&size=1" 2>/dev/null || true)"
+    if [[ "$code" == "200" ]]; then
+      pass "client-gateway ready for /bff/v1/search"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "client-gateway ready timeout for /bff/v1/search"
+  return 1
+}
+
+wait_es_up() {
+  for _ in {1..90}; do
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${ELASTICSEARCH_PORT}/_cluster/health" 2>/dev/null || true)"
+    if [[ "$code" == "200" ]]; then
+      pass "elasticsearch is reachable"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "elasticsearch reachability timeout"
+  return 1
+}
+
+resolve_media_domain() {
+  if [[ -n "$MEDIA_CLOUDFRONT_DOMAIN" ]]; then
+    echo "$MEDIA_CLOUDFRONT_DOMAIN"
+    return 0
+  fi
+
+  if command -v aws >/dev/null 2>&1; then
+    local domain
+    domain="$(env AWS_PROFILE="$AWS_PROFILE_NAME" aws cloudfront list-distributions \
+      --query "DistributionList.Items[?Comment=='${CF_COMMENT}'].DomainName | [0]" \
+      --output text 2>/dev/null || true)"
+    if [[ -n "$domain" && "$domain" != "None" ]]; then
+      echo "https://${domain}"
+      return 0
+    fi
+  fi
+
+  echo "https://${MEDIA_BUCKET}.s3.${AWS_REGION_NAME}.amazonaws.com"
+}
+
+start_media() {
+  echo "[INFO] starting media-api on ${MEDIA_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      AWS_PROFILE="$AWS_PROFILE_NAME" \
+      AWS_REGION="$AWS_REGION_NAME" \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$MEDIA_PORT" \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      MEDIA_S3_REGION="$AWS_REGION_NAME" \
+      MEDIA_S3_BUCKET="$MEDIA_BUCKET" \
+      MEDIA_S3_KEY_PREFIX="$MEDIA_PREFIX" \
+      MEDIA_CLOUDFRONT_DOMAIN="$MEDIA_DOMAIN" \
+      ./gradlew :servers:services:media-api:bootRun --no-daemon >>"$LOG_DIR/media-api.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+start_search() {
+  echo "[INFO] starting search-service on ${SEARCH_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$SEARCH_PORT" \
+      SNOWFLAKE_WORKER_ID=31 \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      MEDIA_SERVICE_URL="http://127.0.0.1:${MEDIA_PORT}" \
+      ELASTICSEARCH_URIS="http://127.0.0.1:${ELASTICSEARCH_PORT}" \
+      ./gradlew :servers:services:search:bootRun --no-daemon >>"$LOG_DIR/search.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+start_gateway() {
+  echo "[INFO] starting client-gateway on ${GW_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$GW_PORT" \
+      APP_SERVICE_SEARCH_URL="http://127.0.0.1:${SEARCH_PORT}" \
+      APP_SERVICE_MEDIA_URL="http://127.0.0.1:${MEDIA_PORT}" \
+      GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:gateways:client-gateway:bootRun --no-daemon >>"$LOG_DIR/gateway.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+create_media_and_confirm() {
+  local result_var="$1"
+  local label="$2"
+  local tmp_file
+  tmp_file="$(mktemp)"
+  local png_base64
+  png_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/aWQAAAAASUVORK5CYII='
+  printf '%s' "$png_base64" | openssl base64 -d -A >"$tmp_file"
+  local file_size
+  file_size="$(wc -c <"$tmp_file" | tr -d ' ')"
+
+  local intent_raw intent_body intent_status
+  intent_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${MEDIA_PORT}/api/v1/media/upload-intents" \
+    -H "Content-Type: application/json" \
+    -d "{\"fileName\":\"${label}.png\",\"contentType\":\"image/png\",\"fileSize\":${file_size}}")"
+  intent_body="$(extract_http_body "$intent_raw")"
+  intent_status="$(extract_http_status "$intent_raw")"
+  ensure_http_status "${label} upload-intent status" "$intent_status" "200" "$intent_body" || return 1
+  ensure_json_success "${label} upload-intent success" "$intent_body" || return 1
+
+  local media_id presigned_url upload_token
+  media_id="$(echo "$intent_body" | jq -r '.data.mediaId // empty')"
+  presigned_url="$(echo "$intent_body" | jq -r '.data.presignedUrl // empty')"
+  upload_token="$(echo "$intent_body" | jq -r '.data.uploadToken // empty')"
+  if [[ -z "$media_id" || -z "$presigned_url" || -z "$upload_token" ]]; then
+    fail "${label} upload-intent response missing fields"
+    return 1
+  fi
+
+  local put_status
+  put_status="$(curl -sS -o /dev/null -w '%{http_code}' -X PUT "$presigned_url" \
+    -H "Content-Type: image/png" \
+    --data-binary @"$tmp_file")"
+  if [[ "$put_status" == "200" || "$put_status" == "204" ]]; then
+    pass "${label} presigned upload"
+  else
+    fail "${label} presigned upload failed (status=${put_status})"
+    return 1
+  fi
+
+  local confirm_raw confirm_body confirm_status
+  confirm_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${MEDIA_PORT}/api/v1/media/confirm" \
+    -H "Content-Type: application/json" \
+    -d "{\"mediaId\":${media_id},\"uploadToken\":\"${upload_token}\"}")"
+  confirm_body="$(extract_http_body "$confirm_raw")"
+  confirm_status="$(extract_http_status "$confirm_raw")"
+  ensure_http_status "${label} confirm status" "$confirm_status" "200" "$confirm_body" || return 1
+  ensure_json_success "${label} confirm success" "$confirm_body" || return 1
+
+  rm -f "$tmp_file"
+  printf -v "$result_var" '%s' "$media_id"
+}
+
+recreate_search_index() {
+  local raw body status
+  raw="$(curl -sS -w '\n%{http_code}' -X POST \
+    "http://127.0.0.1:${SEARCH_PORT}/internal/v1/search/indexes/recreate?indexName=items")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+  ensure_http_status "search index recreate status" "$status" "200" "$body" || return 1
+  ensure_json_success "search index recreate success" "$body" || return 1
+}
+
+index_item_document() {
+  local item_id="$1"
+  local media_id="$2"
+  local keyword="$3"
+  local payload
+  payload="$(cat <<JSON
+{
+  "itemId": ${item_id},
+  "title": "${keyword}",
+  "description": "gateway search fallback e2e",
+  "category": "TEST",
+  "domainType": "PRODUCT",
+  "price": 10000,
+  "status": "ON_SALE",
+  "stock": 10,
+  "thumbnailMediaId": ${media_id},
+  "thumbnailUrlSnapshot": null,
+  "mediaVersion": 1,
+  "stockVersion": 1,
+  "tags": ["fallback", "e2e"],
+  "createdAt": "2026-02-24T00:00:00Z"
+}
+JSON
+)"
+
+  local index_raw index_body index_status
+  index_raw="$(curl -sS -w '\n%{http_code}' -X PUT \
+    "http://127.0.0.1:${ELASTICSEARCH_PORT}/items-write/_doc/${item_id}?refresh=true" \
+    -H "Content-Type: application/json" \
+    -d "$payload")"
+  index_body="$(extract_http_body "$index_raw")"
+  index_status="$(extract_http_status "$index_raw")"
+  if [[ "$index_status" == "200" || "$index_status" == "201" ]]; then
+    pass "index seed document inserted (itemId=${item_id})"
+  else
+    fail "index seed document insert failed (status=${index_status})"
+    echo "[DEBUG] index seed response body=${index_body}"
+    return 1
+  fi
+}
+
+query_search() {
+  local base_url="$1"
+  local keyword="$2"
+  curl -sS "${base_url}?q=${keyword}&size=20"
+}
+
+wait_search_item_visible() {
+  local base_url="$1"
+  local keyword="$2"
+  local expected_item_id="$3"
+  local label="$4"
+
+  for _ in {1..30}; do
+    local body item_id
+    body="$(query_search "$base_url" "$keyword")"
+    item_id="$(echo "$body" | jq -r '.data.items[0].itemId // empty' 2>/dev/null || true)"
+    if [[ "$item_id" == "$expected_item_id" ]]; then
+      pass "$label"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "$label (itemId=${expected_item_id})"
+  return 1
+}
+
+require_cmd curl
+require_cmd jq
+require_cmd docker
+require_cmd lsof
+require_cmd openssl
+require_cmd mktemp
+require_cmd wc
+
+check_port_free "$GW_PORT"
+check_port_free "$SEARCH_PORT"
+check_port_free "$MEDIA_PORT"
+
+echo "[INFO] preparing infra"
+(cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka mariadb elasticsearch >/dev/null)
+wait_es_up
+
+MEDIA_DOMAIN="$(resolve_media_domain)"
+echo "[INFO] media public domain: ${MEDIA_DOMAIN}"
+
+start_media
+start_search
+start_gateway
+
+wait_health "media-api" "$MEDIA_PORT"
+wait_health "search-service" "$SEARCH_PORT"
+wait_gateway_ready
+
+created_media_id=""
+keyword="fallback-e2e-$(date +%s)"
+item_id="$((2000000000 + RANDOM))"
+
+create_media_and_confirm created_media_id "fallback-e2e-media"
+if [[ -z "$created_media_id" || ! "$created_media_id" =~ ^[0-9]+$ ]]; then
+  fail "created mediaId missing or invalid"
+  exit 1
+fi
+recreate_search_index
+index_item_document "$item_id" "$created_media_id" "$keyword"
+wait_search_item_visible "http://127.0.0.1:${SEARCH_PORT}/api/v1/search" "$keyword" "$item_id" "seed item is visible in direct search"
+
+direct_body="$(query_search "http://127.0.0.1:${SEARCH_PORT}/api/v1/search" "$keyword")"
+ensure_json_success "direct search success" "$direct_body"
+direct_thumbnail_url="$(echo "$direct_body" | jq -r '.data.items[0].thumbnailUrl // empty')"
+direct_media_id="$(echo "$direct_body" | jq -r '.data.items[0].thumbnailMediaId // empty')"
+if [[ "$direct_media_id" == "$created_media_id" ]]; then
+  pass "direct search contains thumbnailMediaId"
+else
+  fail "direct search thumbnailMediaId mismatch (expected=${created_media_id}, actual=${direct_media_id})"
+fi
+if [[ -z "$direct_thumbnail_url" ]]; then
+  pass "direct search thumbnailUrl is empty before fallback"
+else
+  fail "direct search thumbnailUrl should be empty before fallback (actual=${direct_thumbnail_url})"
+fi
+
+bff_body="$(query_search "http://127.0.0.1:${GW_PORT}/bff/v1/search" "$keyword")"
+ensure_json_success "bff search success" "$bff_body"
+bff_thumbnail_url="$(echo "$bff_body" | jq -r '.data.items[0].thumbnailUrl // empty')"
+bff_media_id="$(echo "$bff_body" | jq -r '.data.items[0].thumbnailMediaId // empty')"
+if [[ "$bff_media_id" == "$created_media_id" ]]; then
+  pass "bff search contains thumbnailMediaId"
+else
+  fail "bff search thumbnailMediaId mismatch (expected=${created_media_id}, actual=${bff_media_id})"
+fi
+if [[ -n "$bff_thumbnail_url" ]]; then
+  pass "bff search thumbnailUrl fallback resolved"
+else
+  fail "bff search thumbnailUrl fallback unresolved"
+fi
+
+echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}"
+if [[ "$FAILURES" -gt 0 ]]; then
+  exit 1
+fi
+pass "gateway search fallback e2e verify passed"

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SearchMediaBffController.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SearchMediaBffController.java
@@ -1,0 +1,25 @@
+package com.example.gateway.bff.controller;
+
+import com.example.gateway.bff.service.SearchMediaBffService;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/bff/v1")
+@RequiredArgsConstructor
+public class SearchMediaBffController {
+
+    private final SearchMediaBffService searchMediaBffService;
+
+    @GetMapping("/search")
+    public Mono<ResponseEntity<JsonNode>> search(ServerHttpRequest serverHttpRequest) {
+        return searchMediaBffService.search(serverHttpRequest);
+    }
+}
+

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SearchMediaBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SearchMediaBffService.java
@@ -1,0 +1,147 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class SearchMediaBffService {
+
+    private final WebClient searchWebClient;
+    private final WebClient mediaWebClient;
+    private final GatewaySecurityProperties securityProperties;
+    private final SearchThumbnailFallbackEnricher fallbackEnricher;
+    private final ObjectMapper objectMapper;
+
+    public SearchMediaBffService(
+            WebClient.Builder webClientBuilder,
+            GatewaySecurityProperties securityProperties,
+            SearchThumbnailFallbackEnricher fallbackEnricher,
+            ObjectMapper objectMapper,
+            @Value("${app.service.search-url:http://localhost:8088}") String searchServiceUrl,
+            @Value("${app.service.media-url:http://localhost:8094}") String mediaServiceUrl
+    ) {
+        this.searchWebClient = webClientBuilder.baseUrl(searchServiceUrl).build();
+        this.mediaWebClient = webClientBuilder.baseUrl(mediaServiceUrl).build();
+        this.securityProperties = securityProperties;
+        this.fallbackEnricher = fallbackEnricher;
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<ResponseEntity<JsonNode>> search(ServerHttpRequest request) {
+        HttpHeaders downstreamHeaders = buildDownstreamHeaders();
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(request.getQueryParams());
+
+        return callSearch(queryParams, downstreamHeaders)
+                .flatMap(response -> enrichWithMediaFallback(response, downstreamHeaders));
+    }
+
+    private Mono<ResponseEntity<JsonNode>> callSearch(MultiValueMap<String, String> queryParams,
+                                                      HttpHeaders downstreamHeaders) {
+        return searchWebClient.method(HttpMethod.GET)
+                .uri(uriBuilder -> buildSearchUri(uriBuilder, queryParams))
+                .headers(headers -> headers.addAll(downstreamHeaders))
+                .exchangeToMono(response -> response.bodyToMono(JsonNode.class)
+                        .defaultIfEmpty(objectMapper.createObjectNode())
+                        .map(payload -> ResponseEntity.status(response.statusCode()).body(payload)));
+    }
+
+    private Mono<ResponseEntity<JsonNode>> enrichWithMediaFallback(ResponseEntity<JsonNode> searchResponse,
+                                                                   HttpHeaders downstreamHeaders) {
+        JsonNode body = searchResponse.getBody();
+        if (!searchResponse.getStatusCode().is2xxSuccessful() || body == null) {
+            return Mono.just(searchResponse);
+        }
+
+        List<Long> fallbackMediaIds = fallbackEnricher.collectFallbackMediaIds(body);
+        if (fallbackMediaIds.isEmpty()) {
+            return Mono.just(searchResponse);
+        }
+
+        return fetchMediaUrlMap(fallbackMediaIds, downstreamHeaders)
+                .map(mediaUrlMap -> fallbackEnricher.applyFallbackUrls(body, mediaUrlMap))
+                .map(enrichedBody -> ResponseEntity.status(searchResponse.getStatusCode()).body(enrichedBody))
+                .onErrorResume(e -> {
+                    log.warn("[SearchBff] thumbnail fallback failed. mediaCount={}", fallbackMediaIds.size(), e);
+                    return Mono.just(searchResponse);
+                });
+    }
+
+    private Mono<Map<Long, String>> fetchMediaUrlMap(List<Long> mediaIds, HttpHeaders downstreamHeaders) {
+        return mediaWebClient.post()
+                .uri("/internal/v1/media/urls/batch")
+                .headers(headers -> headers.addAll(downstreamHeaders))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("mediaIds", mediaIds))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::toMediaUrlMap);
+    }
+
+    private Map<Long, String> toMediaUrlMap(JsonNode responseBody) {
+        if (responseBody == null || !responseBody.path("success").asBoolean()) {
+            return Map.of();
+        }
+
+        JsonNode data = responseBody.path("data");
+        if (!data.isArray()) {
+            return Map.of();
+        }
+
+        Map<Long, String> mediaUrlMap = new LinkedHashMap<>();
+        for (JsonNode node : data) {
+            long mediaId = node.path("mediaId").asLong(-1L);
+            String mediaUrl = node.path("mediaUrl").asText(null);
+            if (mediaId > 0 && StringUtils.hasText(mediaUrl)) {
+                mediaUrlMap.put(mediaId, mediaUrl);
+            }
+        }
+        return mediaUrlMap;
+    }
+
+    private java.net.URI buildSearchUri(UriBuilder uriBuilder, MultiValueMap<String, String> queryParams) {
+        UriBuilder builder = uriBuilder.path("/api/v1/search");
+        if (queryParams == null || queryParams.isEmpty()) {
+            return builder.build();
+        }
+
+        queryParams.forEach((name, values) -> {
+            if (!StringUtils.hasText(name) || values == null || values.isEmpty()) {
+                return;
+            }
+            for (String value : values) {
+                builder.queryParam(name, value);
+            }
+        });
+        return builder.build();
+    }
+
+    private HttpHeaders buildDownstreamHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (StringUtils.hasText(securityProperties.getInternalAuthToken())
+                && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
+            headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
+        }
+        return headers;
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SearchThumbnailFallbackEnricher.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SearchThumbnailFallbackEnricher.java
@@ -1,0 +1,80 @@
+package com.example.gateway.bff.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class SearchThumbnailFallbackEnricher {
+
+    private final ObjectMapper objectMapper;
+
+    public List<Long> collectFallbackMediaIds(JsonNode searchResponseBody) {
+        if (searchResponseBody == null || !searchResponseBody.path("success").asBoolean()) {
+            return List.of();
+        }
+
+        JsonNode itemsNode = searchResponseBody.path("data").path("items");
+        if (!itemsNode.isArray()) {
+            return List.of();
+        }
+
+        Set<Long> mediaIds = new LinkedHashSet<>();
+        for (JsonNode itemNode : itemsNode) {
+            if (!itemNode.isObject()) {
+                continue;
+            }
+            String thumbnailUrl = itemNode.path("thumbnailUrl").asText(null);
+            long thumbnailMediaId = itemNode.path("thumbnailMediaId").asLong(-1L);
+            if (!StringUtils.hasText(thumbnailUrl) && thumbnailMediaId > 0) {
+                mediaIds.add(thumbnailMediaId);
+            }
+        }
+        return mediaIds.stream().toList();
+    }
+
+    public JsonNode applyFallbackUrls(JsonNode originalResponseBody, Map<Long, String> mediaUrlMap) {
+        if (originalResponseBody == null || mediaUrlMap == null || mediaUrlMap.isEmpty()) {
+            return originalResponseBody;
+        }
+
+        JsonNode copiedNode = objectMapper.valueToTree(originalResponseBody);
+        JsonNode itemsNode = copiedNode.path("data").path("items");
+        if (!(itemsNode instanceof ArrayNode itemsArray)) {
+            return copiedNode;
+        }
+
+        for (JsonNode itemNode : itemsArray) {
+            if (!(itemNode instanceof ObjectNode itemObject)) {
+                continue;
+            }
+            String thumbnailUrl = itemObject.path("thumbnailUrl").asText(null);
+            if (StringUtils.hasText(thumbnailUrl)) {
+                continue;
+            }
+
+            long thumbnailMediaId = itemObject.path("thumbnailMediaId").asLong(-1L);
+            if (thumbnailMediaId <= 0) {
+                continue;
+            }
+
+            String resolvedUrl = mediaUrlMap.get(thumbnailMediaId);
+            if (StringUtils.hasText(resolvedUrl)) {
+                itemObject.put("thumbnailUrl", resolvedUrl);
+            }
+        }
+
+        return copiedNode;
+    }
+}
+

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/SearchThumbnailFallbackEnricherTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/SearchThumbnailFallbackEnricherTest.java
@@ -1,0 +1,83 @@
+package com.example.gateway.bff.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchThumbnailFallbackEnricherTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final SearchThumbnailFallbackEnricher enricher = new SearchThumbnailFallbackEnricher(objectMapper);
+
+    @Test
+    void collectFallbackMediaIds_returnsOnlyMissingThumbnailTargets() throws Exception {
+        JsonNode body = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 1, "thumbnailMediaId": 11, "thumbnailUrl": null},
+                      {"itemId": 2, "thumbnailMediaId": 11, "thumbnailUrl": ""},
+                      {"itemId": 3, "thumbnailMediaId": 12, "thumbnailUrl": "https://cdn/already.jpg"},
+                      {"itemId": 4, "thumbnailMediaId": null, "thumbnailUrl": null},
+                      {"itemId": 5}
+                    ]
+                  }
+                }
+                """);
+
+        List<Long> fallbackMediaIds = enricher.collectFallbackMediaIds(body);
+
+        assertThat(fallbackMediaIds).containsExactly(11L);
+    }
+
+    @Test
+    void applyFallbackUrls_setsUrlWhenMissingOnly() throws Exception {
+        JsonNode body = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 1, "thumbnailMediaId": 11, "thumbnailUrl": null},
+                      {"itemId": 2, "thumbnailMediaId": 12, "thumbnailUrl": "https://cdn/keep.jpg"},
+                      {"itemId": 3, "thumbnailMediaId": 13, "thumbnailUrl": ""}
+                    ]
+                  }
+                }
+                """);
+
+        JsonNode enriched = enricher.applyFallbackUrls(body, Map.of(
+                11L, "https://cdn/fallback-11.webp",
+                13L, "https://cdn/fallback-13.webp"
+        ));
+
+        JsonNode items = enriched.path("data").path("items");
+        assertThat(items.get(0).path("thumbnailUrl").asText()).isEqualTo("https://cdn/fallback-11.webp");
+        assertThat(items.get(1).path("thumbnailUrl").asText()).isEqualTo("https://cdn/keep.jpg");
+        assertThat(items.get(2).path("thumbnailUrl").asText()).isEqualTo("https://cdn/fallback-13.webp");
+    }
+
+    @Test
+    void applyFallbackUrls_returnsOriginalWhenMapIsEmpty() throws Exception {
+        JsonNode body = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 1, "thumbnailMediaId": 11, "thumbnailUrl": null}
+                    ]
+                  }
+                }
+                """);
+
+        JsonNode enriched = enricher.applyFallbackUrls(body, Map.of());
+
+        assertThat(enriched).isSameAs(body);
+    }
+}
+


### PR DESCRIPTION
## 개요
Gateway BFF 검색 경로(`/bff/v1/search`)를 추가해, Search 응답의 `thumbnailUrlSnapshot`이 아직 비어 있는 구간에서도 `thumbnailMediaId` 기반 URL fallback을 제공하도록 보완했습니다.

### 관련 이슈
- Related #676
- Closes #678

### 작업 / 변경 내용
- `GET /bff/v1/search` 엔드포인트 추가
- Search 결과에서 `thumbnailUrl` 누락 아이템만 추출해 `thumbnailMediaId`를 수집
- Media 내부 batch URL 조회(`/internal/v1/media/urls/batch`) 후 누락 `thumbnailUrl`만 병합
- 기존 값이 있는 `thumbnailUrl`은 덮어쓰지 않도록 보존
- fallback 병합 로직을 `SearchThumbnailFallbackEnricher`로 분리해 테스트 가능하게 구성
- 통합 검증 스크립트 추가: `docker/scripts/gateway_search_fallback_e2e_verify.sh`
  - direct search: `thumbnailUrl` 비어 있음 확인
  - BFF search: 동일 item의 `thumbnailUrl` fallback 보강 확인

### 테스트 / 체크리스트
- [x] 로컬에서 빌드/테스트 확인 (`./gradlew :servers:gateways:client-gateway:test`)
- [x] 관련 테스트 작성 또는 확인 (`SearchThumbnailFallbackEnricherTest`)
- [x] 통합 E2E 확인 (`bash docker/scripts/gateway_search_fallback_e2e_verify.sh`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
- 다운스트림(Search/Media)에 URL 생성 로직을 추가하지 않고, `mediaId -> Media URL` 단일 책임을 유지했습니다.
- 기존 `/api/v1/search` 계약은 변경하지 않고, BFF 경로에서만 fallback을 적용해 하위 호환을 유지했습니다.
