### PR TITLE
fix(#713): return full snapshot after partial item updates

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/GoodsCommandService.java
@@ -130,24 +130,21 @@ public class GoodsCommandService {
         }
 
         // 옵션 교체
-        List<ItemOption> options = List.of();
         if (request.getOptions() != null) {
             itemOptionRepository.softDeleteAllByItemId(itemId);
-            options = saveOptions(itemId, request.getOptions());
+            saveOptions(itemId, request.getOptions());
         }
 
         // 배송정보 교체
-        ShippingInfo shippingInfo = null;
         if (request.getShippingInfo() != null) {
             shippingInfoRepository.softDeleteByItemId(itemId);
-            shippingInfo = saveShippingInfo(itemId, request.getShippingInfo());
+            saveShippingInfo(itemId, request.getShippingInfo());
         }
 
         // 공연 연결 교체
-        List<Long> linkedIds = List.of();
         if (request.getLinkedPerformanceItemIds() != null) {
             itemGoodsLinkRepository.softDeleteAllByGoodsItemId(itemId);
-            linkedIds = linkPerformances(itemId, request.getLinkedPerformanceItemIds());
+            linkPerformances(itemId, request.getLinkedPerformanceItemIds());
         }
 
         eventPublisher.publish(
@@ -160,8 +157,13 @@ public class GoodsCommandService {
                 ),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
+        List<ItemOption> currentOptions = itemOptionRepository.findByItemId(itemId);
+        ShippingInfo currentShippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
+        List<Long> currentLinkedIds = itemGoodsLinkRepository.findByGoodsItemId(itemId).stream()
+                .map(ItemGoodsLink::getPerformanceItemId)
+                .toList();
         List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
-        return GoodsDetailResponse.of(item, options, shippingInfo, linkedIds, images);
+        return GoodsDetailResponse.of(item, currentOptions, currentShippingInfo, currentLinkedIds, images);
     }
 
     public void delete(Long itemId, Long sellerId, Long storeIdHeader) {

--- a/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ProductCommandService.java
@@ -120,16 +120,14 @@ public class ProductCommandService {
             }
         }
 
-        List<ItemOption> options = List.of();
         if (request.getOptions() != null) {
             itemOptionRepository.softDeleteAllByItemId(itemId);
-            options = saveOptions(itemId, request.getOptions());
+            saveOptions(itemId, request.getOptions());
         }
 
-        ShippingInfo shippingInfo = null;
         if (request.getShippingInfo() != null) {
             shippingInfoRepository.softDeleteByItemId(itemId);
-            shippingInfo = saveShippingInfo(itemId, request.getShippingInfo());
+            saveShippingInfo(itemId, request.getShippingInfo());
         }
 
         eventPublisher.publish(
@@ -142,8 +140,10 @@ public class ProductCommandService {
                 ),
                 EventMetadata.of("Item", String.valueOf(item.getId())));
 
+        List<ItemOption> currentOptions = itemOptionRepository.findByItemId(itemId);
+        ShippingInfo currentShippingInfo = shippingInfoRepository.findByItemId(itemId).orElse(null);
         List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
-        return GoodsDetailResponse.of(item, options, shippingInfo, List.of(), images);
+        return GoodsDetailResponse.of(item, currentOptions, currentShippingInfo, List.of(), images);
     }
 
     public void delete(Long itemId, Long sellerId, Long storeIdHeader) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/GoodsCommandServiceTest.java
@@ -3,6 +3,11 @@ package com.example.product.service.command;
 import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
 import com.example.product.dto.goods.request.GoodsCreateRequest;
+import com.example.product.dto.goods.request.GoodsUpdateRequest;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import com.example.product.entity.goods.ItemGoodsLink;
+import com.example.product.entity.goods.ItemOption;
+import com.example.product.entity.goods.ShippingInfo;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
 import com.example.product.exception.ProductErrorCode;
