### PR TITLE
fix(#709): split seller detail APIs and enforce public visibility

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerGoodsQueryApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerGoodsQueryApi.java
@@ -1,0 +1,21 @@
+package com.example.product.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Seller Goods Query", description = "판매자 굿즈 조회 API (읽기)")
+public interface SellerGoodsQueryApi {
+
+    @Operation(summary = "판매자 굿즈 상세 조회")
+    @GetMapping("/{itemId}")
+    ApiResponse<GoodsDetailResponse> findSellerById(
+            @PathVariable Long itemId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+}
+

--- a/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerPerformanceQueryApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerPerformanceQueryApi.java
@@ -1,0 +1,21 @@
+package com.example.product.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.performance.response.PerformanceDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Seller Performance Query", description = "판매자 공연 조회 API (읽기)")
+public interface SellerPerformanceQueryApi {
+
+    @Operation(summary = "판매자 공연 상세 조회")
+    @GetMapping("/{itemId}")
+    ApiResponse<PerformanceDetailResponse> findSellerById(
+            @PathVariable Long itemId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+}
+

--- a/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerProductQueryApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/query/SellerProductQueryApi.java
@@ -1,0 +1,21 @@
+package com.example.product.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Seller Product Query", description = "판매자 일반상품 조회 API (읽기)")
+public interface SellerProductQueryApi {
+
+    @Operation(summary = "판매자 일반상품 상세 조회")
+    @GetMapping("/{itemId}")
+    ApiResponse<GoodsDetailResponse> findSellerById(
+            @PathVariable Long itemId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+}
+

--- a/servers/services/product/src/main/java/com/example/product/controller/query/SellerGoodsQueryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/query/SellerGoodsQueryController.java
@@ -1,0 +1,23 @@
+package com.example.product.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.query.SellerGoodsQueryApi;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import com.example.product.service.query.GoodsQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/seller/goods")
+@RequiredArgsConstructor
+public class SellerGoodsQueryController implements SellerGoodsQueryApi {
+
+    private final GoodsQueryService goodsQueryService;
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> findSellerById(Long itemId, Long sellerId) {
+        return ApiResponse.success(goodsQueryService.findSellerGoodsById(itemId, sellerId));
+    }
+}
+

--- a/servers/services/product/src/main/java/com/example/product/controller/query/SellerPerformanceQueryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/query/SellerPerformanceQueryController.java
@@ -1,0 +1,23 @@
+package com.example.product.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.query.SellerPerformanceQueryApi;
+import com.example.product.dto.performance.response.PerformanceDetailResponse;
+import com.example.product.service.query.PerformanceQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/seller/performances")
+@RequiredArgsConstructor
+public class SellerPerformanceQueryController implements SellerPerformanceQueryApi {
+
+    private final PerformanceQueryService performanceQueryService;
+
+    @Override
+    public ApiResponse<PerformanceDetailResponse> findSellerById(Long itemId, Long sellerId) {
+        return ApiResponse.success(performanceQueryService.findSellerById(itemId, sellerId));
+    }
+}
+

--- a/servers/services/product/src/main/java/com/example/product/controller/query/SellerProductQueryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/query/SellerProductQueryController.java
@@ -1,0 +1,23 @@
+package com.example.product.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.product.controller.api.query.SellerProductQueryApi;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import com.example.product.service.query.ProductQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/seller/products")
+@RequiredArgsConstructor
+public class SellerProductQueryController implements SellerProductQueryApi {
+
+    private final ProductQueryService productQueryService;
+
+    @Override
+    public ApiResponse<GoodsDetailResponse> findSellerById(Long itemId, Long sellerId) {
+        return ApiResponse.success(productQueryService.findSellerProductById(itemId, sellerId));
+    }
+}
+

--- a/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/GoodsQueryService.java
@@ -41,6 +41,20 @@ public class GoodsQueryService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         validateItemType(item, ItemType.GOODS);
+        validateVisibleStatus(item);
+        List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
+        ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
+        List<Long> linkedIds = itemGoodsLinkRepository.findByGoodsItemId(itemId).stream()
+                .map(ItemGoodsLink::getPerformanceItemId).toList();
+        List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
+        return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds, images);
+    }
+
+    public GoodsDetailResponse findSellerGoodsById(Long itemId, Long sellerId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.GOODS);
+        item.validateOwnership(sellerId);
         List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
         ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
         List<Long> linkedIds = itemGoodsLinkRepository.findByGoodsItemId(itemId).stream()
@@ -95,6 +109,12 @@ public class GoodsQueryService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateVisibleStatus(Item item) {
+        if (!VISIBLE_STATUSES.contains(item.getStatus())) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_FOUND);
         }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/PerformanceQueryService.java
@@ -41,6 +41,20 @@ public class PerformanceQueryService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         validateItemType(item, ItemType.PERFORMANCE);
+        validateVisibleStatus(item);
+        Performance performance = performanceRepository.findByItemId(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PERFORMANCE_NOT_FOUND));
+        List<SeatGrade> seatGrades = seatGradeRepository.findByPerformanceIdOrderByPriceDesc(performance.getId());
+        List<CastMember> castMembers = castMemberRepository.findByPerformanceId(performance.getId());
+        List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
+        return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers, images);
+    }
+
+    public PerformanceDetailResponse findSellerById(Long itemId, Long sellerId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.PERFORMANCE);
+        item.validateOwnership(sellerId);
         Performance performance = performanceRepository.findByItemId(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PERFORMANCE_NOT_FOUND));
         List<SeatGrade> seatGrades = seatGradeRepository.findByPerformanceIdOrderByPriceDesc(performance.getId());
