### PR TITLE
test(#675): verify media-worker ops recovery path in e2e

### DIFF
--- a/docker/scripts/search_enricher_dlq_verify.sh
+++ b/docker/scripts/search_enricher_dlq_verify.sh
@@ -555,6 +555,120 @@ wait_search_task_retry_observed() {
   return 1
 }
 
+wait_media_task_exists() {
+  local media_id="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  while [[ "$elapsed" -lt "$timeout_seconds" ]]; do
+    local task_id
+    task_id="$(psql_query media_db "SELECT COALESCE(id::text, '') FROM media_derivative_tasks WHERE media_id=${media_id} ORDER BY created_at DESC LIMIT 1;")"
+    if [[ -n "$task_id" ]]; then
+      printf '%s\n' "$task_id"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  return 1
+}
+
+wait_media_task_left_failed() {
+  local task_id="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  while [[ "$elapsed" -lt "$timeout_seconds" ]]; do
+    local status
+    status="$(psql_query media_db "SELECT COALESCE(status, '') FROM media_derivative_tasks WHERE id=${task_id};")"
+    if [[ "$status" != "FAILED" && -n "$status" ]]; then
+      pass "replayed media task moved out of FAILED (taskId=${task_id}, status=${status})"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  fail "replayed media task remained FAILED (taskId=${task_id})"
+  return 1
+}
+
+run_media_worker_ops_case() {
+  echo "[INFO] case3: media-worker ops API recovery paths"
+  local media_ops task_id
+  create_media_and_confirm media_ops "ops-e2e-m1" || return 1
+
+  task_id="$(wait_media_task_exists "$media_ops" 30 || true)"
+  if [[ -z "$task_id" ]]; then
+    fail "media task not found for ops case (mediaId=${media_ops})"
+    return 1
+  fi
+  pass "media task exists for ops case (mediaId=${media_ops}, taskId=${task_id})"
+
+  psql_exec media_db "
+    UPDATE media_derivative_tasks
+       SET status = 'FAILED',
+           completed_at = NOW(),
+           processing_started_at = NULL,
+           next_retry_at = NULL,
+           retry_count = COALESCE(retry_count, 0) + 1,
+           last_error = 'ops-injected failure'
+     WHERE id = ${task_id};
+  "
+  pass "media task forced to FAILED for replay validation (taskId=${task_id})"
+
+  local summary_raw summary_body summary_status failed_count
+  summary_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${WORKER_PORT}/internal/v1/media-worker/tasks/summary")"
+  summary_body="$(extract_http_body "$summary_raw")"
+  summary_status="$(extract_http_status "$summary_raw")"
+  ensure_http_status "media-worker ops summary status" "$summary_status" "200" || return 1
+  ensure_json_success "media-worker ops summary success" "$summary_body" || return 1
+  failed_count="$(echo "$summary_body" | jq -r '.data.failedCount // 0')"
+  if [[ "$failed_count" =~ ^[0-9]+$ && "$failed_count" -ge 1 ]]; then
+    pass "media-worker ops summary reports failedCount>=1"
+  else
+    fail "media-worker ops summary failedCount invalid (actual=${failed_count})"
+    return 1
+  fi
+
+  local dlq_raw dlq_body dlq_status
+  dlq_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${WORKER_PORT}/internal/v1/media-worker/tasks/dlq?size=5")"
+  dlq_body="$(extract_http_body "$dlq_raw")"
+  dlq_status="$(extract_http_status "$dlq_raw")"
+  ensure_http_status "media-worker ops dlq status" "$dlq_status" "200" || return 1
+  ensure_json_success "media-worker ops dlq success" "$dlq_body" || return 1
+
+  local replay_raw replay_body replay_status replay_queued
+  replay_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${WORKER_PORT}/internal/v1/media-worker/tasks/${task_id}/replay" \
+    -H "Content-Type: application/json" \
+    -d '{"reason":"ops e2e replay"}')"
+  replay_body="$(extract_http_body "$replay_raw")"
+  replay_status="$(extract_http_status "$replay_raw")"
+  ensure_http_status "media-worker ops replay status" "$replay_status" "200" || return 1
+  ensure_json_success "media-worker ops replay success" "$replay_body" || return 1
+  replay_queued="$(echo "$replay_body" | jq -r '.data.queued // false')"
+  if [[ "$replay_queued" == "true" ]]; then
+    pass "media-worker ops replay queued=true"
+  else
+    fail "media-worker ops replay queued flag mismatch"
+    return 1
+  fi
+  wait_media_task_left_failed "$task_id" 40 || return 1
+
+  local backfill_raw backfill_body backfill_status scanned_count
+  backfill_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${WORKER_PORT}/internal/v1/media-worker/tasks/backfill" \
+    -H "Content-Type: application/json" \
+    -d "{\"fromMediaId\":${media_ops},\"toMediaId\":${media_ops},\"size\":10,\"derivativeProfile\":\"THUMBNAIL_WEBP\"}")"
+  backfill_body="$(extract_http_body "$backfill_raw")"
+  backfill_status="$(extract_http_status "$backfill_raw")"
+  ensure_http_status "media-worker ops backfill status" "$backfill_status" "200" || return 1
+  ensure_json_success "media-worker ops backfill success" "$backfill_body" || return 1
+  scanned_count="$(echo "$backfill_body" | jq -r '.data.scannedCount // 0')"
+  if [[ "$scanned_count" =~ ^[0-9]+$ && "$scanned_count" -ge 1 ]]; then
+    pass "media-worker ops backfill scannedCount>=1"
+  else
+    fail "media-worker ops backfill scannedCount invalid (actual=${scanned_count})"
+    return 1
+  fi
+}
+
 run_enricher_e2e_cases() {
   echo "[INFO] case1: search enricher happy path"
   local media1 item1 title1
@@ -583,7 +697,7 @@ run_enricher_e2e_cases() {
 }
 
 run_dlq_case() {
-  echo "[INFO] case3: search consumer DLQ on indexing failure"
+  echo "[INFO] case4: search consumer DLQ on indexing failure"
   (cd "$ROOT/docker" && docker compose stop elasticsearch >/dev/null)
   pass "elasticsearch stopped for DLQ injection"
 
@@ -653,6 +767,7 @@ reset_data
 recreate_search_index
 
 run_enricher_e2e_cases
+run_media_worker_ops_case
 run_dlq_case
 
 echo "[INFO] result passes=${PASSES} failures=${FAILURES}"

--- a/docs/media-worker-ops-runbook.md
+++ b/docs/media-worker-ops-runbook.md
@@ -1,0 +1,142 @@
+# Media Worker 운영 Runbook
+
+## 1. 목적
+
+이 문서는 Media Worker 장애/지연 상황에서 운영자가 실제로 확인하고 복구할 수 있는 절차를 정리한다.
+핵심 대상은 아래 4가지다.
+
+- 파생 처리 상태 요약 확인
+- FAILED/DLQ 누적 확인
+- FAILED 작업 수동 replay
+- 범위 기반 backfill enqueue
+
+## 2. 파생 처리 규칙(현재 구현 기준)
+
+코드 기준:
+- `MediaWorkerDerivativeProperties`
+- `S3MediaDerivativeProcessor`
+
+기본 규칙:
+- 출력 포맷: `image/webp`
+- 썸네일 최대 크기: `640x640` (비율 유지)
+- 기본 품질: `0.82` (WebP writer 품질 82)
+- objectKey: 원본 `.../raw/...` 기준 `.../derived/...` 경로로 변환
+
+환경변수:
+- `MEDIA_WORKER_DERIVATIVE_THUMBNAIL_MAX_WIDTH`
+- `MEDIA_WORKER_DERIVATIVE_THUMBNAIL_MAX_HEIGHT`
+- `MEDIA_WORKER_DERIVATIVE_WEBP_QUALITY`
+
+## 3. 상태머신
+
+- `PENDING`: 처리 대기
+- `PROCESSING`: 워커 점유/처리중
+- `COMPLETED`: 파생본 생성 완료
+- `FAILED`: 재시도 한계 초과 또는 비재시도 오류
+
+복구 전이:
+- stale `PROCESSING` -> `PENDING`
+- 운영 replay 시 `FAILED` -> `PENDING`
+
+## 4. 운영 API
+
+base URL 예시:
+- `http://127.0.0.1:18395/internal/v1/media-worker`
+
+### 4.1 상태 요약
+
+```bash
+curl -sS "http://127.0.0.1:18395/internal/v1/media-worker/tasks/summary" | jq
+```
+
+확인 포인트:
+- `pendingCount`, `processingCount`, `completedCount`, `failedCount`, `dlqCount`
+
+### 4.2 DLQ 최근 목록
+
+```bash
+curl -sS "http://127.0.0.1:18395/internal/v1/media-worker/tasks/dlq?size=20" | jq
+```
+
+확인 포인트:
+- `items[].taskId`, `mediaId`, `errorCode`, `retryCount`, `createdAt`
+
+### 4.3 FAILED 작업 replay
+
+```bash
+curl -sS -X POST \
+  "http://127.0.0.1:18395/internal/v1/media-worker/tasks/{taskId}/replay" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"manual replay by operator"}' | jq
+```
+
+성공 조건:
+- `data.queued == true`
+- 이후 DB에서 해당 task가 `FAILED`가 아닌 상태로 이동
+
+### 4.4 backfill enqueue
+
+```bash
+curl -sS -X POST \
+  "http://127.0.0.1:18395/internal/v1/media-worker/tasks/backfill" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fromMediaId": 1000,
+    "toMediaId": 5000,
+    "size": 200,
+    "derivativeProfile": "THUMBNAIL_WEBP"
+  }' | jq
+```
+
+응답 의미:
+- `scannedCount`: 조회된 media_files 수
+- `queuedCount`: 신규 enqueue 수
+- `existingCount`: 기존 task 존재로 스킵된 수
+
+## 5. 메트릭
+
+`MediaWorkerMetricsService` 기준:
+- `media.worker.tasks.success.total`
+- `media.worker.tasks.failure.total`
+- `media.worker.tasks.retry.scheduled.total`
+- `media.worker.tasks.dlq.total`
+- `media.worker.tasks.stale.recovered.total`
+- `media.worker.tasks.processing.latency`
+
+기본 운영 확인:
+- 실패율 증가와 DLQ 증가가 동시에 나타나면 외부 의존성(S3/네트워크/포맷) 우선 점검
+- `processing.latency` 증가와 `pendingCount` 증가가 동반되면 워커 처리량 또는 외부 I/O 병목 점검
+
+## 6. 장애 대응 절차
+
+1. 요약 조회로 `failedCount`, `dlqCount` 급증 여부 확인
+2. DLQ 조회로 대표 `errorCode`/`errorMessage` 패턴 확인
+3. 원인(외부 의존/포맷/권한) 조치
+4. `replay` 또는 `backfill`로 복구 수행
+5. 요약/메트릭 재확인
+
+## 7. 검증 스크립트
+
+### 7.1 Search Enricher + DLQ + Worker Ops E2E
+
+아래 스크립트는 다음을 한 번에 검증한다.
+- Product/Search 연계 썸네일 보강 정합성
+- Search DLQ 적재
+- Media Worker Ops API(summary/dlq/replay/backfill)
+
+```bash
+bash docker/scripts/search_enricher_dlq_verify.sh
+```
+
+성공 기준:
+- 마지막 출력이 `failures=0`
+
+## 8. 롤백 가이드
+
+문제 발생 시 우선순위:
+1. worker 스케줄/파생 기능 환경변수 off (`MEDIA_WORKER_DERIVATIVE_ENABLED=false`)
+2. 기존 원본 URL fallback 정책 유지
+3. 실패 원인 조치 후 replay/backfill 재개
+
+주의:
+- Product/Search는 `mediaId` 계약을 유지하므로, worker off 상태에서도 조회 경로는 원본 fallback으로 동작해야 한다.


### PR DESCRIPTION
## 개요

Media Worker 운영 복구 경로를 실제 E2E 검증에 포함하고, 운영자가 즉시 사용할 수 있는 Runbook을 추가했습니다.

### 관련 이슈
- Related #676
- Closes #675

### 작업 / 변경 내용
- `docker/scripts/search_enricher_dlq_verify.sh` 확장
  - 기존 Search Enricher + DLQ 시나리오에 Media Worker Ops API 검증 케이스 추가
  - 검증 대상:
    - `GET /internal/v1/media-worker/tasks/summary`
    - `GET /internal/v1/media-worker/tasks/dlq`
    - `POST /internal/v1/media-worker/tasks/{taskId}/replay`
    - `POST /internal/v1/media-worker/tasks/backfill`
  - 실패 주입(강제 FAILED) 후 replay로 상태 복구되는지까지 확인
- 운영 문서 추가
  - `docs/media-worker-ops-runbook.md`
  - 파생 규칙(WebP/640x640/quality), 상태머신, 운영 API 사용법, 메트릭, 장애 대응 절차 정리

### 테스트 / 체크리스트
- [ ] 로컬에서 전체 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
  - `./gradlew :servers:services:media-worker:test --no-daemon`
  - `bash docker/scripts/search_enricher_dlq_verify.sh` (passes=75, failures=0)
- [x] 스키마/마이그레이션 변경 없음

### 참고사항
- `.kiro/`는 `.gitignore` 대상이라 동일 내용을 추적 가능한 `docs/`에 반영했습니다.
