### PR TITLE
[MZC-693] [TASK] Search Query 채널 필터/정렬 규칙 구현

### DIFF
--- a/servers/services/search/src/main/java/com/example/search/dto/search/request/SearchRequest.java
+++ b/servers/services/search/src/main/java/com/example/search/dto/search/request/SearchRequest.java
@@ -22,6 +22,8 @@ public class SearchRequest {
 
     private String domainType;
 
+    private String channel = "ALL";
+
     private List<String> status = new ArrayList<>();
 
     @Min(value = 0, message = "최소 가격은 0 이상이어야 합니다.")

--- a/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
@@ -38,6 +38,9 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class SearchQueryService {
 
+    private static final String CHANNEL_ALL = "ALL";
+    private static final Set<String> ALLOWED_CHANNELS = Set.of("ALL", "HOT_DEAL", "FUNDING", "NORMAL");
+
     private static final Set<String> BLOCKED_EXPOSURE_STATUSES = Set.of(
             "DELETED", "HIDDEN", "PRIVATE", "SOLD_OUT", "ENDED", "INACTIVE"
     );
@@ -139,6 +142,10 @@ public class SearchQueryService {
             filter.add(Map.of("terms", Map.of("status", statuses)));
         }
 
+        if (StringUtils.hasText(request.getChannel()) && !CHANNEL_ALL.equals(request.getChannel())) {
+            filter.add(channelFilterClause(request.getChannel()));
+        }
+
         mustNot.add(Map.of("terms", Map.of("status", BLOCKED_EXPOSURE_STATUSES)));
 
         Map<String, Object> priceRange = new LinkedHashMap<>();
@@ -166,23 +173,66 @@ public class SearchQueryService {
 
     private List<Map<String, Object>> buildSort(SearchSortType sortType) {
         return switch (sortType) {
+            case RELEVANCE -> List.of(
+                    Map.of("_score", Map.of("order", "desc")),
+                    Map.of("channelPriority", Map.of("order", "desc", "missing", "_last")),
+                    Map.of("createdAt", Map.of("order", "desc")),
+                    Map.of("itemId", Map.of("order", "desc"))
+            );
             case LATEST -> List.of(
+                    Map.of("channelPriority", Map.of("order", "desc", "missing", "_last")),
                     Map.of("createdAt", Map.of("order", "desc")),
                     Map.of("itemId", Map.of("order", "desc"))
             );
             case POPULAR -> List.of(
                     Map.of("stock", Map.of("order", "desc", "missing", "_last")),
+                    Map.of("channelPriority", Map.of("order", "desc", "missing", "_last")),
                     Map.of("createdAt", Map.of("order", "desc")),
                     Map.of("itemId", Map.of("order", "desc"))
             );
             case PRICE_ASC -> List.of(
                     Map.of("price", Map.of("order", "asc", "missing", "_last")),
+                    Map.of("channelPriority", Map.of("order", "desc", "missing", "_last")),
                     Map.of("itemId", Map.of("order", "desc"))
             );
             case PRICE_DESC -> List.of(
                     Map.of("price", Map.of("order", "desc", "missing", "_last")),
+                    Map.of("channelPriority", Map.of("order", "desc", "missing", "_last")),
                     Map.of("itemId", Map.of("order", "desc"))
             );
+        };
+    }
+
+    private Map<String, Object> channelFilterClause(String channel) {
+        return switch (channel) {
+            case "HOT_DEAL" -> Map.of(
+                    "bool", Map.of(
+                            "should", List.of(
+                                    Map.of("term", Map.of("salesChannel", "HOT_DEAL")),
+                                    Map.of("term", Map.of("status", "HOT_DEAL"))
+                            ),
+                            "minimum_should_match", 1
+                    )
+            );
+            case "FUNDING" -> Map.of(
+                    "bool", Map.of(
+                            "should", List.of(
+                                    Map.of("term", Map.of("salesChannel", "FUNDING")),
+                                    Map.of("terms", Map.of("status", List.of("FUNDING", "FUNDED", "FUND_FAILED")))
+                            ),
+                            "minimum_should_match", 1
+                    )
+            );
+            case "NORMAL" -> Map.of(
+                    "bool", Map.of(
+                            "should", List.of(
+                                    Map.of("term", Map.of("salesChannel", "NORMAL")),
+                                    Map.of("term", Map.of("status", "ON_SALE"))
+                            ),
+                            "minimum_should_match", 1
+                    )
+            );
+            default -> Map.of();
         };
     }
 
@@ -323,6 +373,15 @@ public class SearchQueryService {
         }
         if (StringUtils.hasText(request.getSort())) {
             request.setSort(request.getSort().trim().toUpperCase(Locale.ROOT));
+        }
+        if (StringUtils.hasText(request.getChannel())) {
+            request.setChannel(request.getChannel().trim().toUpperCase(Locale.ROOT));
+        } else {
+            request.setChannel(CHANNEL_ALL);
+        }
+        if (!ALLOWED_CHANNELS.contains(request.getChannel())) {
+            throw new BusinessException(SearchErrorCode.INVALID_SEARCH_PARAMETER,
+                    "channel은 ALL, HOT_DEAL, FUNDING, NORMAL 중 하나여야 합니다.");
         }
 
         if (request.getMinPrice() != null && request.getMinPrice() < 0) {

--- a/servers/services/search/src/main/java/com/example/search/service/query/SearchSortType.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/SearchSortType.java
@@ -6,6 +6,7 @@ import com.example.search.exception.SearchErrorCode;
 import java.util.Locale;
 
 public enum SearchSortType {
+    RELEVANCE,
     LATEST,
     POPULAR,
     PRICE_ASC,

--- a/servers/services/search/src/main/java/com/example/search/service/query/cache/SearchResultCacheService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/cache/SearchResultCacheService.java
@@ -89,6 +89,7 @@ public class SearchResultCacheService {
         normalized.put("q", SearchKeywordNormalizer.normalize(request.getQ()));
         normalized.put("category", normalizeText(request.getCategory()));
         normalized.put("domainType", normalizeDomainType(request.getDomainType()));
+        normalized.put("channel", normalizeChannel(request.getChannel()));
         normalized.put("status", normalizeStatuses(request.getStatus()));
         normalized.put("minPrice", request.getMinPrice());
         normalized.put("maxPrice", request.getMaxPrice());
@@ -117,6 +118,13 @@ public class SearchResultCacheService {
     private String normalizeSort(String value) {
         if (!StringUtils.hasText(value)) {
             return "LATEST";
+        }
+        return value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizeChannel(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "ALL";
         }
         return value.trim().toUpperCase(Locale.ROOT);
     }

--- a/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
@@ -238,9 +238,76 @@ class SearchQueryServiceTest {
     }
 
     @Test
+    void search_appliesChannelFilterWhenProvided() throws Exception {
+        String responseJson = """
+                {"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}
+                """;
+
+        Response response = mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity(responseJson, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+        when(searchResultCacheService.get(any())).thenReturn(java.util.Optional.empty());
+
+        SearchRequest request = new SearchRequest();
+        request.setQ("상품");
+        request.setChannel("hot_deal");
+        request.setSize(20);
+
+        searchQueryService.search(request);
+
+        ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+        verify(restClient).performRequest(captor.capture());
+        String body = EntityUtils.toString(captor.getValue().getEntity());
+        assertThat(body).contains("\"salesChannel\"");
+        assertThat(body).contains("\"HOT_DEAL\"");
+        assertThat(body).contains("\"minimum_should_match\":1");
+    }
+
+    @Test
+    void search_buildsRelevanceSortWithChannelPriority() throws Exception {
+        String responseJson = """
+                {"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}
+                """;
+
+        Response response = mock(Response.class);
+        when(response.getEntity()).thenReturn(new StringEntity(responseJson, ContentType.APPLICATION_JSON));
+        when(restClient.performRequest(any(Request.class))).thenReturn(response);
+        when(searchResultCacheService.get(any())).thenReturn(java.util.Optional.empty());
+
+        SearchRequest request = new SearchRequest();
+        request.setQ("아이폰");
+        request.setSort("RELEVANCE");
+        request.setSize(20);
+
+        searchQueryService.search(request);
+
+        ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+        verify(restClient).performRequest(captor.capture());
+        String body = EntityUtils.toString(captor.getValue().getEntity());
+        assertThat(body).contains("\"_score\"");
+        assertThat(body).contains("\"channelPriority\"");
+    }
+
+    @Test
     void search_throwsWhenQueryBlank() throws Exception {
         SearchRequest request = new SearchRequest();
         request.setQ("   ");
+        request.setSize(20);
+
+        assertThatThrownBy(() -> searchQueryService.search(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode()).isEqualTo(SearchErrorCode.INVALID_SEARCH_PARAMETER);
+                });
+        verify(restClient, never()).performRequest(any(Request.class));
+    }
+
+    @Test
+    void search_throwsWhenChannelInvalid() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.setQ("아이폰");
+        request.setChannel("INVALID");
         request.setSize(20);
 
         assertThatThrownBy(() -> searchQueryService.search(request))

--- a/servers/services/search/src/test/java/com/example/search/service/query/cache/SearchResultCacheServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/query/cache/SearchResultCacheServiceTest.java
@@ -108,10 +108,12 @@ class SearchResultCacheServiceTest {
         SearchRequest lowerCaseRequest = request("아이폰", List.of("SELLING"));
         lowerCaseRequest.setSort("latest");
         lowerCaseRequest.setDomainType("goods");
+        lowerCaseRequest.setChannel("hot_deal");
 
         SearchRequest upperCaseRequest = request("아이폰", List.of("SELLING"));
         upperCaseRequest.setSort("LATEST");
         upperCaseRequest.setDomainType("GOODS");
+        upperCaseRequest.setChannel("HOT_DEAL");
 
         when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(stringRedisTemplate.opsForSet()).thenReturn(setOperations);


### PR DESCRIPTION
## 개요

Search Query 경로에 채널 필터/정렬 규칙을 반영해 통합 카탈로그 조회 요구사항(R2.1~R2.3)을 구현합니다.

### 관련 이슈
- Related #739
- Related #736

### 작업 / 변경 내용
- `SearchRequest`에 `channel=ALL|HOT_DEAL|FUNDING|NORMAL` 파라미터를 추가하고 유효성 검증을 적용했습니다.
- `SearchQueryService`에 채널 필터 clause(`salesChannel` + legacy `status` fallback)를 추가했습니다.
- `RELEVANCE` 정렬을 추가하고 `_score -> channelPriority -> createdAt -> itemId` 순으로 정렬되도록 반영했습니다.
- 기존 정렬(`LATEST/POPULAR/PRICE_ASC/PRICE_DESC`)에도 `channelPriority` tie-breaker를 반영했습니다.
- `SearchResultCacheService` 캐시 키 정규화에 `channel`을 포함했습니다.
- 단위 테스트를 추가/보강했습니다.

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:search:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 현재 브랜치에는 search 모듈 관련 변경만 포함되어 있으며, 다른 로컬 변경 파일은 포함하지 않았습니다.