@@ -21,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,6 +126,33 @@ class GoodsCommandServiceTest {
                 .isEqualTo(ProductErrorCode.CATEGORY_NOT_FOUND);
 
         verifyNoInteractions(itemRepository, itemThumbnailSyncService, eventPublisher);
+    }
+
+    @Test
+    void updateGoods_whenPartialRequest_returnsCurrentSnapshot() {
+        Long itemId = 20L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+        GoodsUpdateRequest request = new GoodsUpdateRequest();
+        ReflectionTestUtils.setField(request, "title", "title-only-update");
+
+        ItemOption option = ItemOption.create(itemId, "옵션A", 0L, 7);
+        ShippingInfo shippingInfo = ShippingInfo.create(itemId, 2500L, null, 3, "policy");
+        ItemGoodsLink link = ItemGoodsLink.create(41L, itemId);
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of(option));
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.of(shippingInfo));
+        when(itemGoodsLinkRepository.findByGoodsItemId(itemId)).thenReturn(List.of(link));
+        when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(List.of());
+
+        GoodsDetailResponse response = goodsCommandService.updateGoods(itemId, request, sellerId, 100L);
+
+        assertThat(response.getOptions()).hasSize(1);
+        assertThat(response.getOptions().get(0).getOptionName()).isEqualTo("옵션A");
+        assertThat(response.getShippingInfo()).isNotNull();
+        assertThat(response.getShippingInfo().getShippingFee()).isEqualTo(2500L);
+        assertThat(response.getLinkedPerformanceItemIds()).containsExactly(41L);
     }
 
     private Item createItem(Long id, Long sellerId) {

--- a/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/ProductCommandServiceTest.java
@@ -4,6 +4,9 @@ import com.example.core.exception.BusinessException;
 import com.example.event.EventPublisher;
 import com.example.product.dto.goods.request.ProductCreateRequest;
 import com.example.product.dto.goods.request.ProductUpdateRequest;
+import com.example.product.dto.goods.response.GoodsDetailResponse;
+import com.example.product.entity.goods.ItemOption;
+import com.example.product.entity.goods.ShippingInfo;
 import com.example.product.entity.image.ItemImage;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemType;
@@ -22,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,6 +117,8 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
         when(mediaReferenceService.resolveMediaUrl(888L)).thenReturn("https://media/888");
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of());
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.empty());
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of(image));
 
         productCommandService.updateProduct(itemId, request, sellerId, 100L);
@@ -154,6 +160,8 @@ class ProductCommandServiceTest {
 
         when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
         when(categoryRepository.existsById(10L)).thenReturn(true);
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of());
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.empty());
         when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(java.util.List.of());
 
         productCommandService.updateProduct(itemId, request, sellerId, 100L);
@@ -301,6 +309,30 @@ class ProductCommandServiceTest {
                 .isEqualTo(ProductErrorCode.STORE_OWNERSHIP_MISMATCH);
 
         verifyNoInteractions(itemThumbnailSyncService, eventPublisher);
+    }
+
+    @Test
+    void updateProduct_whenPartialRequest_returnsCurrentSnapshot() {
+        Long itemId = 3L;
+        Long sellerId = 10L;
+        Item item = createItem(itemId, sellerId);
+        ProductUpdateRequest request = new ProductUpdateRequest();
+        ReflectionTestUtils.setField(request, "title", "title-only-update");
+
+        ItemOption option = ItemOption.create(itemId, "옵션A", 100L, 3);
+        ShippingInfo shippingInfo = ShippingInfo.create(itemId, 3000L, 50000L, 2, "교환/반품 정책");
+
+        when(itemRepository.findByIdForUpdate(itemId)).thenReturn(Optional.of(item));
+        when(itemOptionRepository.findByItemId(itemId)).thenReturn(List.of(option));
+        when(shippingInfoRepository.findByItemId(itemId)).thenReturn(Optional.of(shippingInfo));
+        when(itemImageRepository.findByItemIdOrderBySortOrder(itemId)).thenReturn(List.of());
+
+        GoodsDetailResponse response = productCommandService.updateProduct(itemId, request, sellerId, 100L);
+
+        assertThat(response.getOptions()).hasSize(1);
+        assertThat(response.getOptions().get(0).getOptionName()).isEqualTo("옵션A");
+        assertThat(response.getShippingInfo()).isNotNull();
+        assertThat(response.getShippingInfo().getShippingFee()).isEqualTo(3000L);
     }
 
     private Item createItem(Long id, Long sellerId) {


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #713

### 작업 / 변경 내용
- 부분 수정 이후 현재 저장 상태를 full snapshot으로 응답
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
