### PR TITLE
feat(#679): media-worker observability and DLQ/backfill ops

### DIFF
--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/controller/api/internal/MediaWorkerOpsApi.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/controller/api/internal/MediaWorkerOpsApi.java
@@ -1,0 +1,38 @@
+package com.example.mediaworker.controller.api.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerBackfillRequest;
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerReplayRequest;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerBackfillResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerDlqListResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerReplayResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerTaskSummaryResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface MediaWorkerOpsApi {
+
+    @GetMapping("/tasks/summary")
+    ApiResponse<MediaWorkerTaskSummaryResponse> taskSummary();
+
+    @GetMapping("/tasks/dlq")
+    ApiResponse<MediaWorkerDlqListResponse> recentDlqItems(
+            @RequestParam(required = false) @Min(value = 1, message = "size must be positive") Integer size
+    );
+
+    @PostMapping("/tasks/{taskId}/replay")
+    ApiResponse<MediaWorkerReplayResponse> replayTask(
+            @PathVariable Long taskId,
+            @Valid @RequestBody(required = false) MediaWorkerReplayRequest request
+    );
+
+    @PostMapping("/tasks/backfill")
+    ApiResponse<MediaWorkerBackfillResponse> backfill(
+            @Valid @RequestBody(required = false) MediaWorkerBackfillRequest request
+    );
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/controller/internal/MediaWorkerOpsController.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/controller/internal/MediaWorkerOpsController.java
@@ -1,0 +1,54 @@
+package com.example.mediaworker.controller.internal;
+
+import com.example.api.response.ApiResponse;
+import com.example.mediaworker.controller.api.internal.MediaWorkerOpsApi;
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerBackfillRequest;
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerReplayRequest;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerBackfillResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerDlqListResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerReplayResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerTaskSummaryResponse;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.service.ops.MediaWorkerOpsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/internal/v1/media-worker")
+@RequiredArgsConstructor
+public class MediaWorkerOpsController implements MediaWorkerOpsApi {
+
+    private final MediaWorkerOpsService mediaWorkerOpsService;
+
+    @Override
+    public ApiResponse<MediaWorkerTaskSummaryResponse> taskSummary() {
+        return ApiResponse.success(mediaWorkerOpsService.getTaskSummary());
+    }
+
+    @Override
+    public ApiResponse<MediaWorkerDlqListResponse> recentDlqItems(Integer size) {
+        return ApiResponse.success(mediaWorkerOpsService.getRecentDlqItems(size));
+    }
+
+    @Override
+    public ApiResponse<MediaWorkerReplayResponse> replayTask(Long taskId, MediaWorkerReplayRequest request) {
+        String reason = request == null ? null : request.getReason();
+        MediaDerivativeTask replayedTask = mediaWorkerOpsService.replayFailedTask(taskId, reason);
+        MediaWorkerReplayResponse response = MediaWorkerReplayResponse.builder()
+                .taskId(replayedTask.getId())
+                .queued(true)
+                .previousStatus("FAILED")
+                .currentStatus(replayedTask.getStatus().name())
+                .message("replay queued")
+                .build();
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    public ApiResponse<MediaWorkerBackfillResponse> backfill(MediaWorkerBackfillRequest request) {
+        return ApiResponse.success(mediaWorkerOpsService.backfill(request));
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/request/MediaWorkerBackfillRequest.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/request/MediaWorkerBackfillRequest.java
@@ -1,0 +1,22 @@
+package com.example.mediaworker.dto.internal.ops.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MediaWorkerBackfillRequest {
+
+    @Min(value = 1, message = "fromMediaId must be positive")
+    private Long fromMediaId;
+
+    @Min(value = 1, message = "toMediaId must be positive")
+    private Long toMediaId;
+
+    @Min(value = 1, message = "size must be at least 1")
+    private Integer size;
+
+    private String derivativeProfile;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/request/MediaWorkerReplayRequest.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/request/MediaWorkerReplayRequest.java
@@ -1,0 +1,12 @@
+package com.example.mediaworker.dto.internal.ops.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MediaWorkerReplayRequest {
+
+    private String reason;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerBackfillResponse.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerBackfillResponse.java
@@ -1,0 +1,18 @@
+package com.example.mediaworker.dto.internal.ops.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MediaWorkerBackfillResponse {
+
+    private final Long fromMediaId;
+    private final Long toMediaId;
+    private final int requestedSize;
+    private final String derivativeProfile;
+    private final long scannedCount;
+    private final long queuedCount;
+    private final long existingCount;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerDlqItemResponse.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerDlqItemResponse.java
@@ -1,0 +1,23 @@
+package com.example.mediaworker.dto.internal.ops.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MediaWorkerDlqItemResponse {
+
+    private final Long dlqId;
+    private final Long taskId;
+    private final Long mediaId;
+    private final String derivativeProfile;
+    private final Long mediaVersion;
+    private final Integer retryCount;
+    private final String errorCode;
+    private final String errorMessage;
+    private final String sourceEventId;
+    private final LocalDateTime createdAt;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerDlqListResponse.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerDlqListResponse.java
@@ -1,0 +1,15 @@
+package com.example.mediaworker.dto.internal.ops.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MediaWorkerDlqListResponse {
+
+    private final int size;
+    private final List<MediaWorkerDlqItemResponse> items;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerReplayResponse.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerReplayResponse.java
@@ -1,0 +1,16 @@
+package com.example.mediaworker.dto.internal.ops.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MediaWorkerReplayResponse {
+
+    private final Long taskId;
+    private final boolean queued;
+    private final String previousStatus;
+    private final String currentStatus;
+    private final String message;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerTaskSummaryResponse.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/dto/internal/ops/response/MediaWorkerTaskSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.example.mediaworker.dto.internal.ops.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MediaWorkerTaskSummaryResponse {
+
+    private final long pendingCount;
+    private final long processingCount;
+    private final long completedCount;
+    private final long failedCount;
+    private final long dlqCount;
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTask.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeTask.java
@@ -132,6 +132,19 @@ public class MediaDerivativeTask extends BaseEntity {
         this.lastError = truncate(errorMessage);
     }
 
+    public void requeueForReplay(LocalDateTime replayAt, String replayReason) {
+        if (this.status != MediaDerivativeTaskStatus.FAILED) {
+            throw new IllegalStateException(
+                    "Replay is only allowed for FAILED tasks. actual=" + this.status
+            );
+        }
+        this.status = MediaDerivativeTaskStatus.PENDING;
+        this.processingStartedAt = null;
+        this.nextRetryAt = replayAt;
+        this.completedAt = null;
+        this.lastError = truncate(replayReason);
+    }
+
     private void assertStatus(MediaDerivativeTaskStatus expected) {
         if (this.status != expected) {
             throw new IllegalStateException(

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskDlqRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskDlqRepository.java
@@ -1,7 +1,12 @@
 package com.example.mediaworker.repository;
 
 import com.example.mediaworker.entity.MediaDerivativeTaskDlq;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MediaDerivativeTaskDlqRepository extends JpaRepository<MediaDerivativeTaskDlq, Long> {
+
+    List<MediaDerivativeTaskDlq> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeTaskRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 public interface MediaDerivativeTaskRepository extends JpaRepository<MediaDerivativeTask, Long> {
 
+    long countByStatus(MediaDerivativeTaskStatus status);
+
     Optional<MediaDerivativeTask> findByMediaIdAndDerivativeProfileAndMediaVersion(
             Long mediaId,
             MediaDerivativeProfile derivativeProfile,

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
@@ -1,7 +1,28 @@
 package com.example.mediaworker.repository;
 
 import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.entity.MediaFileStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MediaFileRecordRepository extends JpaRepository<MediaFileRecord, Long> {
+
+    @Query("""
+            select record
+            from MediaFileRecord record
+            where record.status in :statuses
+              and (:fromMediaId is null or record.id >= :fromMediaId)
+              and (:toMediaId is null or record.id <= :toMediaId)
+            order by record.id asc
+            """)
+    List<MediaFileRecord> findBackfillCandidates(
+            @Param("statuses") List<MediaFileStatus> statuses,
+            @Param("fromMediaId") Long fromMediaId,
+            @Param("toMediaId") Long toMediaId,
+            Pageable pageable
+    );
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureHandleResult.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureHandleResult.java
@@ -1,0 +1,31 @@
+package com.example.mediaworker.service;
+
+public record MediaDerivativeFailureHandleResult(
+        MediaDerivativeFailureOutcome outcome,
+        MediaDerivativeFailureCode failureCode,
+        Integer retryCount
+) {
+    public static MediaDerivativeFailureHandleResult skipped() {
+        return new MediaDerivativeFailureHandleResult(
+                MediaDerivativeFailureOutcome.SKIPPED,
+                null,
+                null
+        );
+    }
+
+    public static MediaDerivativeFailureHandleResult retryScheduled(MediaDerivativeFailureCode failureCode, Integer retryCount) {
+        return new MediaDerivativeFailureHandleResult(
+                MediaDerivativeFailureOutcome.RETRY_SCHEDULED,
+                failureCode,
+                retryCount
+        );
+    }
+
+    public static MediaDerivativeFailureHandleResult dlqFailed(MediaDerivativeFailureCode failureCode, Integer retryCount) {
+        return new MediaDerivativeFailureHandleResult(
+                MediaDerivativeFailureOutcome.DLQ_FAILED,
+                failureCode,
+                retryCount
+        );
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureOutcome.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeFailureOutcome.java
@@ -1,0 +1,8 @@
+package com.example.mediaworker.service;
+
+public enum MediaDerivativeFailureOutcome {
+    RETRY_SCHEDULED,
+    DLQ_FAILED,
+    SKIPPED
+}
+

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskScheduler.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskScheduler.java
@@ -1,11 +1,13 @@
 package com.example.mediaworker.service;
 
 import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.service.ops.MediaWorkerMetricsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,7 @@ public class MediaDerivativeTaskScheduler {
 
     private final MediaDerivativeTaskService mediaDerivativeTaskService;
     private final MediaDerivativeProcessor mediaDerivativeProcessor;
+    private final MediaWorkerMetricsService mediaWorkerMetricsService;
 
     @Scheduled(fixedDelayString = "${media.worker.tasks.dispatch-fixed-delay-ms:3000}")
     public void dispatchDueTasks() {
@@ -36,6 +39,7 @@ public class MediaDerivativeTaskScheduler {
         int recoveredCount = mediaDerivativeTaskService.recoverStaleProcessingTasks(LocalDateTime.now());
         if (recoveredCount > 0) {
             log.warn("[MediaWorker] recovered stale processing tasks. count={}", recoveredCount);
+            mediaWorkerMetricsService.recordStaleRecovered(recoveredCount);
         }
     }
 
@@ -45,9 +49,11 @@ public class MediaDerivativeTaskScheduler {
             return;
         }
         MediaDerivativeTask task = optionalTask.get();
+        long startedAtNanos = System.nanoTime();
         try {
             mediaDerivativeProcessor.process(task);
             mediaDerivativeTaskService.markCompleted(taskId, LocalDateTime.now());
+            mediaWorkerMetricsService.recordTaskSuccess(Duration.ofNanos(System.nanoTime() - startedAtNanos));
         } catch (Exception exception) {
             log.warn(
                     "[MediaWorker] derivative processing failed. taskId={}, mediaId={}, profile={}, reason={}",
@@ -56,7 +62,14 @@ public class MediaDerivativeTaskScheduler {
                     task.getDerivativeProfile(),
                     exception.getMessage()
             );
-            mediaDerivativeTaskService.handleFailure(taskId, exception, LocalDateTime.now());
+            mediaWorkerMetricsService.recordTaskFailure(Duration.ofNanos(System.nanoTime() - startedAtNanos));
+            MediaDerivativeFailureHandleResult handleResult =
+                    mediaDerivativeTaskService.handleFailure(taskId, exception, LocalDateTime.now());
+            if (handleResult.outcome() == MediaDerivativeFailureOutcome.RETRY_SCHEDULED) {
+                mediaWorkerMetricsService.recordRetryScheduled();
+            } else if (handleResult.outcome() == MediaDerivativeFailureOutcome.DLQ_FAILED) {
+                mediaWorkerMetricsService.recordDlq();
+            }
         }
     }
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeTaskService.java
@@ -147,35 +147,51 @@ public class MediaDerivativeTaskService {
     }
 
     @Transactional
-    public void handleFailure(Long taskId, Exception exception, LocalDateTime now) {
-        mediaDerivativeTaskRepository.findById(taskId).ifPresent(task -> {
-            if (task.getStatus() != MediaDerivativeTaskStatus.PROCESSING) {
-                log.warn(
-                        "[MediaWorker] skip failure handling. taskId={}, status={}",
-                        task.getId(),
-                        task.getStatus()
-                );
-                return;
-            }
+    public MediaDerivativeFailureHandleResult handleFailure(Long taskId, Exception exception, LocalDateTime now) {
+        return mediaDerivativeTaskRepository.findById(taskId)
+                .map(task -> handleFailure(task, exception, now))
+                .orElseGet(MediaDerivativeFailureHandleResult::skipped);
+    }
 
-            String errorMessage = buildErrorMessage(exception);
-            int nextRetryCount = task.getRetryCount() == null ? 1 : task.getRetryCount() + 1;
-            MediaDerivativeFailureDecision decision = failureClassifier.classify(
-                    exception,
-                    nextRetryCount,
-                    mediaWorkerTaskProperties.getMaxRetryCount()
-            );
-            if (!decision.retriable()) {
-                task.markFailed(errorMessage, now);
-                mediaDerivativeTaskDlqRepository.save(
-                        MediaDerivativeTaskDlq.fromTask(task, decision.failureCode().name(), errorMessage)
-                );
-                return;
+    @Transactional
+    public Optional<MediaDerivativeTask> replayFailedTask(Long taskId, String replayReason, LocalDateTime replayAt) {
+        return mediaDerivativeTaskRepository.findById(taskId).map(task -> {
+            if (task.getStatus() != MediaDerivativeTaskStatus.FAILED) {
+                return task;
             }
-
-            long backoffSeconds = calculateBackoffSeconds(nextRetryCount);
-            task.scheduleRetry(now.plusSeconds(backoffSeconds), errorMessage);
+            task.requeueForReplay(replayAt, replayReason);
+            return task;
         });
+    }
+
+    private MediaDerivativeFailureHandleResult handleFailure(MediaDerivativeTask task, Exception exception, LocalDateTime now) {
+        if (task.getStatus() != MediaDerivativeTaskStatus.PROCESSING) {
+            log.warn(
+                    "[MediaWorker] skip failure handling. taskId={}, status={}",
+                    task.getId(),
+                    task.getStatus()
+            );
+            return MediaDerivativeFailureHandleResult.skipped();
+        }
+
+        String errorMessage = buildErrorMessage(exception);
+        int nextRetryCount = task.getRetryCount() == null ? 1 : task.getRetryCount() + 1;
+        MediaDerivativeFailureDecision decision = failureClassifier.classify(
+                exception,
+                nextRetryCount,
+                mediaWorkerTaskProperties.getMaxRetryCount()
+        );
+        if (!decision.retriable()) {
+            task.markFailed(errorMessage, now);
+            mediaDerivativeTaskDlqRepository.save(
+                    MediaDerivativeTaskDlq.fromTask(task, decision.failureCode().name(), errorMessage)
+            );
+            return MediaDerivativeFailureHandleResult.dlqFailed(decision.failureCode(), task.getRetryCount());
+        }
+
+        long backoffSeconds = calculateBackoffSeconds(nextRetryCount);
+        task.scheduleRetry(now.plusSeconds(backoffSeconds), errorMessage);
+        return MediaDerivativeFailureHandleResult.retryScheduled(decision.failureCode(), task.getRetryCount());
     }
 
     private long normalizeMediaVersion(Long mediaVersion) {

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/ops/MediaWorkerMetricsService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/ops/MediaWorkerMetricsService.java
@@ -1,0 +1,69 @@
+package com.example.mediaworker.service.ops;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class MediaWorkerMetricsService {
+
+    private final Counter taskSuccessCounter;
+    private final Counter taskFailureCounter;
+    private final Counter taskRetryScheduledCounter;
+    private final Counter taskDlqCounter;
+    private final Counter staleRecoveredCounter;
+    private final Timer taskProcessingLatencyTimer;
+
+    public MediaWorkerMetricsService(MeterRegistry meterRegistry) {
+        this.taskSuccessCounter = Counter.builder("media.worker.tasks.success.total")
+                .description("Total number of media derivative tasks completed successfully")
+                .register(meterRegistry);
+        this.taskFailureCounter = Counter.builder("media.worker.tasks.failure.total")
+                .description("Total number of media derivative processing attempts failed")
+                .register(meterRegistry);
+        this.taskRetryScheduledCounter = Counter.builder("media.worker.tasks.retry.scheduled.total")
+                .description("Total number of media derivative retries scheduled")
+                .register(meterRegistry);
+        this.taskDlqCounter = Counter.builder("media.worker.tasks.dlq.total")
+                .description("Total number of media derivative tasks moved to DLQ")
+                .register(meterRegistry);
+        this.staleRecoveredCounter = Counter.builder("media.worker.tasks.stale.recovered.total")
+                .description("Total number of stale PROCESSING tasks recovered")
+                .register(meterRegistry);
+        this.taskProcessingLatencyTimer = Timer.builder("media.worker.tasks.processing.latency")
+                .description("Latency of media derivative task processing")
+                .register(meterRegistry);
+    }
+
+    public void recordTaskSuccess(Duration latency) {
+        if (latency != null && !latency.isNegative()) {
+            taskProcessingLatencyTimer.record(latency);
+        }
+        taskSuccessCounter.increment();
+    }
+
+    public void recordTaskFailure(Duration latency) {
+        if (latency != null && !latency.isNegative()) {
+            taskProcessingLatencyTimer.record(latency);
+        }
+        taskFailureCounter.increment();
+    }
+
+    public void recordRetryScheduled() {
+        taskRetryScheduledCounter.increment();
+    }
+
+    public void recordDlq() {
+        taskDlqCounter.increment();
+    }
+
+    public void recordStaleRecovered(int count) {
+        if (count <= 0) {
+            return;
+        }
+        staleRecoveredCounter.increment(count);
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/ops/MediaWorkerOpsService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/ops/MediaWorkerOpsService.java
@@ -1,0 +1,188 @@
+package com.example.mediaworker.service.ops;
+
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerBackfillRequest;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerBackfillResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerDlqItemResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerDlqListResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerTaskSummaryResponse;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskDlq;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.entity.MediaFileStatus;
+import com.example.mediaworker.repository.MediaDerivativeTaskDlqRepository;
+import com.example.mediaworker.repository.MediaDerivativeTaskRepository;
+import com.example.mediaworker.repository.MediaFileRecordRepository;
+import com.example.mediaworker.service.MediaDerivativeTaskService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaWorkerOpsService {
+
+    private static final int DEFAULT_DLQ_SIZE = 20;
+    private static final int MAX_DLQ_SIZE = 200;
+    private static final int DEFAULT_BACKFILL_SIZE = 100;
+    private static final int MAX_BACKFILL_SIZE = 1_000;
+    private static final long BACKFILL_MEDIA_VERSION = 1L;
+    private static final String BACKFILL_EVENT_ID = "ops-backfill";
+
+    private final MediaDerivativeTaskRepository mediaDerivativeTaskRepository;
+    private final MediaDerivativeTaskDlqRepository mediaDerivativeTaskDlqRepository;
+    private final MediaFileRecordRepository mediaFileRecordRepository;
+    private final MediaDerivativeTaskService mediaDerivativeTaskService;
+
+    @Transactional(readOnly = true)
+    public MediaWorkerTaskSummaryResponse getTaskSummary() {
+        return MediaWorkerTaskSummaryResponse.builder()
+                .pendingCount(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.PENDING))
+                .processingCount(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.PROCESSING))
+                .completedCount(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.COMPLETED))
+                .failedCount(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.FAILED))
+                .dlqCount(mediaDerivativeTaskDlqRepository.count())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MediaWorkerDlqListResponse getRecentDlqItems(Integer size) {
+        int normalizedSize = normalizeSize(size, DEFAULT_DLQ_SIZE, MAX_DLQ_SIZE);
+        List<MediaDerivativeTaskDlq> items = mediaDerivativeTaskDlqRepository.findAllByOrderByCreatedAtDesc(
+                PageRequest.of(0, normalizedSize)
+        );
+        return MediaWorkerDlqListResponse.builder()
+                .size(items.size())
+                .items(items.stream().map(this::toDlqItemResponse).toList())
+                .build();
+    }
+
+    @Transactional
+    public MediaDerivativeTask replayFailedTask(Long taskId, String reason) {
+        if (taskId == null || taskId <= 0) {
+            throw new IllegalArgumentException("taskId must be positive");
+        }
+
+        MediaDerivativeTask task = mediaDerivativeTaskRepository.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("task not found"));
+
+        if (task.getStatus() != MediaDerivativeTaskStatus.FAILED) {
+            throw new IllegalArgumentException("replay is only allowed for FAILED tasks");
+        }
+
+        MediaDerivativeTask replayed = mediaDerivativeTaskService
+                .replayFailedTask(taskId, normalizeReplayReason(reason), LocalDateTime.now())
+                .orElseThrow(() -> new IllegalArgumentException("task not found"));
+
+        log.info(
+                "[MediaWorkerOps] replay queued. taskId={}, mediaId={}, profile={}, mediaVersion={}, reason={}",
+                replayed.getId(),
+                replayed.getMediaId(),
+                replayed.getDerivativeProfile(),
+                replayed.getMediaVersion(),
+                replayed.getLastError()
+        );
+        return replayed;
+    }
+
+    @Transactional
+    public MediaWorkerBackfillResponse backfill(MediaWorkerBackfillRequest request) {
+        Long fromMediaId = request == null ? null : request.getFromMediaId();
+        Long toMediaId = request == null ? null : request.getToMediaId();
+        int requestedSize = normalizeSize(request == null ? null : request.getSize(), DEFAULT_BACKFILL_SIZE, MAX_BACKFILL_SIZE);
+        MediaDerivativeProfile profile = resolveProfile(request == null ? null : request.getDerivativeProfile());
+
+        List<MediaFileRecord> candidates = mediaFileRecordRepository.findBackfillCandidates(
+                List.of(MediaFileStatus.CONFIRMED, MediaFileStatus.READY),
+                fromMediaId,
+                toMediaId,
+                PageRequest.of(0, requestedSize)
+        );
+
+        long queuedCount = 0L;
+        long existingCount = 0L;
+
+        for (MediaFileRecord candidate : candidates) {
+            boolean alreadyExists = mediaDerivativeTaskRepository
+                    .findByMediaIdAndDerivativeProfileAndMediaVersion(candidate.getId(), profile, BACKFILL_MEDIA_VERSION)
+                    .isPresent();
+            if (alreadyExists) {
+                existingCount++;
+                continue;
+            }
+            mediaDerivativeTaskService.enqueuePending(candidate.getId(), BACKFILL_MEDIA_VERSION, profile, BACKFILL_EVENT_ID);
+            queuedCount++;
+        }
+
+        log.info(
+                "[MediaWorkerOps] backfill finished. profile={}, fromMediaId={}, toMediaId={}, requestedSize={}, scanned={}, queued={}, existing={}",
+                profile,
+                fromMediaId,
+                toMediaId,
+                requestedSize,
+                candidates.size(),
+                queuedCount,
+                existingCount
+        );
+
+        return MediaWorkerBackfillResponse.builder()
+                .fromMediaId(fromMediaId)
+                .toMediaId(toMediaId)
+                .requestedSize(requestedSize)
+                .derivativeProfile(profile.name())
+                .scannedCount(candidates.size())
+                .queuedCount(queuedCount)
+                .existingCount(existingCount)
+                .build();
+    }
+
+    private MediaWorkerDlqItemResponse toDlqItemResponse(MediaDerivativeTaskDlq item) {
+        return MediaWorkerDlqItemResponse.builder()
+                .dlqId(item.getId())
+                .taskId(item.getTaskId())
+                .mediaId(item.getMediaId())
+                .derivativeProfile(item.getDerivativeProfile().name())
+                .mediaVersion(item.getMediaVersion())
+                .retryCount(item.getRetryCount())
+                .errorCode(item.getErrorCode())
+                .errorMessage(item.getErrorMessage())
+                .sourceEventId(item.getSourceEventId())
+                .createdAt(item.getCreatedAt())
+                .build();
+    }
+
+    private int normalizeSize(Integer size, int defaultSize, int maxSize) {
+        if (size == null || size <= 0) {
+            return defaultSize;
+        }
+        return Math.min(size, maxSize);
+    }
+
+    private MediaDerivativeProfile resolveProfile(String rawProfile) {
+        if (!StringUtils.hasText(rawProfile)) {
+            return MediaDerivativeProfile.THUMBNAIL_WEBP;
+        }
+        String normalized = rawProfile.trim().toUpperCase(Locale.ROOT);
+        try {
+            return MediaDerivativeProfile.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            return MediaDerivativeProfile.THUMBNAIL_WEBP;
+        }
+    }
+
+    private String normalizeReplayReason(String reason) {
+        if (!StringUtils.hasText(reason)) {
+            return "manual replay requested";
+        }
+        return reason.trim();
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskSchedulerTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskSchedulerTest.java
@@ -3,6 +3,7 @@ package com.example.mediaworker.service;
 import com.example.mediaworker.entity.MediaDerivativeProfile;
 import com.example.mediaworker.entity.MediaDerivativeTask;
 import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import com.example.mediaworker.service.ops.MediaWorkerMetricsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,11 +30,15 @@ class MediaDerivativeTaskSchedulerTest {
     @Mock
     private MediaDerivativeProcessor mediaDerivativeProcessor;
 
+    @Mock
+    private MediaWorkerMetricsService mediaWorkerMetricsService;
+
     @Test
     void dispatchDueTasks_onSuccess_marksCompleted() {
         MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
                 mediaDerivativeTaskService,
-                mediaDerivativeProcessor
+                mediaDerivativeProcessor,
+                mediaWorkerMetricsService
         );
         MediaDerivativeTask processingTask = MediaDerivativeTask.createPending(1L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-1");
         ReflectionTestUtils.setField(processingTask, "id", 101L);
@@ -47,13 +52,16 @@ class MediaDerivativeTaskSchedulerTest {
         verify(mediaDerivativeProcessor).process(processingTask);
         verify(mediaDerivativeTaskService).markCompleted(eq(101L), any(LocalDateTime.class));
         verify(mediaDerivativeTaskService, never()).handleFailure(eq(101L), any(Exception.class), any(LocalDateTime.class));
+        verify(mediaWorkerMetricsService).recordTaskSuccess(any());
+        verify(mediaWorkerMetricsService, never()).recordTaskFailure(any());
     }
 
     @Test
     void dispatchDueTasks_onFailure_handlesRetryPath() {
         MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
                 mediaDerivativeTaskService,
-                mediaDerivativeProcessor
+                mediaDerivativeProcessor,
+                mediaWorkerMetricsService
         );
         MediaDerivativeTask processingTask = MediaDerivativeTask.createPending(2L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-2");
         ReflectionTestUtils.setField(processingTask, "id", 102L);
@@ -62,23 +70,33 @@ class MediaDerivativeTaskSchedulerTest {
         when(mediaDerivativeTaskService.claimDueTaskIds(any(LocalDateTime.class))).thenReturn(List.of(102L));
         when(mediaDerivativeTaskService.findById(102L)).thenReturn(Optional.of(processingTask));
         doThrow(new RuntimeException("processing failed")).when(mediaDerivativeProcessor).process(processingTask);
+        when(mediaDerivativeTaskService.handleFailure(eq(102L), any(Exception.class), any(LocalDateTime.class)))
+                .thenReturn(MediaDerivativeFailureHandleResult.retryScheduled(
+                        MediaDerivativeFailureCode.RETRIABLE_EXCEPTION,
+                        1
+                ));
 
         scheduler.dispatchDueTasks();
 
         verify(mediaDerivativeTaskService).handleFailure(eq(102L), any(Exception.class), any(LocalDateTime.class));
         verify(mediaDerivativeTaskService, never()).markCompleted(eq(102L), any(LocalDateTime.class));
+        verify(mediaWorkerMetricsService).recordTaskFailure(any());
+        verify(mediaWorkerMetricsService).recordRetryScheduled();
+        verify(mediaWorkerMetricsService, never()).recordDlq();
     }
 
     @Test
     void recoverStaleProcessingTasks_invokesRecoveryService() {
         MediaDerivativeTaskScheduler scheduler = new MediaDerivativeTaskScheduler(
                 mediaDerivativeTaskService,
-                mediaDerivativeProcessor
+                mediaDerivativeProcessor,
+                mediaWorkerMetricsService
         );
         when(mediaDerivativeTaskService.recoverStaleProcessingTasks(any(LocalDateTime.class))).thenReturn(1);
 
         scheduler.recoverStaleProcessingTasks();
 
         verify(mediaDerivativeTaskService).recoverStaleProcessingTasks(any(LocalDateTime.class));
+        verify(mediaWorkerMetricsService).recordStaleRecovered(1);
     }
 }

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskServiceTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeTaskServiceTest.java
@@ -143,12 +143,14 @@ class MediaDerivativeTaskServiceTest {
         when(failureClassifier.classify(any(), eq(1), eq(properties.getMaxRetryCount())))
                 .thenReturn(new MediaDerivativeFailureDecision(true, MediaDerivativeFailureCode.RETRIABLE_EXCEPTION));
 
-        mediaDerivativeTaskService.handleFailure(201L, new RuntimeException("temporary"), now);
+        MediaDerivativeFailureHandleResult handleResult =
+                mediaDerivativeTaskService.handleFailure(201L, new RuntimeException("temporary"), now);
 
         assertThat(processing.getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
         assertThat(processing.getRetryCount()).isEqualTo(1);
         assertThat(processing.getNextRetryAt()).isAfter(now.minusSeconds(1));
         assertThat(processing.getLastError()).contains("RuntimeException");
+        assertThat(handleResult.outcome()).isEqualTo(MediaDerivativeFailureOutcome.RETRY_SCHEDULED);
         verify(mediaDerivativeTaskDlqRepository, never()).save(any());
     }
 
@@ -164,11 +166,29 @@ class MediaDerivativeTaskServiceTest {
         when(failureClassifier.classify(any(), eq(1), eq(properties.getMaxRetryCount())))
                 .thenReturn(new MediaDerivativeFailureDecision(false, MediaDerivativeFailureCode.MAX_RETRY_EXCEEDED));
 
-        mediaDerivativeTaskService.handleFailure(202L, new RuntimeException("boom"), now);
+        MediaDerivativeFailureHandleResult handleResult =
+                mediaDerivativeTaskService.handleFailure(202L, new RuntimeException("boom"), now);
 
         assertThat(processing.getStatus()).isEqualTo(MediaDerivativeTaskStatus.FAILED);
         assertThat(processing.getRetryCount()).isEqualTo(1);
         assertThat(processing.getCompletedAt()).isEqualTo(now);
+        assertThat(handleResult.outcome()).isEqualTo(MediaDerivativeFailureOutcome.DLQ_FAILED);
         verify(mediaDerivativeTaskDlqRepository).save(any());
+    }
+
+    @Test
+    void replayFailedTask_movesFailedToPending() {
+        LocalDateTime replayAt = LocalDateTime.now();
+        MediaDerivativeTask failedTask = MediaDerivativeTask.createPending(30L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-30");
+        ReflectionTestUtils.setField(failedTask, "status", MediaDerivativeTaskStatus.FAILED);
+        ReflectionTestUtils.setField(failedTask, "id", 301L);
+
+        when(mediaDerivativeTaskRepository.findById(301L)).thenReturn(Optional.of(failedTask));
+
+        Optional<MediaDerivativeTask> replayed = mediaDerivativeTaskService.replayFailedTask(301L, "manual replay", replayAt);
+
+        assertThat(replayed).isPresent();
+        assertThat(replayed.get().getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
+        assertThat(replayed.get().getNextRetryAt()).isEqualTo(replayAt);
     }
 }

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/ops/MediaWorkerOpsServiceTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/ops/MediaWorkerOpsServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.mediaworker.service.ops;
+
+import com.example.mediaworker.dto.internal.ops.request.MediaWorkerBackfillRequest;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerBackfillResponse;
+import com.example.mediaworker.dto.internal.ops.response.MediaWorkerTaskSummaryResponse;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeTask;
+import com.example.mediaworker.entity.MediaDerivativeTaskStatus;
+import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.repository.MediaDerivativeTaskDlqRepository;
+import com.example.mediaworker.repository.MediaDerivativeTaskRepository;
+import com.example.mediaworker.repository.MediaFileRecordRepository;
+import com.example.mediaworker.service.MediaDerivativeTaskService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaWorkerOpsServiceTest {
+
+    @Mock
+    private MediaDerivativeTaskRepository mediaDerivativeTaskRepository;
+
+    @Mock
+    private MediaDerivativeTaskDlqRepository mediaDerivativeTaskDlqRepository;
+
+    @Mock
+    private MediaFileRecordRepository mediaFileRecordRepository;
+
+    @Mock
+    private MediaDerivativeTaskService mediaDerivativeTaskService;
+
+    @Test
+    void getTaskSummary_aggregatesAllStatusCounts() {
+        MediaWorkerOpsService service = createService();
+
+        when(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.PENDING)).thenReturn(3L);
+        when(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.PROCESSING)).thenReturn(2L);
+        when(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.COMPLETED)).thenReturn(11L);
+        when(mediaDerivativeTaskRepository.countByStatus(MediaDerivativeTaskStatus.FAILED)).thenReturn(1L);
+        when(mediaDerivativeTaskDlqRepository.count()).thenReturn(4L);
+
+        MediaWorkerTaskSummaryResponse summary = service.getTaskSummary();
+
+        assertThat(summary.getPendingCount()).isEqualTo(3L);
+        assertThat(summary.getProcessingCount()).isEqualTo(2L);
+        assertThat(summary.getCompletedCount()).isEqualTo(11L);
+        assertThat(summary.getFailedCount()).isEqualTo(1L);
+        assertThat(summary.getDlqCount()).isEqualTo(4L);
+    }
+
+    @Test
+    void replayFailedTask_requeuesFailedTask() {
+        MediaWorkerOpsService service = createService();
+        MediaDerivativeTask failedTask = MediaDerivativeTask.createPending(10L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-10");
+        ReflectionTestUtils.setField(failedTask, "id", 100L);
+        ReflectionTestUtils.setField(failedTask, "status", MediaDerivativeTaskStatus.FAILED);
+
+        MediaDerivativeTask replayedTask = MediaDerivativeTask.createPending(10L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-10");
+        ReflectionTestUtils.setField(replayedTask, "id", 100L);
+        ReflectionTestUtils.setField(replayedTask, "status", MediaDerivativeTaskStatus.PENDING);
+        ReflectionTestUtils.setField(replayedTask, "lastError", "manual replay requested");
+
+        when(mediaDerivativeTaskRepository.findById(100L)).thenReturn(Optional.of(failedTask));
+        when(mediaDerivativeTaskService.replayFailedTask(eq(100L), eq("manual replay requested"), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(replayedTask));
+
+        MediaDerivativeTask result = service.replayFailedTask(100L, " ");
+
+        assertThat(result.getId()).isEqualTo(100L);
+        assertThat(result.getStatus()).isEqualTo(MediaDerivativeTaskStatus.PENDING);
+    }
+
+    @Test
+    void replayFailedTask_rejectsNonFailedTask() {
+        MediaWorkerOpsService service = createService();
+        MediaDerivativeTask completedTask = MediaDerivativeTask.createPending(11L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event-11");
+        ReflectionTestUtils.setField(completedTask, "id", 101L);
+        ReflectionTestUtils.setField(completedTask, "status", MediaDerivativeTaskStatus.COMPLETED);
+
+        when(mediaDerivativeTaskRepository.findById(101L)).thenReturn(Optional.of(completedTask));
+
+        assertThatThrownBy(() -> service.replayFailedTask(101L, "retry"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("FAILED");
+        verify(mediaDerivativeTaskService, never())
+                .replayFailedTask(eq(101L), any(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void backfill_enqueuesOnlyMissingTasks() {
+        MediaWorkerOpsService service = createService();
+        MediaWorkerBackfillRequest request = new MediaWorkerBackfillRequest();
+        ReflectionTestUtils.setField(request, "size", 10);
+        ReflectionTestUtils.setField(request, "derivativeProfile", "THUMBNAIL_WEBP");
+
+        MediaFileRecord candidateA = mock(MediaFileRecord.class);
+        MediaFileRecord candidateB = mock(MediaFileRecord.class);
+        when(candidateA.getId()).thenReturn(201L);
+        when(candidateB.getId()).thenReturn(202L);
+
+        when(mediaFileRecordRepository.findBackfillCandidates(any(), eq(null), eq(null), any(Pageable.class)))
+                .thenReturn(List.of(candidateA, candidateB));
+        when(mediaDerivativeTaskRepository.findByMediaIdAndDerivativeProfileAndMediaVersion(
+                201L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L
+        )).thenReturn(Optional.empty());
+        when(mediaDerivativeTaskRepository.findByMediaIdAndDerivativeProfileAndMediaVersion(
+                202L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L
+        )).thenReturn(Optional.of(MediaDerivativeTask.createPending(202L, MediaDerivativeProfile.THUMBNAIL_WEBP, 1L, "event")));
+
+        MediaWorkerBackfillResponse response = service.backfill(request);
+
+        assertThat(response.getScannedCount()).isEqualTo(2L);
+        assertThat(response.getQueuedCount()).isEqualTo(1L);
+        assertThat(response.getExistingCount()).isEqualTo(1L);
+        verify(mediaDerivativeTaskService).enqueuePending(201L, 1L, MediaDerivativeProfile.THUMBNAIL_WEBP, "ops-backfill");
+    }
+
+    private MediaWorkerOpsService createService() {
+        return new MediaWorkerOpsService(
+                mediaDerivativeTaskRepository,
+                mediaDerivativeTaskDlqRepository,
+                mediaFileRecordRepository,
+                mediaDerivativeTaskService
+        );
+    }
+}


### PR DESCRIPTION
## 개요

Media Worker 운영 복구 시나리오(#679)를 위해 운영 API/메트릭/재처리(backfill/replay) 경로를 추가하고, 관련 코드를 `ops` 패키지로 정리했습니다.

### 관련 이슈
- Related #676
- Closes #679

### 작업 / 변경 내용
- `media_derivative_tasks` 상태 집계 및 DLQ 조회/재시도/백필용 내부 API 추가
  - `GET /internal/v1/media-worker/tasks/summary`
  - `GET /internal/v1/media-worker/tasks/dlq?size=`
  - `POST /internal/v1/media-worker/tasks/{taskId}/replay`
  - `POST /internal/v1/media-worker/tasks/backfill`
- 워커 실패 처리 결과를 outcome(`RETRY_SCHEDULED`/`DLQ_FAILED`/`SKIPPED`)로 명시화
- 스케줄러에 워커 메트릭 연동
  - 성공/실패/재시도 예약/DLQ/stale-recovery 카운터
  - 처리 지연 타이머
- FAILED 작업 수동 재큐잉 상태 전이 추가 (`FAILED -> PENDING`)
- 백필 후보 조회 및 DLQ 최근 조회를 위한 repository 메서드 추가
- 관련 테스트 보강
  - `MediaDerivativeTaskServiceTest`
  - `MediaDerivativeTaskSchedulerTest`
  - `MediaWorkerOpsServiceTest`(신규)

### 테스트 / 체크리스트
- [ ] 로컬에서 전체 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
  - `./gradlew :servers:services:media-worker:test --no-daemon`
- [x] 스키마/마이그레이션 변경 없음

### 참고사항
- 패키지 정리는 신규 운영 코드 영역(`dto/internal/ops`, `service/ops`) 위주로 선반영했습니다.
