### PR TITLE
[MZC-697] [TASK] Search projection legacy 문서 기본값 정책 반영

### DIFF
--- a/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
@@ -217,17 +217,22 @@ public class SearchQueryService {
     private SearchItemResponse toSearchItem(Map<String, Object> hit) {
         Map<String, Object> source = toMap(hit.get("_source"));
         Map<String, Object> highlight = toMap(hit.get("highlight"));
+        Long price = asLong(source.get("price"));
+        String status = asString(source.get("status"));
+        String salesChannel = resolveSalesChannel(source, status);
+        Integer channelPriority = resolveChannelPriority(source, salesChannel);
+        Long effectivePrice = firstNonNull(asLong(source.get("effectivePrice")), price);
 
         return SearchItemResponse.builder()
                 .itemId(asLong(source.get("itemId")))
                 .title(asString(source.get("title")))
                 .category(asString(source.get("category")))
                 .domainType(asString(source.get("domainType")))
-                .price(asLong(source.get("price")))
-                .effectivePrice(asLong(source.get("effectivePrice")))
-                .status(asString(source.get("status")))
-                .salesChannel(asString(source.get("salesChannel")))
-                .channelPriority(asInteger(source.get("channelPriority")))
+                .price(price)
+                .effectivePrice(effectivePrice)
+                .status(status)
+                .salesChannel(salesChannel)
+                .channelPriority(channelPriority)
                 .activeHotDealId(asLong(source.get("activeHotDealId")))
                 .activeCampaignId(asLong(source.get("activeCampaignId")))
                 .stock(asInteger(source.get("stock")))
@@ -237,6 +242,41 @@ public class SearchQueryService {
                 .highlightedTitle(firstHighlight(highlight, "title"))
                 .highlightedDescription(firstHighlight(highlight, "description"))
                 .build();
+    }
+
+    private String resolveSalesChannel(Map<String, Object> source, String status) {
+        String fromDocument = asString(source.get("salesChannel"));
+        if (StringUtils.hasText(fromDocument)) {
+            return fromDocument;
+        }
+        return switch (normalizeStatus(status)) {
+            case "HOT_DEAL" -> "HOT_DEAL";
+            case "FUNDING", "FUNDED", "FUND_FAILED" -> "FUNDING";
+            default -> "NORMAL";
+        };
+    }
+
+    private Integer resolveChannelPriority(Map<String, Object> source, String salesChannel) {
+        Integer fromDocument = asInteger(source.get("channelPriority"));
+        if (fromDocument != null) {
+            return fromDocument;
+        }
+        return switch (normalizeStatus(salesChannel)) {
+            case "HOT_DEAL" -> 3;
+            case "FUNDING" -> 2;
+            default -> 1;
+        };
+    }
+
+    private String normalizeStatus(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return "";
+        }
+        return raw.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private Long firstNonNull(Long first, Long second) {
+        return first != null ? first : second;
     }
 
     private List<String> normalizeStatuses(List<String> statuses) {

--- a/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
@@ -198,6 +198,46 @@ class SearchQueryServiceTest {
     }
 
     @Test
+    void search_appliesDefaultProjectionValuesWhenFieldsMissing() throws Exception {
+        String responseJson = """
+                {
+                  "hits": {
+                    "total": {"value": 1, "relation": "eq"},
+                    "hits": [
+                      {
+                        "_source": {
+                          "itemId": 201,
+                          "title": "핫딜 상품",
+                          "price": 15000,
+                          "status": "HOT_DEAL"
+                        },
+                        "_score": 2.5,
+                        "sort": [201]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        Response response = mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity(responseJson, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+        when(searchResultCacheService.get(any())).thenReturn(java.util.Optional.empty());
+
+        SearchRequest request = new SearchRequest();
+        request.setQ("핫딜");
+        request.setSize(1);
+
+        CursorResponse<SearchItemResponse> result = searchQueryService.search(request);
+
+        assertThat(result.getItems()).hasSize(1);
+        SearchItemResponse item = result.getItems().get(0);
+        assertThat(item.getSalesChannel()).isEqualTo("HOT_DEAL");
+        assertThat(item.getChannelPriority()).isEqualTo(3);
+        assertThat(item.getEffectivePrice()).isEqualTo(15000L);
+    }
+
+    @Test
     void search_throwsWhenQueryBlank() throws Exception {
         SearchRequest request = new SearchRequest();
         request.setQ("   ");


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #742

### 작업 / 변경 내용
- 기존 search 문서(legacy docs)에 projection 신규 필드가 없을 때의 기본값 정책을 Query 레이어에 반영
  - `salesChannel` 누락 시 `status` 기반 fallback (`HOT_DEAL/FUNDING/NORMAL`)
  - `channelPriority` 누락 시 채널 기반 fallback (`3/2/1`)
  - `effectivePrice` 누락 시 `price` fallback
- fallback 정책 검증 테스트 추가

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:search:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
- 기존 워크트리의 unrelated 변경(`libs/clients/*`, `docs/*`)은 본 PR에 포함하지 않았습니다.
