### PR TITLE
fix(#708): enforce item type boundary in product APIs

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
+++ b/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
@@ -15,6 +15,7 @@ public enum ProductErrorCode implements DomainErrorCode {
     INVALID_ITEM_STATUS_TRANSITION("PRODUCT-003", "유효하지 않은 상품 상태 전이입니다", HttpStatus.BAD_REQUEST),
     ITEM_NOT_EDITABLE("PRODUCT-004", "수정할 수 없는 상태의 상품입니다", HttpStatus.BAD_REQUEST),
     ITEM_NOT_DELETABLE("PRODUCT-005", "삭제할 수 없는 상태의 상품입니다", HttpStatus.BAD_REQUEST),
+    ITEM_TYPE_MISMATCH("PRODUCT-006", "요청한 상품 타입과 실제 상품 타입이 일치하지 않습니다", HttpStatus.BAD_REQUEST),
 
     // Category
     CATEGORY_NOT_FOUND("PRODUCT-101", "카테고리를 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -93,6 +93,7 @@ public class GoodsCommandService {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        validateItemType(item, ItemType.GOODS);
         if (!item.isEditable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
         }
@@ -156,6 +157,7 @@ public class GoodsCommandService {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        validateItemType(item, ItemType.GOODS);
         if (!item.isDeletable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
         }
@@ -202,6 +204,12 @@ public class GoodsCommandService {
                 .toList();
         itemGoodsLinkRepository.saveAll(links);
         return performanceItemIds;
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -179,13 +179,21 @@ public class PerformanceCommandService {
     }
 
     private Item getItem(Long itemId) {
-        return itemRepository.findByIdForUpdate(itemId)
+        Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.PERFORMANCE);
+        return item;
     }
 
     private Performance getPerformance(Long itemId) {
         return performanceRepository.findByItemId(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PERFORMANCE_NOT_FOUND));
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -88,6 +88,7 @@ public class ProductCommandService {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        validateItemType(item, ItemType.PRODUCT);
         if (!item.isEditable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
         }
@@ -142,6 +143,7 @@ public class ProductCommandService {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
+        validateItemType(item, ItemType.PRODUCT);
         if (!item.isDeletable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
         }
@@ -167,6 +169,12 @@ public class ProductCommandService {
         ShippingInfo si = ShippingInfo.create(itemId, request.getShippingFee(),
                 request.getFreeShippingThreshold(), request.getEstimatedDays(), request.getReturnPolicy());
         return shippingInfoRepository.save(si);
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
@@ -40,6 +40,7 @@ public class GoodsQueryService {
     public GoodsDetailResponse findGoodsById(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.GOODS);
         List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
         ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
         List<Long> linkedIds = itemGoodsLinkRepository.findByGoodsItemId(itemId).stream()
@@ -89,5 +90,11 @@ public class GoodsQueryService {
 
         String nextCursor = hasNext ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId()) : null;
         return CursorResponse.of(content, nextCursor);
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
@@ -40,6 +40,7 @@ public class PerformanceQueryService {
     public PerformanceDetailResponse findById(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.PERFORMANCE);
         Performance performance = performanceRepository.findByItemId(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PERFORMANCE_NOT_FOUND));
         List<SeatGrade> seatGrades = seatGradeRepository.findByPerformanceIdOrderByPriceDesc(performance.getId());
@@ -77,5 +78,11 @@ public class PerformanceQueryService {
 
         String nextCursor = hasNext ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId()) : null;
         return CursorResponse.of(content, nextCursor);
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/ProductQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/ProductQueryService.java
@@ -37,6 +37,7 @@ public class ProductQueryService {
     public GoodsDetailResponse findProductById(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.PRODUCT);
         List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
         ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
         List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
@@ -77,5 +78,11 @@ public class ProductQueryService {
 
         String nextCursor = hasNext ? CursorUtils.encode(pageItems.get(pageItems.size() - 1).getId()) : null;
         return CursorResponse.of(content, nextCursor);
+    }
+
+    private void validateItemType(Item item, ItemType expectedType) {
+        if (item.getItemType() != expectedType) {
+            throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
     }
 }

--- a/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.product.service.command;
 
+import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
+import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.ItemGoodsLinkRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemOptionRepository;
@@ -20,7 +22,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,12 +68,33 @@ class GoodsCommandServiceTest {
         assertThat(item.getThumbnailMediaId()).isNull();
     }
 
+    @Test
+    void delete_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 2L;
+        Long sellerId = 10L;
+        Item productItem = createItem(itemId, sellerId, ItemType.PRODUCT);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(productItem));
+
+        assertThatThrownBy(() -> goodsCommandService.delete(itemId, sellerId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemGoodsLinkRepository, itemImageRepository);
+        verifyNoInteractions(itemThumbnailSyncService);
+    }
+
     private Item createItem(Long id, Long sellerId) {
+        return createItem(id, sellerId, ItemType.GOODS);
+    }
+
+    private Item createItem(Long id, Long sellerId, ItemType itemType) {
         Item item = Item.create(
                 "goods",
                 "desc",
                 1000L,
-                ItemType.GOODS,
+                itemType,
                 null,
                 sellerId,
                 100L,

--- a/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
@@ -1,9 +1,11 @@
 package com.example.product.service.command;
 
+import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
 import com.example.product.entity.performance.Performance;
+import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.CastMemberRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemRepository;
@@ -23,7 +25,9 @@ import java.time.LocalTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,12 +73,33 @@ class PerformanceCommandServiceTest {
         assertThat(item.getThumbnailMediaId()).isNull();
     }
 
+    @Test
+    void delete_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 3L;
+        Long sellerId = 10L;
+        Item goodsItem = createItem(itemId, sellerId, ItemType.GOODS);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
+
+        assertThatThrownBy(() -> performanceCommandService.delete(itemId, sellerId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(seatGradeRepository, castMemberRepository, performanceRepository, itemImageRepository);
+        verifyNoInteractions(itemThumbnailSyncService);
+    }
+
     private Item createItem(Long id, Long sellerId) {
+        return createItem(id, sellerId, ItemType.PERFORMANCE);
+    }
+
+    private Item createItem(Long id, Long sellerId, ItemType itemType) {
         Item item = Item.create(
                 "performance",
                 "desc",
                 1000L,
-                ItemType.PERFORMANCE,
+                itemType,
                 null,
                 sellerId,
                 100L,

--- a/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
@@ -176,6 +176,25 @@ class ProductCommandServiceTest {
     }
 
     @Test
+    void updateProduct_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 1L;
+        Long sellerId = 10L;
+        Item goodsItem = createItem(itemId, sellerId, ItemType.GOODS);
+        ProductUpdateRequest request = new ProductUpdateRequest();
+        ReflectionTestUtils.setField(request, "title", "updated");
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
+
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(itemThumbnailSyncService);
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
     void delete_clearsItemMediaLinks() {
         Long itemId = 1L;
         Long sellerId = 10L;
@@ -192,12 +211,30 @@ class ProductCommandServiceTest {
         assertThat(item.getThumbnailMediaId()).isNull();
     }
 
+    @Test
+    void delete_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 1L;
+        Long sellerId = 10L;
+        Item goodsItem = createItem(itemId, sellerId, ItemType.GOODS);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
+
+        assertThatThrownBy(() -> productCommandService.delete(itemId, sellerId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+    }
+
     private Item createItem(Long id, Long sellerId) {
+        return createItem(id, sellerId, ItemType.PRODUCT);
+    }
+
+    private Item createItem(Long id, Long sellerId, ItemType itemType) {
         Item item = Item.create(
                 "item",
                 "desc",
                 1000L,
-                ItemType.PRODUCT,
+                itemType,
                 null,
                 sellerId,
                 100L,

--- a/servers/services/product/src/test/java/com/example/product/service/query/GoodsQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/GoodsQueryServiceTest.java
@@ -1,0 +1,56 @@
+package com.example.product.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemType;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.ItemGoodsLinkRepository;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemOptionRepository;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.ShippingInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GoodsQueryServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ItemOptionRepository itemOptionRepository;
+    @Mock
+    private ShippingInfoRepository shippingInfoRepository;
+    @Mock
+    private ItemGoodsLinkRepository itemGoodsLinkRepository;
+    @Mock
+    private ItemImageRepository itemImageRepository;
+
+    @InjectMocks
+    private GoodsQueryService goodsQueryService;
+
+    @Test
+    void findGoodsById_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 100L;
+        Item productItem = Item.create("product", "desc", 1000L, ItemType.PRODUCT, null, 1L, 1L, null);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(productItem));
+
+        assertThatThrownBy(() -> goodsQueryService.findGoodsById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemGoodsLinkRepository, itemImageRepository);
+    }
+}
+

--- a/servers/services/product/src/test/java/com/example/product/service/query/PerformanceQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/PerformanceQueryServiceTest.java
@@ -1,0 +1,56 @@
+package com.example.product.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemType;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CastMemberRepository;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.PerformanceRepository;
+import com.example.product.repository.SeatGradeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceQueryServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private PerformanceRepository performanceRepository;
+    @Mock
+    private SeatGradeRepository seatGradeRepository;
+    @Mock
+    private CastMemberRepository castMemberRepository;
+    @Mock
+    private ItemImageRepository itemImageRepository;
+
+    @InjectMocks
+    private PerformanceQueryService performanceQueryService;
+
+    @Test
+    void findById_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 100L;
+        Item goodsItem = Item.create("goods", "desc", 1000L, ItemType.GOODS, null, 1L, 1L, null);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(goodsItem));
+
+        assertThatThrownBy(() -> performanceQueryService.findById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(performanceRepository, seatGradeRepository, castMemberRepository, itemImageRepository);
+    }
+}
+

--- a/servers/services/product/src/test/java/com/example/product/service/query/ProductQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/ProductQueryServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.product.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemType;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemOptionRepository;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.ShippingInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductQueryServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ItemOptionRepository itemOptionRepository;
+    @Mock
+    private ShippingInfoRepository shippingInfoRepository;
+    @Mock
+    private ItemImageRepository itemImageRepository;
+
+    @InjectMocks
+    private ProductQueryService productQueryService;
+
+    @Test
+    void findProductById_whenItemTypeMismatch_throwsBusinessError() {
+        Long itemId = 100L;
+        Item goodsItem = Item.create("goods", "desc", 1000L, ItemType.GOODS, null, 1L, 1L, null);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(goodsItem));
+
+        assertThatThrownBy(() -> productQueryService.findProductById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+
+        verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemImageRepository);
+    }
+}
+


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #708

### 작업 / 변경 내용
- 서비스별 itemType 경계를 강제해 교차 수정/조회 경로를 차단
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
