### PR TITLE
fix(#710): add X-Store-Id ownership guard to product commands

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/controller/api/command/GoodsCommandApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/command/GoodsCommandApi.java
@@ -22,7 +22,8 @@ public interface GoodsCommandApi {
     @PostMapping
     ApiResponse<GoodsDetailResponse> create(
             @Valid @RequestBody GoodsCreateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "굿즈 수정")
     @ApiResponses({
@@ -35,7 +36,8 @@ public interface GoodsCommandApi {
     ApiResponse<GoodsDetailResponse> update(
             @PathVariable Long itemId,
             @Valid @RequestBody GoodsUpdateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "굿즈 삭제")
     @ApiResponses({
@@ -46,5 +48,6 @@ public interface GoodsCommandApi {
     @DeleteMapping("/{itemId}")
     ApiResponse<Void> delete(
             @PathVariable Long itemId,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/api/command/PerformanceCommandApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/command/PerformanceCommandApi.java
@@ -22,7 +22,8 @@ public interface PerformanceCommandApi {
     @PostMapping
     ApiResponse<PerformanceDetailResponse> create(
             @Valid @RequestBody PerformanceCreateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "공연 수정")
     @ApiResponses({
@@ -34,7 +35,8 @@ public interface PerformanceCommandApi {
     ApiResponse<PerformanceDetailResponse> update(
             @PathVariable Long itemId,
             @Valid @RequestBody PerformanceUpdateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "공연 삭제")
     @ApiResponses({
@@ -45,5 +47,6 @@ public interface PerformanceCommandApi {
     @DeleteMapping("/{itemId}")
     ApiResponse<Void> delete(
             @PathVariable Long itemId,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/api/command/ProductCommandApi.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/api/command/ProductCommandApi.java
@@ -22,7 +22,8 @@ public interface ProductCommandApi {
     @PostMapping
     ApiResponse<GoodsDetailResponse> create(
             @Valid @RequestBody ProductCreateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "일반상품 수정")
     @ApiResponses({
@@ -35,7 +36,8 @@ public interface ProductCommandApi {
     ApiResponse<GoodsDetailResponse> update(
             @PathVariable Long itemId,
             @Valid @RequestBody ProductUpdateRequest request,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 
     @Operation(summary = "일반상품 삭제")
     @ApiResponses({
@@ -46,5 +48,6 @@ public interface ProductCommandApi {
     @DeleteMapping("/{itemId}")
     ApiResponse<Void> delete(
             @PathVariable Long itemId,
-            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId);
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long sellerId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-Store-Id") Long storeId);
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/command/GoodsCommandController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/command/GoodsCommandController.java
@@ -7,7 +7,6 @@ import com.example.product.dto.goods.request.GoodsUpdateRequest;
 import com.example.product.dto.goods.response.GoodsDetailResponse;
 import com.example.product.service.command.GoodsCommandService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,18 +18,18 @@ public class GoodsCommandController implements GoodsCommandApi {
     private final GoodsCommandService goodsCommandService;
 
     @Override
-    public ApiResponse<GoodsDetailResponse> create(GoodsCreateRequest request, Long sellerId) {
-        return ApiResponse.success(goodsCommandService.createGoods(request, sellerId));
+    public ApiResponse<GoodsDetailResponse> create(GoodsCreateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(goodsCommandService.createGoods(request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<GoodsDetailResponse> update(Long itemId, GoodsUpdateRequest request, Long sellerId) {
-        return ApiResponse.success(goodsCommandService.updateGoods(itemId, request, sellerId));
+    public ApiResponse<GoodsDetailResponse> update(Long itemId, GoodsUpdateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(goodsCommandService.updateGoods(itemId, request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<Void> delete(Long itemId, Long sellerId) {
-        goodsCommandService.delete(itemId, sellerId);
+    public ApiResponse<Void> delete(Long itemId, Long sellerId, Long storeId) {
+        goodsCommandService.delete(itemId, sellerId, storeId);
         return ApiResponse.success();
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/command/PerformanceCommandController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/command/PerformanceCommandController.java
@@ -18,18 +18,18 @@ public class PerformanceCommandController implements PerformanceCommandApi {
     private final PerformanceCommandService performanceCommandService;
 
     @Override
-    public ApiResponse<PerformanceDetailResponse> create(PerformanceCreateRequest request, Long sellerId) {
-        return ApiResponse.success(performanceCommandService.create(request, sellerId));
+    public ApiResponse<PerformanceDetailResponse> create(PerformanceCreateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(performanceCommandService.create(request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<PerformanceDetailResponse> update(Long itemId, PerformanceUpdateRequest request, Long sellerId) {
-        return ApiResponse.success(performanceCommandService.update(itemId, request, sellerId));
+    public ApiResponse<PerformanceDetailResponse> update(Long itemId, PerformanceUpdateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(performanceCommandService.update(itemId, request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<Void> delete(Long itemId, Long sellerId) {
-        performanceCommandService.delete(itemId, sellerId);
+    public ApiResponse<Void> delete(Long itemId, Long sellerId, Long storeId) {
+        performanceCommandService.delete(itemId, sellerId, storeId);
         return ApiResponse.success();
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/controller/command/ProductCommandController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/command/ProductCommandController.java
@@ -18,18 +18,18 @@ public class ProductCommandController implements ProductCommandApi {
     private final ProductCommandService productCommandService;
 
     @Override
-    public ApiResponse<GoodsDetailResponse> create(ProductCreateRequest request, Long sellerId) {
-        return ApiResponse.success(productCommandService.createProduct(request, sellerId));
+    public ApiResponse<GoodsDetailResponse> create(ProductCreateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(productCommandService.createProduct(request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<GoodsDetailResponse> update(Long itemId, ProductUpdateRequest request, Long sellerId) {
-        return ApiResponse.success(productCommandService.updateProduct(itemId, request, sellerId));
+    public ApiResponse<GoodsDetailResponse> update(Long itemId, ProductUpdateRequest request, Long sellerId, Long storeId) {
+        return ApiResponse.success(productCommandService.updateProduct(itemId, request, sellerId, storeId));
     }
 
     @Override
-    public ApiResponse<Void> delete(Long itemId, Long sellerId) {
-        productCommandService.delete(itemId, sellerId);
+    public ApiResponse<Void> delete(Long itemId, Long sellerId, Long storeId) {
+        productCommandService.delete(itemId, sellerId, storeId);
         return ApiResponse.success();
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
+++ b/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
@@ -46,7 +46,8 @@ public enum ProductErrorCode implements DomainErrorCode {
     INVALID_THUMBNAIL_UPDATE_REQUEST("PRODUCT-605", "썸네일 변경 요청이 유효하지 않습니다", HttpStatus.BAD_REQUEST),
 
     // Authorization
-    UNAUTHORIZED_ACCESS("PRODUCT-901", "해당 상품에 대한 권한이 없습니다", HttpStatus.FORBIDDEN);
+    UNAUTHORIZED_ACCESS("PRODUCT-901", "해당 상품에 대한 권한이 없습니다", HttpStatus.FORBIDDEN),
+    STORE_OWNERSHIP_MISMATCH("PRODUCT-902", "요청한 가게 정보와 인증 가게 정보가 일치하지 않습니다", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -41,8 +42,9 @@ public class GoodsCommandService {
     private final ItemThumbnailSyncService itemThumbnailSyncService;
     private final EventPublisher eventPublisher;
 
-    public GoodsDetailResponse createGoods(GoodsCreateRequest request, Long sellerId) {
+    public GoodsDetailResponse createGoods(GoodsCreateRequest request, Long sellerId, Long storeIdHeader) {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
+        validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
@@ -89,11 +91,12 @@ public class GoodsCommandService {
         return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds, images);
     }
 
-    public GoodsDetailResponse updateGoods(Long itemId, GoodsUpdateRequest request, Long sellerId) {
+    public GoodsDetailResponse updateGoods(Long itemId, GoodsUpdateRequest request, Long sellerId, Long storeIdHeader) {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
         validateItemType(item, ItemType.GOODS);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isEditable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
         }
@@ -153,11 +156,12 @@ public class GoodsCommandService {
         return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds, images);
     }
 
-    public void delete(Long itemId, Long sellerId) {
+    public void delete(Long itemId, Long sellerId, Long storeIdHeader) {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
         validateItemType(item, ItemType.GOODS);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isDeletable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
         }
@@ -209,6 +213,12 @@ public class GoodsCommandService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
+        if (!Objects.equals(expectedStoreId, requestStoreId)) {
+            throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
         }
     }
 

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -38,8 +39,9 @@ public class PerformanceCommandService {
     private final ItemThumbnailSyncService itemThumbnailSyncService;
     private final EventPublisher eventPublisher;
 
-    public PerformanceDetailResponse create(PerformanceCreateRequest request, Long sellerId) {
+    public PerformanceDetailResponse create(PerformanceCreateRequest request, Long sellerId, Long storeIdHeader) {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
+        validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
@@ -94,9 +96,10 @@ public class PerformanceCommandService {
         return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers, images);
     }
 
-    public PerformanceDetailResponse update(Long itemId, PerformanceUpdateRequest request, Long sellerId) {
+    public PerformanceDetailResponse update(Long itemId, PerformanceUpdateRequest request, Long sellerId, Long storeIdHeader) {
         Item item = getItem(itemId);
         item.validateOwnership(sellerId);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isEditable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
         }
@@ -159,9 +162,10 @@ public class PerformanceCommandService {
         return PerformanceDetailResponse.of(item, performance, seatGrades, castMembers, images);
     }
 
-    public void delete(Long itemId, Long sellerId) {
+    public void delete(Long itemId, Long sellerId, Long storeIdHeader) {
         Item item = getItem(itemId);
         item.validateOwnership(sellerId);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isDeletable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
         }
@@ -193,6 +197,12 @@ public class PerformanceCommandService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
+        if (!Objects.equals(expectedStoreId, requestStoreId)) {
+            throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
         }
     }
 

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -41,8 +42,9 @@ public class ProductCommandService {
     private final ItemThumbnailSyncService itemThumbnailSyncService;
     private final EventPublisher eventPublisher;
 
-    public GoodsDetailResponse createProduct(ProductCreateRequest request, Long sellerId) {
+    public GoodsDetailResponse createProduct(ProductCreateRequest request, Long sellerId, Long storeIdHeader) {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
+        validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
@@ -84,11 +86,12 @@ public class ProductCommandService {
         return GoodsDetailResponse.of(item, options, shippingInfo, List.of(), images);
     }
 
-    public GoodsDetailResponse updateProduct(Long itemId, ProductUpdateRequest request, Long sellerId) {
+    public GoodsDetailResponse updateProduct(Long itemId, ProductUpdateRequest request, Long sellerId, Long storeIdHeader) {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
         validateItemType(item, ItemType.PRODUCT);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isEditable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_EDITABLE);
         }
@@ -139,11 +142,12 @@ public class ProductCommandService {
         return GoodsDetailResponse.of(item, options, shippingInfo, List.of(), images);
     }
 
-    public void delete(Long itemId, Long sellerId) {
+    public void delete(Long itemId, Long sellerId, Long storeIdHeader) {
         Item item = itemRepository.findByIdForUpdate(itemId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         item.validateOwnership(sellerId);
         validateItemType(item, ItemType.PRODUCT);
+        validateStoreOwnership(item.getStoreId(), storeIdHeader);
         if (!item.isDeletable()) {
             throw new BusinessException(ProductErrorCode.ITEM_NOT_DELETABLE);
         }
@@ -174,6 +178,12 @@ public class ProductCommandService {
     private void validateItemType(Item item, ItemType expectedType) {
         if (item.getItemType() != expectedType) {
             throw new BusinessException(ProductErrorCode.ITEM_TYPE_MISMATCH);
+        }
+    }
+
+    private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
+        if (!Objects.equals(expectedStoreId, requestStoreId)) {
+            throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
         }
     }
 

--- a/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
@@ -58,7 +58,7 @@ class GoodsCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
 
-        goodsCommandService.delete(itemId, sellerId);
+        goodsCommandService.delete(itemId, sellerId, 100L);
 
         verify(itemOptionRepository).softDeleteAllByItemId(itemId);
         verify(shippingInfoRepository).softDeleteByItemId(itemId);
@@ -76,13 +76,27 @@ class GoodsCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(productItem));
 
-        assertThatThrownBy(() -> goodsCommandService.delete(itemId, sellerId))
+        assertThatThrownBy(() -> goodsCommandService.delete(itemId, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
 
         verifyNoInteractions(itemOptionRepository, shippingInfoRepository, itemGoodsLinkRepository, itemImageRepository);
         verifyNoInteractions(itemThumbnailSyncService);
+    }
+
+    @Test
+    void delete_whenStoreHeaderMismatch_throwsOwnershipError() {
+        Long itemId = 2L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> goodsCommandService.delete(itemId, sellerId, 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
     }
 
     private Item createItem(Long id, Long sellerId) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
@@ -63,7 +63,7 @@ class PerformanceCommandServiceTest {
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
         when(performanceRepository.findByItemId(itemId)).thenReturn(Optional.of(performance));
 
-        performanceCommandService.delete(itemId, sellerId);
+        performanceCommandService.delete(itemId, sellerId, 100L);
 
         verify(seatGradeRepository).softDeleteAllByPerformanceId(100L);
         verify(castMemberRepository).softDeleteAllByPerformanceId(100L);
@@ -81,13 +81,27 @@ class PerformanceCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
 
-        assertThatThrownBy(() -> performanceCommandService.delete(itemId, sellerId))
+        assertThatThrownBy(() -> performanceCommandService.delete(itemId, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
 
         verifyNoInteractions(seatGradeRepository, castMemberRepository, performanceRepository, itemImageRepository);
         verifyNoInteractions(itemThumbnailSyncService);
+    }
+
+    @Test
+    void delete_whenStoreHeaderMismatch_throwsOwnershipError() {
+        Long itemId = 3L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> performanceCommandService.delete(itemId, sellerId, 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
     }
 
     private Item createItem(Long id, Long sellerId) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
@@ -69,7 +69,7 @@ class ProductCommandServiceTest {
         });
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of());
 
-        productCommandService.createProduct(request, 77L);
+        productCommandService.createProduct(request, 77L, 10L);
 
         verify(itemThumbnailSyncService).syncAfterCommit(itemId, 501L);
         verify(eventPublisher).publish(any(), any());
@@ -87,7 +87,7 @@ class ProductCommandServiceTest {
         when(mediaReferenceService.resolveMediaUrl(501L))
                 .thenThrow(new BusinessException(ProductErrorCode.INVALID_MEDIA_REFERENCE));
 
-        assertThatThrownBy(() -> productCommandService.createProduct(request, 77L))
+        assertThatThrownBy(() -> productCommandService.createProduct(request, 77L, 10L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.INVALID_MEDIA_REFERENCE);
@@ -112,7 +112,7 @@ class ProductCommandServiceTest {
         when(mediaReferenceService.resolveMediaUrl(888L)).thenReturn("https://media/888");
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of(image));
 
-        productCommandService.updateProduct(itemId, request, sellerId);
+        productCommandService.updateProduct(itemId, request, sellerId, 100L);
 
         verify(itemThumbnailSyncService).syncAfterCommit(itemId, 888L);
         verify(eventPublisher).publish(any(), any());
@@ -130,7 +130,7 @@ class ProductCommandServiceTest {
         when(mediaReferenceService.resolveMediaUrl(777L))
                 .thenThrow(new BusinessException(ProductErrorCode.INVALID_MEDIA_REFERENCE));
 
-        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId))
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.INVALID_MEDIA_REFERENCE);
@@ -149,7 +149,7 @@ class ProductCommandServiceTest {
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of());
 
-        productCommandService.updateProduct(itemId, request, sellerId);
+        productCommandService.updateProduct(itemId, request, sellerId, 100L);
 
         assertThat(item.getThumbnailMediaId()).isNull();
         verify(itemThumbnailSyncService).syncAfterCommit(itemId, null, true);
@@ -167,7 +167,7 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
 
-        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId))
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.INVALID_THUMBNAIL_UPDATE_REQUEST);
@@ -185,7 +185,7 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
 
-        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId))
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
@@ -202,7 +202,7 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
 
-        productCommandService.delete(itemId, sellerId);
+        productCommandService.delete(itemId, sellerId, 100L);
 
         verify(itemOptionRepository).softDeleteAllByItemId(itemId);
         verify(shippingInfoRepository).softDeleteByItemId(itemId);
@@ -219,10 +219,43 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(goodsItem));
 
-        assertThatThrownBy(() -> productCommandService.delete(itemId, sellerId))
+        assertThatThrownBy(() -> productCommandService.delete(itemId, sellerId, 100L))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.ITEM_TYPE_MISMATCH);
+    }
+
+    @Test
+    void createProduct_whenStoreHeaderMismatch_throwsOwnershipError() {
+        ProductCreateRequest request = new ProductCreateRequest();
+        ReflectionTestUtils.setField(request, "title", "new item");
+        ReflectionTestUtils.setField(request, "description", "desc");
+        ReflectionTestUtils.setField(request, "price", 1000L);
+        ReflectionTestUtils.setField(request, "storeId", 10L);
+
+        assertThatThrownBy(() -> productCommandService.createProduct(request, 77L, 99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+
+        verifyNoInteractions(itemRepository, itemThumbnailSyncService, eventPublisher);
+    }
+
+    @Test
+    void updateProduct_whenStoreHeaderMismatch_throwsOwnershipError() {
+        Long itemId = 1L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+        ProductUpdateRequest request = new ProductUpdateRequest();
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId, 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+
+        verifyNoInteractions(itemThumbnailSyncService, eventPublisher);
     }
 
     private Item createItem(Long id, Long sellerId) {


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #710

### 작업 / 변경 내용
- X-Store-Id 헤더 기반으로 seller-store 1차 소유권 가드를 추가
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
