### PR TITLE
[MZC-698] [TASK] 통합 목록 API 요청/응답 계약 및 검증 구현

### DIFF
--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/CatalogBffController.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/CatalogBffController.java
@@ -1,0 +1,24 @@
+package com.example.gateway.bff.controller;
+
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.bff.service.CatalogBffService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/bff/v1")
+@RequiredArgsConstructor
+public class CatalogBffController {
+
+    private final CatalogBffService catalogBffService;
+
+    @GetMapping("/catalog/items")
+    public Mono<ResponseEntity<CatalogItemsResponse>> listCatalogItems(ServerHttpRequest request) {
+        return catalogBffService.listCatalogItems(request);
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogDetailTargetResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogDetailTargetResponse.java
@@ -1,0 +1,7 @@
+package com.example.gateway.bff.dto.catalog;
+
+public record CatalogDetailTargetResponse(
+        String type,
+        String path
+) {
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogErrorResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogErrorResponse.java
@@ -1,0 +1,7 @@
+package com.example.gateway.bff.dto.catalog;
+
+public record CatalogErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemCardResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemCardResponse.java
@@ -1,0 +1,21 @@
+package com.example.gateway.bff.dto.catalog;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CatalogItemCardResponse(
+        Long itemId,
+        String title,
+        BffItemType itemType,
+        CatalogSalesChannel salesChannel,
+        String status,
+        CatalogPriceResponse price,
+        Integer stock,
+        Long thumbnailMediaId,
+        String thumbnailUrl,
+        Long activeHotDealId,
+        Long activeCampaignId,
+        CatalogDetailTargetResponse detailTarget
+) {
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemsDataResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemsDataResponse.java
@@ -1,0 +1,10 @@
+package com.example.gateway.bff.dto.catalog;
+
+import java.util.List;
+
+public record CatalogItemsDataResponse(
+        List<CatalogItemCardResponse> items,
+        String nextCursor,
+        Long totalCount
+) {
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemsResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogItemsResponse.java
@@ -1,0 +1,18 @@
+package com.example.gateway.bff.dto.catalog;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CatalogItemsResponse(
+        boolean success,
+        CatalogItemsDataResponse data,
+        CatalogErrorResponse error
+) {
+    public static CatalogItemsResponse success(CatalogItemsDataResponse data) {
+        return new CatalogItemsResponse(true, data, null);
+    }
+
+    public static CatalogItemsResponse error(String code, String message) {
+        return new CatalogItemsResponse(false, null, new CatalogErrorResponse(code, message));
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogPriceResponse.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogPriceResponse.java
@@ -1,0 +1,7 @@
+package com.example.gateway.bff.dto.catalog;
+
+public record CatalogPriceResponse(
+        Long base,
+        Long effective
+) {
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogQueryParams.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogQueryParams.java
@@ -1,0 +1,236 @@
+package com.example.gateway.bff.dto.catalog;
+
+import com.example.gateway.bff.dto.BffItemType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+public record CatalogQueryParams(
+        String query,
+        String category,
+        BffItemType itemType,
+        CatalogSalesChannel channel,
+        List<String> statuses,
+        Long minPrice,
+        Long maxPrice,
+        String sort,
+        String cursor,
+        Integer size
+) {
+
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+    private static final Set<String> ALLOWED_SORTS = Set.of(
+            "LATEST",
+            "POPULAR",
+            "PRICE_ASC",
+            "PRICE_DESC"
+    );
+    private static final Set<String> ALLOWED_STATUSES = Set.of(
+            "DRAFT",
+            "FUNDING",
+            "FUNDED",
+            "FUND_FAILED",
+            "ON_SALE",
+            "HOT_DEAL",
+            "HIDDEN",
+            "SOLD_OUT",
+            "CLOSED"
+    );
+    private static final Map<CatalogSalesChannel, Set<String>> CHANNEL_ALLOWED_STATUSES = Map.of(
+            CatalogSalesChannel.HOT_DEAL, Set.of("HOT_DEAL"),
+            CatalogSalesChannel.FUNDING, Set.of("FUNDING", "FUNDED", "FUND_FAILED"),
+            CatalogSalesChannel.NORMAL, Set.of("ON_SALE")
+    );
+
+    public static CatalogQueryParams from(ServerHttpRequest request) {
+        MultiValueMap<String, String> queryParams = request.getQueryParams();
+
+        String query = trimToNull(queryParams.getFirst("q"));
+        if (!StringUtils.hasText(query)) {
+            throw new IllegalArgumentException("q는 필수입니다");
+        }
+
+        String category = trimToNull(queryParams.getFirst("category"));
+        BffItemType itemType = parseItemType(queryParams.getFirst("itemType"));
+        CatalogSalesChannel channel = CatalogSalesChannel.fromNullable(queryParams.getFirst("channel"));
+        List<String> statuses = parseStatuses(queryParams.get("status"));
+        Long minPrice = parseNonNegativeLong(queryParams.getFirst("minPrice"), "minPrice");
+        Long maxPrice = parseNonNegativeLong(queryParams.getFirst("maxPrice"), "maxPrice");
+        if (minPrice != null && maxPrice != null && minPrice > maxPrice) {
+            throw new IllegalArgumentException("minPrice는 maxPrice보다 클 수 없습니다");
+        }
+
+        String sort = parseSort(queryParams.getFirst("sort"));
+        String cursor = trimToNull(queryParams.getFirst("cursor"));
+        Integer size = parseSize(queryParams.getFirst("size"));
+
+        validateStatuses(statuses);
+        validateChannelAndStatuses(channel, statuses);
+
+        return new CatalogQueryParams(
+                query,
+                category,
+                itemType,
+                channel,
+                statuses,
+                minPrice,
+                maxPrice,
+                sort,
+                cursor,
+                size
+        );
+    }
+
+    public List<String> resolvedStatuses() {
+        if (!statuses.isEmpty()) {
+            return statuses;
+        }
+        if (channel == CatalogSalesChannel.ALL) {
+            return List.of();
+        }
+        return List.copyOf(CHANNEL_ALLOWED_STATUSES.getOrDefault(channel, Set.of()));
+    }
+
+    public MultiValueMap<String, String> toSearchQueryParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("q", query);
+        addIfPresent(params, "category", category);
+        if (itemType != null) {
+            params.add("domainType", itemType.name());
+        }
+        for (String status : resolvedStatuses()) {
+            params.add("status", status);
+        }
+        if (minPrice != null) {
+            params.add("minPrice", String.valueOf(minPrice));
+        }
+        if (maxPrice != null) {
+            params.add("maxPrice", String.valueOf(maxPrice));
+        }
+        addIfPresent(params, "sort", sort);
+        addIfPresent(params, "cursor", cursor);
+        params.add("size", String.valueOf(size));
+        return params;
+    }
+
+    private static void addIfPresent(MultiValueMap<String, String> params, String key, String value) {
+        if (StringUtils.hasText(value)) {
+            params.add(key, value);
+        }
+    }
+
+    private static BffItemType parseItemType(String raw) {
+        String normalized = trimToNull(raw);
+        if (!StringUtils.hasText(normalized)) {
+            return null;
+        }
+        try {
+            return BffItemType.fromNullable(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("itemType은 PRODUCT, GOODS, PERFORMANCE 중 하나여야 합니다");
+        }
+    }
+
+    private static String parseSort(String raw) {
+        String normalized = trimToNull(raw);
+        if (!StringUtils.hasText(normalized)) {
+            return "LATEST";
+        }
+        String upper = normalized.toUpperCase(Locale.ROOT);
+        if (!ALLOWED_SORTS.contains(upper)) {
+            throw new IllegalArgumentException("sort는 LATEST, POPULAR, PRICE_ASC, PRICE_DESC 중 하나여야 합니다");
+        }
+        return upper;
+    }
+
+    private static Integer parseSize(String raw) {
+        String normalized = trimToNull(raw);
+        if (!StringUtils.hasText(normalized)) {
+            return DEFAULT_SIZE;
+        }
+        try {
+            int parsed = Integer.parseInt(normalized);
+            if (parsed < 1 || parsed > MAX_SIZE) {
+                throw new IllegalArgumentException("size는 1 이상 100 이하여야 합니다");
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("size는 정수여야 합니다");
+        }
+    }
+
+    private static Long parseNonNegativeLong(String raw, String fieldName) {
+        String normalized = trimToNull(raw);
+        if (!StringUtils.hasText(normalized)) {
+            return null;
+        }
+        try {
+            long parsed = Long.parseLong(normalized);
+            if (parsed < 0) {
+                throw new IllegalArgumentException(fieldName + "는 0 이상이어야 합니다");
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(fieldName + "는 정수여야 합니다");
+        }
+    }
+
+    private static List<String> parseStatuses(List<String> rawValues) {
+        if (rawValues == null || rawValues.isEmpty()) {
+            return List.of();
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String rawValue : rawValues) {
+            if (!StringUtils.hasText(rawValue)) {
+                continue;
+            }
+            String[] tokens = rawValue.split(",");
+            for (String token : tokens) {
+                String status = trimToNull(token);
+                if (!StringUtils.hasText(status)) {
+                    continue;
+                }
+                normalized.add(status.toUpperCase(Locale.ROOT));
+            }
+        }
+        return List.copyOf(new ArrayList<>(normalized));
+    }
+
+    private static void validateStatuses(List<String> statuses) {
+        for (String status : statuses) {
+            if (!ALLOWED_STATUSES.contains(status)) {
+                throw new IllegalArgumentException("지원하지 않는 status 값입니다: " + status);
+            }
+        }
+    }
+
+    private static void validateChannelAndStatuses(CatalogSalesChannel channel, List<String> statuses) {
+        if (channel == CatalogSalesChannel.ALL || statuses.isEmpty()) {
+            return;
+        }
+        Set<String> allowedByChannel = CHANNEL_ALLOWED_STATUSES.getOrDefault(channel, Set.of());
+
+        for (String status : statuses) {
+            if (!allowedByChannel.contains(status)) {
+                throw new IllegalArgumentException("channel과 status 조합이 유효하지 않습니다");
+            }
+        }
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogSalesChannel.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogSalesChannel.java
@@ -1,0 +1,33 @@
+package com.example.gateway.bff.dto.catalog;
+
+import java.util.Locale;
+
+public enum CatalogSalesChannel {
+    ALL,
+    HOT_DEAL,
+    FUNDING,
+    NORMAL;
+
+    public static CatalogSalesChannel fromNullable(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return ALL;
+        }
+        try {
+            return CatalogSalesChannel.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("channel은 ALL, HOT_DEAL, FUNDING, NORMAL 중 하나여야 합니다");
+        }
+    }
+
+    public static CatalogSalesChannel fromStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return NORMAL;
+        }
+        String normalized = status.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "HOT_DEAL" -> HOT_DEAL;
+            case "FUNDING", "FUNDED", "FUND_FAILED" -> FUNDING;
+            default -> NORMAL;
+        };
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
@@ -1,0 +1,220 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.bff.dto.catalog.CatalogQueryParams;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class CatalogBffService {
+
+    private static final String CODE_INVALID_REQUEST = "BFF-CATALOG-400";
+    private static final String CODE_DOWNSTREAM_ERROR = "BFF-CATALOG-502";
+
+    private final WebClient searchWebClient;
+    private final WebClient mediaWebClient;
+    private final GatewaySecurityProperties securityProperties;
+    private final SearchThumbnailFallbackEnricher fallbackEnricher;
+    private final CatalogResponseMapper responseMapper;
+    private final ObjectMapper objectMapper;
+
+    public CatalogBffService(
+            WebClient.Builder webClientBuilder,
+            GatewaySecurityProperties securityProperties,
+            SearchThumbnailFallbackEnricher fallbackEnricher,
+            CatalogResponseMapper responseMapper,
+            ObjectMapper objectMapper,
+            @Value("${app.service.search-url:http://localhost:8088}") String searchServiceUrl,
+            @Value("${app.service.media-url:http://localhost:8094}") String mediaServiceUrl
+    ) {
+        this.searchWebClient = webClientBuilder.baseUrl(searchServiceUrl).build();
+        this.mediaWebClient = webClientBuilder.baseUrl(mediaServiceUrl).build();
+        this.securityProperties = securityProperties;
+        this.fallbackEnricher = fallbackEnricher;
+        this.responseMapper = responseMapper;
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<ResponseEntity<CatalogItemsResponse>> listCatalogItems(ServerHttpRequest request) {
+        CatalogQueryParams params;
+        try {
+            params = CatalogQueryParams.from(request);
+        } catch (IllegalArgumentException e) {
+            return Mono.just(badRequest(e.getMessage()));
+        }
+
+        HttpHeaders downstreamHeaders = buildDownstreamHeaders();
+        MultiValueMap<String, String> searchQueryParams = params.toSearchQueryParams();
+
+        return callSearch(searchQueryParams, downstreamHeaders)
+                .flatMap(searchResponse -> enrichWithMediaFallback(searchResponse, downstreamHeaders))
+                .map(searchResponse -> mapCatalogResponse(searchResponse, params))
+                .onErrorResume(e -> {
+                    log.warn("[CatalogBff] catalog query failed", e);
+                    return Mono.just(badGateway("통합 목록 조회에 실패했습니다"));
+                });
+    }
+
+    private Mono<ResponseEntity<JsonNode>> callSearch(MultiValueMap<String, String> queryParams,
+                                                      HttpHeaders downstreamHeaders) {
+        return searchWebClient.method(HttpMethod.GET)
+                .uri(uriBuilder -> buildSearchUri(uriBuilder, queryParams))
+                .headers(headers -> headers.addAll(downstreamHeaders))
+                .exchangeToMono(response -> response.bodyToMono(JsonNode.class)
+                        .defaultIfEmpty(objectMapper.createObjectNode())
+                        .map(payload -> ResponseEntity.status(response.statusCode()).body(payload)));
+    }
+
+    private Mono<ResponseEntity<JsonNode>> enrichWithMediaFallback(ResponseEntity<JsonNode> searchResponse,
+                                                                   HttpHeaders downstreamHeaders) {
+        JsonNode body = searchResponse.getBody();
+        if (!searchResponse.getStatusCode().is2xxSuccessful() || body == null) {
+            return Mono.just(searchResponse);
+        }
+
+        List<Long> fallbackMediaIds = fallbackEnricher.collectFallbackMediaIds(body);
+        if (fallbackMediaIds.isEmpty()) {
+            return Mono.just(searchResponse);
+        }
+
+        return fetchMediaUrlMap(fallbackMediaIds, downstreamHeaders)
+                .map(mediaUrlMap -> fallbackEnricher.applyFallbackUrls(body, mediaUrlMap))
+                .map(enrichedBody -> ResponseEntity.status(searchResponse.getStatusCode()).body(enrichedBody))
+                .onErrorResume(e -> {
+                    log.warn("[CatalogBff] thumbnail fallback failed. mediaCount={}", fallbackMediaIds.size(), e);
+                    return Mono.just(searchResponse);
+                });
+    }
+
+    private Mono<Map<Long, String>> fetchMediaUrlMap(List<Long> mediaIds, HttpHeaders downstreamHeaders) {
+        return mediaWebClient.post()
+                .uri("/internal/v1/media/urls/batch")
+                .headers(headers -> headers.addAll(downstreamHeaders))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("mediaIds", mediaIds))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::toMediaUrlMap);
+    }
+
+    private Map<Long, String> toMediaUrlMap(JsonNode responseBody) {
+        if (responseBody == null || !responseBody.path("success").asBoolean()) {
+            return Map.of();
+        }
+
+        JsonNode data = responseBody.path("data");
+        if (!data.isArray()) {
+            return Map.of();
+        }
+
+        Map<Long, String> mediaUrlMap = new LinkedHashMap<>();
+        for (JsonNode node : data) {
+            long mediaId = node.path("mediaId").asLong(-1L);
+            String mediaUrl = node.path("mediaUrl").asText(null);
+            if (mediaId > 0 && StringUtils.hasText(mediaUrl)) {
+                mediaUrlMap.put(mediaId, mediaUrl);
+            }
+        }
+        return mediaUrlMap;
+    }
+
+    private java.net.URI buildSearchUri(UriBuilder uriBuilder, MultiValueMap<String, String> queryParams) {
+        UriBuilder builder = uriBuilder.path("/api/v1/search");
+        if (queryParams == null || queryParams.isEmpty()) {
+            return builder.build();
+        }
+
+        queryParams.forEach((name, values) -> {
+            if (!StringUtils.hasText(name) || values == null || values.isEmpty()) {
+                return;
+            }
+            for (String value : values) {
+                builder.queryParam(name, value);
+            }
+        });
+        return builder.build();
+    }
+
+    private ResponseEntity<CatalogItemsResponse> mapCatalogResponse(ResponseEntity<JsonNode> searchResponse,
+                                                                    CatalogQueryParams params) {
+        if (!searchResponse.getStatusCode().is2xxSuccessful()) {
+            return ResponseEntity.status(searchResponse.getStatusCode())
+                    .body(CatalogItemsResponse.error(CODE_DOWNSTREAM_ERROR,
+                            extractDownstreamErrorMessage(searchResponse.getBody())));
+        }
+
+        try {
+            CatalogItemsResponse response = responseMapper.toCatalogResponse(searchResponse.getBody(), params);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return badGateway(e.getMessage());
+        }
+    }
+
+    private String extractDownstreamErrorMessage(JsonNode body) {
+        if (body == null) {
+            return "검색 서비스 호출에 실패했습니다";
+        }
+
+        String errorMessage = textOrNull(body.path("error").path("message"));
+        if (StringUtils.hasText(errorMessage)) {
+            return errorMessage;
+        }
+        String message = textOrNull(body.path("message"));
+        if (StringUtils.hasText(message)) {
+            return message;
+        }
+        return "검색 서비스 호출에 실패했습니다";
+    }
+
+    private String textOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        String value = node.asText(null);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private ResponseEntity<CatalogItemsResponse> badRequest(String message) {
+        return ResponseEntity.badRequest()
+                .body(CatalogItemsResponse.error(CODE_INVALID_REQUEST, message));
+    }
+
+    private ResponseEntity<CatalogItemsResponse> badGateway(String message) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(CatalogItemsResponse.error(CODE_DOWNSTREAM_ERROR, message));
+    }
+
+    private HttpHeaders buildDownstreamHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (StringUtils.hasText(securityProperties.getInternalAuthToken())
+                && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
+            headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
+        }
+        return headers;
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogResponseMapper.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogResponseMapper.java
@@ -1,0 +1,242 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.example.gateway.bff.dto.catalog.CatalogDetailTargetResponse;
+import com.example.gateway.bff.dto.catalog.CatalogItemCardResponse;
+import com.example.gateway.bff.dto.catalog.CatalogItemsDataResponse;
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.bff.dto.catalog.CatalogPriceResponse;
+import com.example.gateway.bff.dto.catalog.CatalogQueryParams;
+import com.example.gateway.bff.dto.catalog.CatalogSalesChannel;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+public class CatalogResponseMapper {
+
+    public CatalogItemsResponse toCatalogResponse(JsonNode searchResponseBody, CatalogQueryParams params) {
+        if (searchResponseBody == null || !searchResponseBody.path("success").asBoolean()) {
+            throw new IllegalArgumentException("검색 응답 형식이 올바르지 않습니다");
+        }
+
+        JsonNode dataNode = searchResponseBody.path("data");
+        if (!dataNode.isObject()) {
+            throw new IllegalArgumentException("검색 응답 data 형식이 올바르지 않습니다");
+        }
+
+        JsonNode itemsNode = dataNode.path("items");
+        List<CatalogItemCardResponse> catalogItems = toCatalogItems(itemsNode, params);
+        String nextCursor = textOrNull(dataNode.path("nextCursor"));
+        Long totalCount = asNullableLong(dataNode.path("totalCount"));
+
+        return CatalogItemsResponse.success(new CatalogItemsDataResponse(catalogItems, nextCursor, totalCount));
+    }
+
+    private List<CatalogItemCardResponse> toCatalogItems(JsonNode itemsNode, CatalogQueryParams params) {
+        if (!itemsNode.isArray()) {
+            return List.of();
+        }
+
+        List<CatalogItemCardResponse> results = new ArrayList<>();
+        for (JsonNode itemNode : itemsNode) {
+            if (!itemNode.isObject()) {
+                continue;
+            }
+            CatalogItemCardResponse mapped = mapItemCard(itemNode, params.itemType());
+            if (mapped == null) {
+                continue;
+            }
+            if (params.channel() != CatalogSalesChannel.ALL
+                    && mapped.salesChannel() != params.channel()) {
+                continue;
+            }
+            results.add(mapped);
+        }
+        return List.copyOf(results);
+    }
+
+    private CatalogItemCardResponse mapItemCard(JsonNode itemNode, BffItemType requestItemType) {
+        Long itemId = asNullableLong(itemNode.path("itemId"));
+        if (itemId == null || itemId <= 0) {
+            return null;
+        }
+
+        BffItemType itemType = resolveItemType(itemNode.path("domainType"), requestItemType);
+        String status = resolveStatus(itemNode.path("status"));
+        CatalogSalesChannel salesChannel = resolveSalesChannel(itemNode.path("salesChannel"), status);
+        Long activeHotDealId = asNullableLong(itemNode.path("activeHotDealId"));
+        Long activeCampaignId = asNullableLong(itemNode.path("activeCampaignId"));
+
+        CatalogPriceResponse price = resolvePrice(itemNode);
+        CatalogDetailTargetResponse detailTarget = resolveDetailTarget(
+                itemId, itemType, salesChannel, activeHotDealId, activeCampaignId
+        );
+
+        return new CatalogItemCardResponse(
+                itemId,
+                textOrNull(itemNode.path("title")),
+                itemType,
+                salesChannel,
+                status,
+                price,
+                asNullableInteger(itemNode.path("stock")),
+                asNullableLong(itemNode.path("thumbnailMediaId")),
+                textOrNull(itemNode.path("thumbnailUrl")),
+                activeHotDealId,
+                activeCampaignId,
+                detailTarget
+        );
+    }
+
+    private CatalogDetailTargetResponse resolveDetailTarget(Long itemId,
+                                                            BffItemType itemType,
+                                                            CatalogSalesChannel salesChannel,
+                                                            Long activeHotDealId,
+                                                            Long activeCampaignId) {
+        return switch (salesChannel) {
+            case HOT_DEAL -> {
+                if (activeHotDealId != null && activeHotDealId > 0) {
+                    yield new CatalogDetailTargetResponse("HOT_DEAL", "/api/v1/hot-deals/" + activeHotDealId);
+                }
+                yield new CatalogDetailTargetResponse("NORMAL", buildNormalDetailPath(itemId, itemType));
+            }
+            case FUNDING -> {
+                if (activeCampaignId != null && activeCampaignId > 0) {
+                    yield new CatalogDetailTargetResponse("FUNDING", "/api/campaigns/" + activeCampaignId);
+                }
+                yield new CatalogDetailTargetResponse("FUNDING", "/api/campaigns/item/" + itemId);
+            }
+            case NORMAL, ALL -> new CatalogDetailTargetResponse("NORMAL", buildNormalDetailPath(itemId, itemType));
+        };
+    }
+
+    private String buildNormalDetailPath(Long itemId, BffItemType itemType) {
+        if (itemType == null) {
+            return "/bff/v1/items/" + itemId;
+        }
+        return "/bff/v1/items/" + itemId + "?type=" + itemType.name();
+    }
+
+    private CatalogPriceResponse resolvePrice(JsonNode itemNode) {
+        Long basePrice = firstNonNull(
+                asNullableLong(itemNode.path("basePrice")),
+                asNullableLong(itemNode.path("price"))
+        );
+        Long effectivePrice = firstNonNull(
+                asNullableLong(itemNode.path("effectivePrice")),
+                asNullableLong(itemNode.path("discountPrice")),
+                basePrice
+        );
+        if (basePrice == null && effectivePrice == null) {
+            return null;
+        }
+        return new CatalogPriceResponse(basePrice, effectivePrice);
+    }
+
+    private CatalogSalesChannel resolveSalesChannel(JsonNode channelNode, String status) {
+        String rawChannel = textOrNull(channelNode);
+        if (StringUtils.hasText(rawChannel)) {
+            try {
+                CatalogSalesChannel parsed = CatalogSalesChannel.fromNullable(rawChannel);
+                if (parsed != CatalogSalesChannel.ALL) {
+                    return parsed;
+                }
+            } catch (IllegalArgumentException ignored) {
+                return CatalogSalesChannel.fromStatus(status);
+            }
+        }
+        return CatalogSalesChannel.fromStatus(status);
+    }
+
+    private String resolveStatus(JsonNode statusNode) {
+        String status = textOrNull(statusNode);
+        if (!StringUtils.hasText(status)) {
+            return "ON_SALE";
+        }
+        return status.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private BffItemType resolveItemType(JsonNode domainTypeNode, BffItemType requestItemType) {
+        String domainType = textOrNull(domainTypeNode);
+        if (!StringUtils.hasText(domainType)) {
+            return requestItemType;
+        }
+        try {
+            return BffItemType.fromNullable(domainType);
+        } catch (IllegalArgumentException e) {
+            return requestItemType;
+        }
+    }
+
+    private String textOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        String value = node.asText(null);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private Long asNullableLong(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isIntegralNumber()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            String raw = node.asText(null);
+            if (!StringUtils.hasText(raw)) {
+                return null;
+            }
+            try {
+                return Long.parseLong(raw.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer asNullableInteger(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isIntegralNumber()) {
+            return node.asInt();
+        }
+        if (node.isTextual()) {
+            String raw = node.asText(null);
+            if (!StringUtils.hasText(raw)) {
+                return null;
+            }
+            try {
+                return Integer.parseInt(raw.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Long firstNonNull(Long first, Long second) {
+        return first != null ? first : second;
+    }
+
+    private Long firstNonNull(Long first, Long second, Long third) {
+        if (first != null) {
+            return first;
+        }
+        if (second != null) {
+            return second;
+        }
+        return third;
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/dto/catalog/CatalogQueryParamsTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/dto/catalog/CatalogQueryParamsTest.java
@@ -1,0 +1,96 @@
+package com.example.gateway.bff.dto.catalog;
+
+import com.example.gateway.bff.dto.BffItemType;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.util.MultiValueMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CatalogQueryParamsTest {
+
+    @Test
+    void from_parsesAndNormalizesValidRequest() {
+        ServerHttpRequest request = MockServerHttpRequest.get(
+                        "/bff/v1/catalog/items?q=shoe&channel=funding&itemType=product&status=funding"
+                                + "&sort=price_desc&minPrice=1000&maxPrice=5000&cursor=c1&size=30")
+                .build();
+
+        CatalogQueryParams params = CatalogQueryParams.from(request);
+        MultiValueMap<String, String> searchParams = params.toSearchQueryParams();
+
+        assertThat(params.query()).isEqualTo("shoe");
+        assertThat(params.channel()).isEqualTo(CatalogSalesChannel.FUNDING);
+        assertThat(params.itemType()).isEqualTo(BffItemType.PRODUCT);
+        assertThat(params.statuses()).containsExactly("FUNDING");
+        assertThat(params.sort()).isEqualTo("PRICE_DESC");
+        assertThat(params.minPrice()).isEqualTo(1000L);
+        assertThat(params.maxPrice()).isEqualTo(5000L);
+        assertThat(params.cursor()).isEqualTo("c1");
+        assertThat(params.size()).isEqualTo(30);
+
+        assertThat(searchParams.getFirst("q")).isEqualTo("shoe");
+        assertThat(searchParams.getFirst("domainType")).isEqualTo("PRODUCT");
+        assertThat(searchParams.get("status")).containsExactly("FUNDING");
+        assertThat(searchParams.getFirst("sort")).isEqualTo("PRICE_DESC");
+    }
+
+    @Test
+    void from_appliesDefaultsWhenOptionalFieldsMissing() {
+        ServerHttpRequest request = MockServerHttpRequest.get("/bff/v1/catalog/items?q=shoe").build();
+
+        CatalogQueryParams params = CatalogQueryParams.from(request);
+        MultiValueMap<String, String> searchParams = params.toSearchQueryParams();
+
+        assertThat(params.channel()).isEqualTo(CatalogSalesChannel.ALL);
+        assertThat(params.sort()).isEqualTo("LATEST");
+        assertThat(params.size()).isEqualTo(20);
+        assertThat(params.resolvedStatuses()).isEmpty();
+
+        assertThat(searchParams.getFirst("q")).isEqualTo("shoe");
+        assertThat(searchParams.getFirst("size")).isEqualTo("20");
+        assertThat(searchParams.containsKey("status")).isFalse();
+    }
+
+    @Test
+    void from_throwsWhenChannelValueIsInvalid() {
+        ServerHttpRequest request = MockServerHttpRequest.get("/bff/v1/catalog/items?q=shoe&channel=foo").build();
+
+        assertThatThrownBy(() -> CatalogQueryParams.from(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("channel은 ALL, HOT_DEAL, FUNDING, NORMAL 중 하나여야 합니다");
+    }
+
+    @Test
+    void from_throwsWhenChannelAndStatusCombinationIsInvalid() {
+        ServerHttpRequest request = MockServerHttpRequest.get(
+                        "/bff/v1/catalog/items?q=shoe&channel=HOT_DEAL&status=FUNDING")
+                .build();
+
+        assertThatThrownBy(() -> CatalogQueryParams.from(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("channel과 status 조합이 유효하지 않습니다");
+    }
+
+    @Test
+    void from_throwsWhenPriceRangeIsInvalid() {
+        ServerHttpRequest request = MockServerHttpRequest.get(
+                        "/bff/v1/catalog/items?q=shoe&minPrice=10000&maxPrice=1000")
+                .build();
+
+        assertThatThrownBy(() -> CatalogQueryParams.from(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("minPrice는 maxPrice보다 클 수 없습니다");
+    }
+
+    @Test
+    void from_throwsWhenSizeIsOutOfRange() {
+        ServerHttpRequest request = MockServerHttpRequest.get("/bff/v1/catalog/items?q=shoe&size=0").build();
+
+        assertThatThrownBy(() -> CatalogQueryParams.from(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size는 1 이상 100 이하여야 합니다");
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogResponseMapperTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogResponseMapperTest.java
@@ -1,0 +1,163 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.example.gateway.bff.dto.catalog.CatalogItemCardResponse;
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.bff.dto.catalog.CatalogQueryParams;
+import com.example.gateway.bff.dto.catalog.CatalogSalesChannel;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CatalogResponseMapperTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CatalogResponseMapper mapper = new CatalogResponseMapper();
+
+    @Test
+    void toCatalogResponse_mapsSalesChannelAndDetailTarget() throws Exception {
+        JsonNode searchBody = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {
+                        "itemId": 11,
+                        "title": "hot",
+                        "domainType": "PRODUCT",
+                        "status": "HOT_DEAL",
+                        "activeHotDealId": 901,
+                        "price": 10000
+                      },
+                      {
+                        "itemId": 22,
+                        "title": "fund",
+                        "domainType": "GOODS",
+                        "status": "FUNDING",
+                        "activeCampaignId": 301,
+                        "price": 20000
+                      },
+                      {
+                        "itemId": 33,
+                        "title": "normal",
+                        "domainType": "PERFORMANCE",
+                        "status": "ON_SALE",
+                        "price": 30000
+                      }
+                    ],
+                    "nextCursor": "n1",
+                    "totalCount": 3
+                  }
+                }
+                """);
+
+        CatalogItemsResponse response = mapper.toCatalogResponse(searchBody, defaultParams());
+
+        assertThat(response.success()).isTrue();
+        assertThat(response.data()).isNotNull();
+        assertThat(response.data().items()).hasSize(3);
+
+        CatalogItemCardResponse hotDeal = response.data().items().get(0);
+        assertThat(hotDeal.salesChannel()).isEqualTo(CatalogSalesChannel.HOT_DEAL);
+        assertThat(hotDeal.detailTarget().type()).isEqualTo("HOT_DEAL");
+        assertThat(hotDeal.detailTarget().path()).isEqualTo("/api/v1/hot-deals/901");
+
+        CatalogItemCardResponse funding = response.data().items().get(1);
+        assertThat(funding.salesChannel()).isEqualTo(CatalogSalesChannel.FUNDING);
+        assertThat(funding.detailTarget().type()).isEqualTo("FUNDING");
+        assertThat(funding.detailTarget().path()).isEqualTo("/api/campaigns/301");
+
+        CatalogItemCardResponse normal = response.data().items().get(2);
+        assertThat(normal.salesChannel()).isEqualTo(CatalogSalesChannel.NORMAL);
+        assertThat(normal.detailTarget().type()).isEqualTo("NORMAL");
+        assertThat(normal.detailTarget().path()).isEqualTo("/bff/v1/items/33?type=PERFORMANCE");
+    }
+
+    @Test
+    void toCatalogResponse_usesRequestItemTypeWhenDomainTypeMissing() throws Exception {
+        JsonNode searchBody = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 101, "title": "item", "status": "ON_SALE", "price": 12000}
+                    ],
+                    "nextCursor": null,
+                    "totalCount": 1
+                  }
+                }
+                """);
+
+        CatalogQueryParams params = new CatalogQueryParams(
+                "run", null, BffItemType.PRODUCT, CatalogSalesChannel.ALL,
+                List.of(), null, null, "LATEST", null, 20
+        );
+
+        CatalogItemsResponse response = mapper.toCatalogResponse(searchBody, params);
+        CatalogItemCardResponse item = response.data().items().get(0);
+
+        assertThat(item.itemType()).isEqualTo(BffItemType.PRODUCT);
+        assertThat(item.detailTarget().path()).isEqualTo("/bff/v1/items/101?type=PRODUCT");
+    }
+
+    @Test
+    void toCatalogResponse_filtersByChannel() throws Exception {
+        JsonNode searchBody = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 1, "domainType": "PRODUCT", "status": "ON_SALE", "price": 12000},
+                      {"itemId": 2, "domainType": "PRODUCT", "status": "FUNDING", "price": 14000}
+                    ],
+                    "nextCursor": null,
+                    "totalCount": 2
+                  }
+                }
+                """);
+
+        CatalogQueryParams params = new CatalogQueryParams(
+                "run", null, null, CatalogSalesChannel.FUNDING,
+                List.of(), null, null, "LATEST", null, 20
+        );
+
+        CatalogItemsResponse response = mapper.toCatalogResponse(searchBody, params);
+
+        assertThat(response.data().items()).hasSize(1);
+        assertThat(response.data().items().get(0).salesChannel()).isEqualTo(CatalogSalesChannel.FUNDING);
+    }
+
+    @Test
+    void toCatalogResponse_throwsWhenSearchBodyIsInvalid() throws Exception {
+        JsonNode invalid = objectMapper.readTree("""
+                {
+                  "success": false,
+                  "error": {"code": "S-400", "message": "invalid"}
+                }
+                """);
+
+        assertThatThrownBy(() -> mapper.toCatalogResponse(invalid, defaultParams()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("검색 응답 형식이 올바르지 않습니다");
+    }
+
+    private CatalogQueryParams defaultParams() {
+        return new CatalogQueryParams(
+                "run",
+                null,
+                null,
+                CatalogSalesChannel.ALL,
+                List.of(),
+                null,
+                null,
+                "LATEST",
+                null,
+                20
+        );
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #740

### 작업 / 변경 내용
- `GET /bff/v1/catalog/items` 엔드포인트 추가
- `channel/itemType/status/price/sort/cursor/size` 검증 및 정규화 구현
- `salesChannel/detailTarget` 포함 통합 목록 응답 DTO 및 매핑 로직 구현
- search 응답 기준 media thumbnail fallback 연동 및 다운스트림 오류 응답 변환
- 요청 검증/응답 매핑 단위 테스트 추가

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:gateways:client-gateway:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
- 기존 워크트리의 unrelated 변경(`libs/clients/*`, `docs/*`)은 본 PR에 포함하지 않았습니다.
