### PR TITLE
fix(#714): clarify internal item query contracts

### DIFF
--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/ProductClient.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/client/ProductClient.java
@@ -43,10 +43,10 @@ public class ProductClient {
     /**
      * D-3 이내 마감 예정 상품 목록 조회
      */
-    public JsonNode findItemsEndingSoon(int withinDays) {
+    public JsonNode findItemsEndingSoon() {
         try {
             JsonNode response = webClient.get()
-                    .uri("/internal/v1/items/ending-soon?withinDays={days}", withinDays)
+                    .uri("/internal/v1/items/ending-soon")
                     .retrieve()
                     .bodyToMono(JsonNode.class)
                     .block();
@@ -59,7 +59,7 @@ public class ProductClient {
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Product ending-soon lookup failed: withinDays={}", withinDays, e);
+            log.error("Product ending-soon lookup failed", e);
             throw new BusinessException(HotDealErrorCode.PRODUCT_SERVICE_ERROR);
         }
     }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealSelectionScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/HotDealSelectionScheduler.java
@@ -34,7 +34,7 @@ public class HotDealSelectionScheduler {
         log.info("Hot deal selection scheduler started");
 
         try {
-            JsonNode items = productClient.findItemsEndingSoon(3);
+            JsonNode items = productClient.findItemsEndingSoon();
 
             if (items == null || !items.isArray()) {
                 log.info("No items ending soon found");

--- a/servers/services/product/src/main/java/com/example/product/controller/query/InternalItemQueryController.java
+++ b/servers/services/product/src/main/java/com/example/product/controller/query/InternalItemQueryController.java
@@ -32,8 +32,7 @@ public class InternalItemQueryController {
 
     @Operation(summary = "마감 임박 상품 조회 (내부)")
     @GetMapping("/ending-soon")
-    public ApiResponse<List<ItemSummaryResponse>> findItemsEndingSoon(
-            @RequestParam(defaultValue = "3") int withinDays) {
-        return ApiResponse.success(internalItemQueryService.findItemsEndingSoon(withinDays));
+    public ApiResponse<List<ItemSummaryResponse>> findItemsEndingSoon() {
+        return ApiResponse.success(internalItemQueryService.findItemsEndingSoon());
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/query/InternalItemQueryService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/query/InternalItemQueryService.java
@@ -1,9 +1,11 @@
 package com.example.product.service.query;
 
+import com.example.core.exception.BusinessException;
 import com.example.product.dto.item.response.ItemSummaryResponse;
 import com.example.product.entity.image.ItemImage;
 import com.example.product.entity.item.Item;
 import com.example.product.entity.item.ItemStatus;
+import com.example.product.exception.ProductErrorCode;
 import com.example.product.repository.ItemImageRepository;
 import com.example.product.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +26,8 @@ public class InternalItemQueryService {
     private final ItemImageRepository itemImageRepository;
 
     public ItemSummaryResponse findById(Long itemId) {
-        Item item = itemRepository.findById(itemId).orElse(null);
-        if (item == null) return null;
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.ITEM_NOT_FOUND));
         List<ItemImage> images = itemImageRepository.findByItemIdOrderBySortOrder(itemId);
         return ItemSummaryResponse.from(item, images);
     }
@@ -40,9 +42,8 @@ public class InternalItemQueryService {
                 .toList();
     }
 
-    public List<ItemSummaryResponse> findItemsEndingSoon(int withinDays) {
-        // For MVP, return ON_SALE items as hot-deal candidates
-        // Future: filter by actual end date when the field is added
+    public List<ItemSummaryResponse> findItemsEndingSoon() {
+        // MVP에서는 마감일 컬럼이 없어 ON_SALE 상태를 후보로 반환한다.
         List<Item> items = itemRepository.findByStatusIn(
                 List.of(ItemStatus.ON_SALE), Pageable.ofSize(50));
         List<Long> itemIds = items.stream().map(Item::getId).toList();

--- a/servers/services/product/src/test/java/com/example/product/service/query/InternalItemQueryServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/query/InternalItemQueryServiceTest.java
@@ -1,0 +1,57 @@
+package com.example.product.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.product.entity.item.ItemStatus;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.ItemImageRepository;
+import com.example.product.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InternalItemQueryServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ItemImageRepository itemImageRepository;
+
+    @InjectMocks
+    private InternalItemQueryService internalItemQueryService;
+
+    @Test
+    void findById_whenItemMissing_throwsItemNotFound() {
+        Long itemId = 1L;
+        when(itemRepository.findById(itemId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> internalItemQueryService.findById(itemId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.ITEM_NOT_FOUND);
+    }
+
+    @Test
+    void findItemsEndingSoon_queriesOnSaleCandidates() {
+        when(itemRepository.findByStatusIn(eq(List.of(ItemStatus.ON_SALE)), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(itemImageRepository.findByItemIdInOrderByItemIdAscSortOrderAsc(List.of()))
+                .thenReturn(List.of());
+
+        internalItemQueryService.findItemsEndingSoon();
+
+        verify(itemRepository).findByStatusIn(eq(List.of(ItemStatus.ON_SALE)), any(Pageable.class));
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #714

### 작업 / 변경 내용
- 내부 API 단건 miss 계약을 명확히 하고 미사용 파라미터를 제거
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
