### PR TITLE
fix(#711): enforce category referential integrity checks

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
+++ b/servers/services/product/src/main/java/com/example/product/exception/ProductErrorCode.java
@@ -21,6 +21,7 @@ public enum ProductErrorCode implements DomainErrorCode {
     CATEGORY_NOT_FOUND("PRODUCT-101", "카테고리를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     CATEGORY_DEPTH_EXCEEDED("PRODUCT-102", "카테고리 최대 깊이를 초과했습니다", HttpStatus.BAD_REQUEST),
     CATEGORY_HAS_CHILDREN("PRODUCT-103", "하위 카테고리가 있어 삭제할 수 없습니다", HttpStatus.CONFLICT),
+    CATEGORY_IN_USE("PRODUCT-104", "연결된 상품이 있어 카테고리를 삭제할 수 없습니다", HttpStatus.CONFLICT),
 
     // Performance
     PERFORMANCE_NOT_FOUND("PRODUCT-201", "공연 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/servers/services/product/src/main/java/com/example/product/repository/ItemRepository.java
+++ b/servers/services/product/src/main/java/com/example/product/repository/ItemRepository.java
@@ -40,5 +40,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     List<Item> findByCategoryIdOrderByIdDesc(Long categoryId, Pageable pageable);
 
+    boolean existsByCategoryId(Long categoryId);
+
     List<Item> findByStatusIn(List<ItemStatus> statuses, Pageable pageable);
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/CategoryCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/CategoryCommandService.java
@@ -6,6 +6,7 @@ import com.example.product.dto.category.request.CategoryUpdateRequest;
 import com.example.product.entity.category.Category;
 import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.CategoryRepository;
+import com.example.product.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryCommandService {
 
     private final CategoryRepository categoryRepository;
+    private final ItemRepository itemRepository;
 
     public Category create(CategoryCreateRequest request) {
         if (request.getParentId() == null) {
@@ -47,6 +49,9 @@ public class CategoryCommandService {
 
         if (categoryRepository.existsByParentId(id)) {
             throw new BusinessException(ProductErrorCode.CATEGORY_HAS_CHILDREN);
+        }
+        if (itemRepository.existsByCategoryId(id)) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_IN_USE);
         }
 
         category.softDelete();

--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -18,7 +18,12 @@ import com.example.product.event.ItemCreatedEvent;
 import com.example.product.event.ItemCreatedEvent.StockItemInfo;
 import com.example.product.event.ItemUpdatedEvent;
 import com.example.product.exception.ProductErrorCode;
-import com.example.product.repository.*;
+import com.example.product.repository.CategoryRepository;
+import com.example.product.repository.ItemGoodsLinkRepository;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemOptionRepository;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.ShippingInfoRepository;
 import com.example.product.service.command.image.ItemThumbnailSyncService;
 import com.example.product.service.command.image.MediaReferenceService;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +38,7 @@ import java.util.Objects;
 @Transactional
 public class GoodsCommandService {
 
+    private final CategoryRepository categoryRepository;
     private final ItemRepository itemRepository;
     private final ItemOptionRepository itemOptionRepository;
     private final ShippingInfoRepository shippingInfoRepository;
@@ -46,6 +52,7 @@ public class GoodsCommandService {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
         validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
+        validateCategoryExists(request.getCategoryId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
                 ItemType.GOODS, request.getCategoryId(), sellerId, request.getStoreId(),
@@ -106,6 +113,7 @@ public class GoodsCommandService {
         if (clearThumbnail && thumbnailMediaId != null) {
             throw new BusinessException(ProductErrorCode.INVALID_THUMBNAIL_UPDATE_REQUEST);
         }
+        validateCategoryExists(request.getCategoryId());
 
         if (clearThumbnail) {
             item.update(request.getTitle(), request.getDescription(), request.getPrice(),
@@ -219,6 +227,12 @@ public class GoodsCommandService {
     private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
         if (!Objects.equals(expectedStoreId, requestStoreId)) {
             throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+        }
+    }
+
+    private void validateCategoryExists(Long categoryId) {
+        if (categoryId != null && !categoryRepository.existsById(categoryId)) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_NOT_FOUND);
         }
     }
 

--- a/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/PerformanceCommandService.java
@@ -15,7 +15,12 @@ import com.example.product.entity.performance.SeatGrade;
 import com.example.product.event.ItemCreatedEvent;
 import com.example.product.event.ItemUpdatedEvent;
 import com.example.product.exception.ProductErrorCode;
-import com.example.product.repository.*;
+import com.example.product.repository.CastMemberRepository;
+import com.example.product.repository.CategoryRepository;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.PerformanceRepository;
+import com.example.product.repository.SeatGradeRepository;
 import com.example.product.service.command.image.ItemThumbnailSyncService;
 import com.example.product.service.command.image.MediaReferenceService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,7 @@ import java.util.Objects;
 @Transactional
 public class PerformanceCommandService {
 
+    private final CategoryRepository categoryRepository;
     private final ItemRepository itemRepository;
     private final PerformanceRepository performanceRepository;
     private final SeatGradeRepository seatGradeRepository;
@@ -43,6 +49,7 @@ public class PerformanceCommandService {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
         validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
+        validateCategoryExists(request.getCategoryId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
                 ItemType.PERFORMANCE, request.getCategoryId(), sellerId, request.getStoreId(),
@@ -109,6 +116,7 @@ public class PerformanceCommandService {
         if (clearThumbnail && thumbnailMediaId != null) {
             throw new BusinessException(ProductErrorCode.INVALID_THUMBNAIL_UPDATE_REQUEST);
         }
+        validateCategoryExists(request.getCategoryId());
 
         if (clearThumbnail) {
             item.update(request.getTitle(), request.getDescription(), request.getPrice(),
@@ -203,6 +211,12 @@ public class PerformanceCommandService {
     private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
         if (!Objects.equals(expectedStoreId, requestStoreId)) {
             throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+        }
+    }
+
+    private void validateCategoryExists(Long categoryId) {
+        if (categoryId != null && !categoryRepository.existsById(categoryId)) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_NOT_FOUND);
         }
     }
 

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -16,6 +16,7 @@ import com.example.product.entity.goods.ShippingInfo;
 import com.example.product.event.ItemCreatedEvent;
 import com.example.product.event.ItemUpdatedEvent;
 import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CategoryRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemOptionRepository;
 import com.example.product.repository.ItemRepository;
@@ -34,6 +35,7 @@ import java.util.Objects;
 @Transactional
 public class ProductCommandService {
 
+    private final CategoryRepository categoryRepository;
     private final ItemRepository itemRepository;
     private final ItemOptionRepository itemOptionRepository;
     private final ShippingInfoRepository shippingInfoRepository;
@@ -46,6 +48,7 @@ public class ProductCommandService {
         // TODO: store-service 연동 후 sellerId-storeId 소유권 검증을 추가한다.
         validateStoreOwnership(request.getStoreId(), storeIdHeader);
         mediaReferenceService.resolveMediaUrl(request.getThumbnailMediaId());
+        validateCategoryExists(request.getCategoryId());
         Item item = Item.create(
                 request.getTitle(), request.getDescription(), request.getPrice(),
                 ItemType.PRODUCT, request.getCategoryId(), sellerId, request.getStoreId(),
@@ -101,6 +104,7 @@ public class ProductCommandService {
         if (clearThumbnail && thumbnailMediaId != null) {
             throw new BusinessException(ProductErrorCode.INVALID_THUMBNAIL_UPDATE_REQUEST);
         }
+        validateCategoryExists(request.getCategoryId());
 
         if (clearThumbnail) {
             item.update(request.getTitle(), request.getDescription(), request.getPrice(),
@@ -184,6 +188,12 @@ public class ProductCommandService {
     private void validateStoreOwnership(Long expectedStoreId, Long requestStoreId) {
         if (!Objects.equals(expectedStoreId, requestStoreId)) {
             throw new BusinessException(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+        }
+    }
+
+    private void validateCategoryExists(Long categoryId) {
+        if (categoryId != null && !categoryRepository.existsById(categoryId)) {
+            throw new BusinessException(ProductErrorCode.CATEGORY_NOT_FOUND);
         }
     }
 

--- a/servers/services/product/src/test/java/com/example/product/service/command/CategoryCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/CategoryCommandServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.product.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.entity.category.Category;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CategoryRepository;
+import com.example.product.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryCommandServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private ItemRepository itemRepository;
+
+    @InjectMocks
+    private CategoryCommandService categoryCommandService;
+
+    @Test
+    void delete_whenCategoryIsReferencedByItems_throwsConflict() {
+        Long categoryId = 10L;
+        Category category = Category.createRoot("Root", 1);
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        when(categoryRepository.existsByParentId(categoryId)).thenReturn(false);
+        when(itemRepository.existsByCategoryId(categoryId)).thenReturn(true);
+
+        assertThatThrownBy(() -> categoryCommandService.delete(categoryId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.CATEGORY_IN_USE);
+    }
+
+    @Test
+    void delete_whenCategoryHasNoChildrenAndNoReferences_softDeletesCategory() {
+        Long categoryId = 11L;
+        Category category = Category.createRoot("Root", 1);
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        when(categoryRepository.existsByParentId(categoryId)).thenReturn(false);
+        when(itemRepository.existsByCategoryId(categoryId)).thenReturn(false);
+
+        categoryCommandService.delete(categoryId);
+
+        verify(categoryRepository).findById(categoryId);
+        verify(categoryRepository).existsByParentId(categoryId);
+        verify(itemRepository).existsByCategoryId(categoryId);
+    }
+}

--- a/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
@@ -2,9 +2,11 @@ package com.example.product.service.command;
 
 import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
+import com.example.product.dto.goods.request.GoodsCreateRequest;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
 import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CategoryRepository;
 import com.example.product.repository.ItemGoodsLinkRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemOptionRepository;
@@ -30,6 +32,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class GoodsCommandServiceTest {
 
+    @Mock
+    private CategoryRepository categoryRepository;
     @Mock
     private ItemRepository itemRepository;
     @Mock
@@ -97,6 +101,25 @@ class GoodsCommandServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+    }
+
+    @Test
+    void createGoods_whenCategoryNotFound_throwsBusinessError() {
+        GoodsCreateRequest request = new GoodsCreateRequest();
+        ReflectionTestUtils.setField(request, "title", "goods");
+        ReflectionTestUtils.setField(request, "description", "desc");
+        ReflectionTestUtils.setField(request, "price", 1000L);
+        ReflectionTestUtils.setField(request, "storeId", 1L);
+        ReflectionTestUtils.setField(request, "categoryId", 999L);
+
+        when(categoryRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() -> goodsCommandService.createGoods(request, 10L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.CATEGORY_NOT_FOUND);
+
+        verifyNoInteractions(itemRepository, itemThumbnailSyncService, eventPublisher);
     }
 
     private Item createItem(Long id, Long sellerId) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/PerformanceCommandServiceTest.java
@@ -2,10 +2,12 @@ package com.example.product.service.command;
 
 import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
+import com.example.product.dto.performance.request.PerformanceCreateRequest;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
 import com.example.product.entity.performance.Performance;
 import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CategoryRepository;
 import com.example.product.repository.CastMemberRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemRepository;
@@ -22,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +36,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PerformanceCommandServiceTest {
 
+    @Mock
+    private CategoryRepository categoryRepository;
     @Mock
     private ItemRepository itemRepository;
     @Mock
@@ -102,6 +107,30 @@ class PerformanceCommandServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
+    }
+
+    @Test
+    void create_whenCategoryNotFound_throwsBusinessError() {
+        PerformanceCreateRequest request = new PerformanceCreateRequest();
+        ReflectionTestUtils.setField(request, "title", "performance");
+        ReflectionTestUtils.setField(request, "description", "desc");
+        ReflectionTestUtils.setField(request, "price", 1000L);
+        ReflectionTestUtils.setField(request, "storeId", 1L);
+        ReflectionTestUtils.setField(request, "categoryId", 999L);
+        ReflectionTestUtils.setField(request, "venue", "hall");
+        ReflectionTestUtils.setField(request, "performanceDate", LocalDate.of(2030, 1, 1));
+        ReflectionTestUtils.setField(request, "performanceTime", LocalTime.of(18, 0));
+        ReflectionTestUtils.setField(request, "totalSeats", 100);
+        ReflectionTestUtils.setField(request, "seatGrades", List.of());
+
+        when(categoryRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() -> performanceCommandService.create(request, 10L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.CATEGORY_NOT_FOUND);
+
+        verifyNoInteractions(itemRepository, performanceRepository, seatGradeRepository, castMemberRepository, eventPublisher);
     }
 
     private Item createItem(Long id, Long sellerId) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
@@ -8,6 +8,7 @@ import com.example.product.entity.image.ItemImage;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
 import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.CategoryRepository;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemOptionRepository;
 import com.example.product.repository.ItemRepository;
@@ -33,6 +34,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ProductCommandServiceTest {
 
+    @Mock
+    private CategoryRepository categoryRepository;
     @Mock
     private ItemRepository itemRepository;
     @Mock
@@ -125,8 +128,10 @@ class ProductCommandServiceTest {
         Item item = createItem(itemId, sellerId);
         ProductUpdateRequest request = new ProductUpdateRequest();
         ReflectionTestUtils.setField(request, "thumbnailMediaId", 777L);
+        ReflectionTestUtils.setField(request, "categoryId", 10L);
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+        when(categoryRepository.existsById(10L)).thenReturn(true);
         when(mediaReferenceService.resolveMediaUrl(777L))
                 .thenThrow(new BusinessException(ProductErrorCode.INVALID_MEDIA_REFERENCE));
 
@@ -145,8 +150,10 @@ class ProductCommandServiceTest {
         Item item = createItem(itemId, sellerId);
         ProductUpdateRequest request = new ProductUpdateRequest();
         ReflectionTestUtils.setField(request, "clearThumbnail", true);
+        ReflectionTestUtils.setField(request, "categoryId", 10L);
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+        when(categoryRepository.existsById(10L)).thenReturn(true);
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of());
 
         productCommandService.updateProduct(itemId, request, sellerId, 100L);
@@ -192,6 +199,44 @@ class ProductCommandServiceTest {
 
         verifyNoInteractions(itemThumbnailSyncService);
         verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void createProduct_whenCategoryNotFound_throwsBusinessError() {
+        ProductCreateRequest request = new ProductCreateRequest();
+        ReflectionTestUtils.setField(request, "title", "new item");
+        ReflectionTestUtils.setField(request, "description", "desc");
+        ReflectionTestUtils.setField(request, "price", 1000L);
+        ReflectionTestUtils.setField(request, "storeId", 10L);
+        ReflectionTestUtils.setField(request, "categoryId", 999L);
+
+        when(categoryRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() -> productCommandService.createProduct(request, 77L, 10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.CATEGORY_NOT_FOUND);
+
+        verifyNoInteractions(itemRepository, itemThumbnailSyncService, eventPublisher);
+    }
+
+    @Test
+    void updateProduct_whenCategoryNotFound_throwsBusinessError() {
+        Long itemId = 1L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+        ProductUpdateRequest request = new ProductUpdateRequest();
+        ReflectionTestUtils.setField(request, "categoryId", 999L);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+        when(categoryRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() -> productCommandService.updateProduct(itemId, request, sellerId, 100L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.CATEGORY_NOT_FOUND);
+
+        verifyNoInteractions(itemThumbnailSyncService, eventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #711

### 작업 / 변경 내용
- 카테고리 존재/참조 무결성 검증을 생성·수정·삭제 경로에 적용
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