@@ -83,6 +97,12 @@ public class PerformanceQueryService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateVisibleStatus(Item item) {
+        if (!VISIBLE_STATUSES.contains(item.getStatus())) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_FOUND);
         }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/ProductQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/ProductQueryService.java
@@ -38,6 +38,18 @@ public class ProductQueryService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         validateItemType(item, ItemType.PRODUCT);
+        validateVisibleStatus(item);
+        List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
+        ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
+        List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
+        return GoodsDetailResponse.of(item, options, shippingInfo, List.of(), images);
+    }
+
+    public GoodsDetailResponse findSellerProductById(Long itemId, Long sellerId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
+        validateItemType(item, ItemType.PRODUCT);
+        item.validateOwnership(sellerId);
         List<ItemOption> options = itemOptionRepository.findByItemId(itemId);
         ShippingInfo shippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
         List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
@@ -83,6 +95,12 @@ public class ProductQueryService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateVisibleStatus(Item item) {
+        if (!VISIBLE_STATUSES.contains(item.getStatus())) {
+            throw new BusinessException(ProductErrorCode.ITEM_NOT_FOUND);
         }
     }
 }

--- a/servers/services/product/src/test/java/com/example/product/service/query/GoodsQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/GoodsQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.example.product.service.query;
 
 import com.example.core.exception.BusinessException;
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.item.ItemType;
 import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.ItemGoodsLinkRepository;
@@ -14,9 +15,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -52,5 +56,37 @@ class GoodsQueryServiceTest {
 
         verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemGoodsLinkRepository, itemImageRepository);
     }
-}
 
+    @Test
+    void findGoodsById_whenItemNotVisible_throwsItemNotFound() {
+        Long itemId = 101L;
+        Item hiddenGoods = Item.create("goods", "desc", 1000L, ItemType.GOODS, null, 1L, 1L, null);
+        ReflectionTestUtils.setField(hiddenGoods, "status", ItemStatus.HIDDEN);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenGoods));
+
+        assertThatThrownBy(() -> goodsQueryService.findGoodsById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_NOT_FOUND);
+
+        verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemGoodsLinkRepository, itemImageRepository);
+    }
+
+    @Test
+    void findSellerGoodsById_whenOwnerCanAccessHiddenItem_returnsDetail() {
+        Long itemId = 102L;
+        Long sellerId = 9L;
+        Item hiddenGoods = Item.create("goods", "desc", 1000L, ItemType.GOODS, null, sellerId, 1L, null);
+        ReflectionTestUtils.setField(hiddenGoods, "status", ItemStatus.HIDDEN);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenGoods));
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of());
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.empty());
+        when(itemGoodsLinkRepository.findByGoodsItemId(itemId)).thenReturn(List.of());
+        when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(List.of());
+
+        assertThat(goodsQueryService.findSellerGoodsById(itemId, sellerId).getStatus())
+                .isEqualTo(ItemStatus.HIDDEN.name());
+    }
+}

