### PR TITLE
fix(#715): map invalid status inputs to domain errors

### DIFF
--- a/servers/services/product/src/main/java/com/example/product/entity/item/ItemStatus.java
+++ b/servers/services/product/src/main/java/com/example/product/entity/item/ItemStatus.java
@@ -3,6 +3,7 @@ package com.example.product.entity.item;
 import com.example.core.exception.BusinessException;
 import com.example.product.exception.ProductErrorCode;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,5 +39,16 @@ public enum ItemStatus {
 
     public boolean canTransitionTo(ItemStatus target) {
         return TRANSITIONS.getOrDefault(this, Set.of()).contains(target);
+    }
+
+    public static ItemStatus from(String rawStatus) {
+        if (rawStatus == null || rawStatus.isBlank()) {
+            throw new BusinessException(ProductErrorCode.INVALID_ITEM_STATUS_TRANSITION);
+        }
+        try {
+            return ItemStatus.valueOf(rawStatus.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ProductErrorCode.INVALID_ITEM_STATUS_TRANSITION);
+        }
     }
 }

--- a/servers/services/product/src/main/java/com/example/product/service/command/ItemStatusCommandService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/ItemStatusCommandService.java
@@ -33,7 +33,7 @@ public class ItemStatusCommandService {
         item.validateOwnership(userId);
 
         ItemStatus previousStatus = item.getStatus();
-        ItemStatus newStatus = ItemStatus.valueOf(request.getStatus());
+        ItemStatus newStatus = ItemStatus.from(request.getStatus());
 
         item.changeStatus(newStatus);
 

--- a/servers/services/product/src/test/java/com/example/product/service/command/ItemStatusCommandServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/ItemStatusCommandServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.product.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventPublisher;
+import com.example.product.dto.item.request.StatusChangeRequest;
+import com.example.product.entity.item.Item;
+import com.example.product.entity.item.ItemStatus;
+import com.example.product.entity.item.ItemType;
+import com.example.product.exception.ProductErrorCode;
+import com.example.product.repository.ItemRepository;
+import com.example.product.repository.ItemStatusHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemStatusCommandServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ItemStatusHistoryRepository statusHistoryRepository;
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private ItemStatusCommandService itemStatusCommandService;
+
+    @Test
+    void changeStatus_whenStatusIsLowerCase_parsesAndChanges() {
+        Long itemId = 1L;
+        Long ownerId = 10L;
+        Item item = createItem(itemId, ownerId);
+        StatusChangeRequest request = new StatusChangeRequest();
+        ReflectionTestUtils.setField(request, "status", "on_sale");
+        ReflectionTestUtils.setField(request, "reason", "manual");
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(item));
+
+        itemStatusCommandService.changeStatus(itemId, request, ownerId);
+
+        assertThat(item.getStatus()).isEqualTo(ItemStatus.ON_SALE);
+        verify(statusHistoryRepository).save(any());
+        verify(eventPublisher).publish(any(), any());
+    }
+
+    @Test
+    void changeStatus_whenStatusIsInvalid_throwsDomainError() {
+        Long itemId = 1L;
+        Long ownerId = 10L;
+        Item item = createItem(itemId, ownerId);
+        StatusChangeRequest request = new StatusChangeRequest();
+        ReflectionTestUtils.setField(request, "status", "on-sale");
+
+        when(itemRepository.findById(itemId)).thenReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> itemStatusCommandService.changeStatus(itemId, request, ownerId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ProductErrorCode.INVALID_ITEM_STATUS_TRANSITION);
+
+        verifyNoInteractions(statusHistoryRepository);
+        verifyNoInteractions(eventPublisher);
+    }
+
+    private Item createItem(Long itemId, Long sellerId) {
+        Item item = Item.create(
+                "item",
+                "desc",
+                1000L,
+                ItemType.PRODUCT,
+                null,
+                sellerId,
+                100L,
+                null
+        );
+        ReflectionTestUtils.setField(item, "id", itemId);
+        return item;
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #715

### 작업 / 변경 내용
- 상태 입력 파싱 실패를 도메인 에러코드로 매핑
- 관련 서비스/단위 테스트 보강 및 회귀 확인
- API 계약/예외 코드/권한 검증 정합성 강화

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 대상 모듈: `servers/services/product` (이슈 714는 `servers/services/hot-deal` 호출부 동기화 포함)