--- a/servers/services/product/src/test/java/com/example/product/service/query/PerformanceQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/PerformanceQueryServiceTest.java
@@ -2,7 +2,9 @@ package com.example.product.service.query;
 
 import com.example.core.exception.BusinessException;
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.item.ItemType;
+import com.example.product.entity.performance.Performance;
 import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.CastMemberRepository;
 import com.example.product.repository.ItemImageRepository;
@@ -14,9 +16,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -52,5 +59,45 @@ class PerformanceQueryServiceTest {
 
         verifyNoInteractions(performanceRepository, seatGradeRepository, castMemberRepository, itemImageRepository);
     }
-}
 
+    @Test
+    void findById_whenItemNotVisible_throwsItemNotFound() {
+        Long itemId = 101L;
+        Item hiddenPerformance = Item.create("performance", "desc", 1000L, ItemType.PERFORMANCE, null, 1L, 1L, null);
+        ReflectionTestUtils.setField(hiddenPerformance, "status", ItemStatus.HIDDEN);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenPerformance));
+
+        assertThatThrownBy(() -> performanceQueryService.findById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_NOT_FOUND);
+
+        verifyNoInteractions(performanceRepository, seatGradeRepository, castMemberRepository, itemImageRepository);
+    }
+
+    @Test
+    void findSellerById_whenOwnerCanAccessHiddenItem_returnsDetail() {
+        Long itemId = 102L;
+        Long sellerId = 11L;
+        Item hiddenPerformance = Item.create("performance", "desc", 1000L, ItemType.PERFORMANCE, null, sellerId, 1L, null);
+        ReflectionTestUtils.setField(hiddenPerformance, "status", ItemStatus.HIDDEN);
+        Performance performance = Performance.create(
+                itemId,
+                "hall",
+                LocalDate.of(2030, 1, 1),
+                LocalTime.of(18, 0),
+                100
+        );
+        ReflectionTestUtils.setField(performance, "id", 500L);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenPerformance));
+        when(performanceRepository.findByItemId(itemId)).thenReturn(Optional.of(performance));
+        when(seatGradeRepository.findByPerformanceIdOrderByPriceDesc(500L)).thenReturn(List.of());
+        when(castMemberRepository.findByPerformanceId(500L)).thenReturn(List.of());
+        when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(List.of());
+
+        assertThat(performanceQueryService.findSellerById(itemId, sellerId).getStatus())
+                .isEqualTo(ItemStatus.HIDDEN.name());
+    }
+}

--- a/servers/services/product/src/test/java/com/example/product/service/query/ProductQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/ProductQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.example.product.service.query;
 
 import com.example.core.exception.BusinessException;
 import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
 import com.example.product.entity.item.ItemType;
 import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.ItemImageRepository;
@@ -13,9 +14,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -49,5 +53,36 @@ class ProductQueryServiceTest {
 
         verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemImageRepository);
     }
-}
 
+    @Test
+    void findProductById_whenItemNotVisible_throwsItemNotFound() {
+        Long itemId = 101L;
+        Item hiddenProduct = Item.create("product", "desc", 1000L, ItemType.PRODUCT, null, 1L, 1L, null);
+        ReflectionTestUtils.setField(hiddenProduct, "status", ItemStatus.HIDDEN);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenProduct));
+
+        assertThatThrownBy(() -> productQueryService.findProductById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_NOT_FOUND);
+
+        verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemImageRepository);
+    }
+
+    @Test
+    void findSellerProductById_whenOwnerCanAccessHiddenItem_returnsDetail() {
+        Long itemId = 102L;
+        Long sellerId = 7L;
+        Item hiddenProduct = Item.create("product", "desc", 1000L, ItemType.PRODUCT, null, sellerId, 1L, null);
+        ReflectionTestUtils.setField(hiddenProduct, "status", ItemStatus.HIDDEN);
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(hiddenProduct));
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of());
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.empty());
+        when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(List.of());
+
+        assertThat(productQueryService.findSellerProductById(itemId, sellerId).getStatus())
+                .isEqualTo(ItemStatus.HIDDEN.name());
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #709

### 작업 / 변경 내용
- 공개 상세 노출 정책을 목록과 일치시키고 판매자 전용 상세 경로를 분리
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
