### PR TITLE
[MZC-696] [TASK] 채널 기반 상세 라우팅 및 404 fallback 구현

### DIFF
--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/CatalogBffController.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/CatalogBffController.java
@@ -1,12 +1,16 @@
 package com.example.gateway.bff.controller;
 
 import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.bff.service.CatalogDetailBffService;
 import com.example.gateway.bff.service.CatalogBffService;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
@@ -16,9 +20,19 @@ import reactor.core.publisher.Mono;
 public class CatalogBffController {
 
     private final CatalogBffService catalogBffService;
+    private final CatalogDetailBffService catalogDetailBffService;
 
     @GetMapping("/catalog/items")
     public Mono<ResponseEntity<CatalogItemsResponse>> listCatalogItems(ServerHttpRequest request) {
         return catalogBffService.listCatalogItems(request);
+    }
+
+    @GetMapping("/catalog/items/{itemId}/detail")
+    public Mono<ResponseEntity<JsonNode>> getCatalogDetail(@PathVariable Long itemId,
+                                                           @RequestParam String itemType,
+                                                           @RequestParam String salesChannel,
+                                                           @RequestParam(required = false) Long hotDealId,
+                                                           @RequestParam(required = false) Long campaignId) {
+        return catalogDetailBffService.getCatalogDetail(itemId, itemType, salesChannel, hotDealId, campaignId);
     }
 }

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
@@ -1,0 +1,184 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.example.gateway.bff.dto.catalog.CatalogSalesChannel;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class CatalogDetailBffService {
+
+    private static final String CODE_INVALID_REQUEST = "BFF-CATALOG-400";
+    private static final String CODE_DOWNSTREAM_ERROR = "BFF-CATALOG-502";
+
+    private final CatalogDetailDownstreamClient downstreamClient;
+    private final GatewaySecurityProperties securityProperties;
+    private final ObjectMapper objectMapper;
+
+    public CatalogDetailBffService(CatalogDetailDownstreamClient downstreamClient,
+                                   GatewaySecurityProperties securityProperties,
+                                   ObjectMapper objectMapper) {
+        this.downstreamClient = downstreamClient;
+        this.securityProperties = securityProperties;
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<ResponseEntity<JsonNode>> getCatalogDetail(Long itemId,
+                                                           String itemTypeValue,
+                                                           String salesChannelValue,
+                                                           Long hotDealId,
+                                                           Long campaignId) {
+        CatalogDetailRequest request;
+        try {
+            request = normalize(itemId, itemTypeValue, salesChannelValue, hotDealId, campaignId);
+        } catch (IllegalArgumentException e) {
+            return Mono.just(badRequest(e.getMessage()));
+        }
+
+        HttpHeaders downstreamHeaders = buildDownstreamHeaders();
+        return routePrimary(request, downstreamHeaders)
+                .onErrorResume(e -> {
+                    log.warn("[CatalogDetail] route failed. itemId={}, channel={}", request.itemId(), request.salesChannel(), e);
+                    return Mono.just(badGateway("상세 조회에 실패했습니다"));
+                });
+    }
+
+    private Mono<ResponseEntity<JsonNode>> routePrimary(CatalogDetailRequest request, HttpHeaders headers) {
+        return switch (request.salesChannel()) {
+            case HOT_DEAL -> routeHotDeal(request, headers);
+            case FUNDING -> routeFunding(request, headers);
+            case NORMAL, ALL -> downstreamClient.fetchNormalDetail(request.itemType(), request.itemId(), headers);
+        };
+    }
+
+    private Mono<ResponseEntity<JsonNode>> routeHotDeal(CatalogDetailRequest request, HttpHeaders headers) {
+        if (request.hotDealId() == null) {
+            return fallbackToNormal(request, headers, "hot_deal_id_missing");
+        }
+        return downstreamClient.fetchHotDealDetail(request.hotDealId(), headers)
+                .flatMap(primary -> apply404Fallback(request, headers, primary, "hot_deal_404"));
+    }
+
+    private Mono<ResponseEntity<JsonNode>> routeFunding(CatalogDetailRequest request, HttpHeaders headers) {
+        Mono<ResponseEntity<JsonNode>> primaryMono = request.campaignId() != null
+                ? downstreamClient.fetchFundingDetail(request.campaignId(), headers)
+                : downstreamClient.fetchFundingDetailByItem(request.itemId(), headers);
+
+        String fallbackReason = request.campaignId() != null
+                ? "funding_campaign_404"
+                : "funding_item_404";
+
+        return primaryMono.flatMap(primary -> apply404Fallback(request, headers, primary, fallbackReason));
+    }
+
+    private Mono<ResponseEntity<JsonNode>> apply404Fallback(CatalogDetailRequest request,
+                                                            HttpHeaders headers,
+                                                            ResponseEntity<JsonNode> primaryResponse,
+                                                            String reason) {
+        if (primaryResponse.getStatusCode() != HttpStatus.NOT_FOUND) {
+            return Mono.just(primaryResponse);
+        }
+        return fallbackToNormal(request, headers, reason);
+    }
+
+    private Mono<ResponseEntity<JsonNode>> fallbackToNormal(CatalogDetailRequest request,
+                                                            HttpHeaders headers,
+                                                            String reason) {
+        log.info("[CatalogDetail] fallback applied. itemId={}, salesChannel={}, reason={}",
+                request.itemId(), request.salesChannel(), reason);
+        return downstreamClient.fetchNormalDetail(request.itemType(), request.itemId(), headers)
+                .onErrorResume(e -> {
+                    log.warn("[CatalogDetail] fallback route failed. itemId={}, salesChannel={}, reason={}",
+                            request.itemId(), request.salesChannel(), reason, e);
+                    return Mono.just(badGateway("fallback 상세 조회에 실패했습니다"));
+                });
+    }
+
+    private CatalogDetailRequest normalize(Long itemId,
+                                           String itemTypeValue,
+                                           String salesChannelValue,
+                                           Long hotDealId,
+                                           Long campaignId) {
+        if (itemId == null || itemId <= 0) {
+            throw new IllegalArgumentException("itemId는 양수여야 합니다");
+        }
+        if (hotDealId != null && hotDealId <= 0) {
+            throw new IllegalArgumentException("hotDealId는 양수여야 합니다");
+        }
+        if (campaignId != null && campaignId <= 0) {
+            throw new IllegalArgumentException("campaignId는 양수여야 합니다");
+        }
+
+        BffItemType itemType = parseItemType(itemTypeValue);
+        CatalogSalesChannel salesChannel = parseSalesChannel(salesChannelValue);
+        return new CatalogDetailRequest(itemId, itemType, salesChannel, hotDealId, campaignId);
+    }
+
+    private BffItemType parseItemType(String itemTypeValue) {
+        if (!StringUtils.hasText(itemTypeValue)) {
+            throw new IllegalArgumentException("itemType은 필수입니다");
+        }
+        try {
+            return BffItemType.fromNullable(itemTypeValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("itemType은 PRODUCT, GOODS, PERFORMANCE 중 하나여야 합니다");
+        }
+    }
+
+    private CatalogSalesChannel parseSalesChannel(String salesChannelValue) {
+        if (!StringUtils.hasText(salesChannelValue)) {
+            throw new IllegalArgumentException("salesChannel은 필수입니다");
+        }
+        CatalogSalesChannel channel = CatalogSalesChannel.fromNullable(salesChannelValue);
+        if (channel == CatalogSalesChannel.ALL) {
+            return CatalogSalesChannel.NORMAL;
+        }
+        return channel;
+    }
+
+    private HttpHeaders buildDownstreamHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (StringUtils.hasText(securityProperties.getInternalAuthToken())
+                && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
+            headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
+        }
+        return headers;
+    }
+
+    private ResponseEntity<JsonNode> badRequest(String message) {
+        return ResponseEntity.badRequest().body(errorPayload(CODE_INVALID_REQUEST, message));
+    }
+
+    private ResponseEntity<JsonNode> badGateway(String message) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(errorPayload(CODE_DOWNSTREAM_ERROR, message));
+    }
+
+    private ObjectNode errorPayload(String code, String message) {
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("success", false);
+        ObjectNode error = body.putObject("error");
+        error.put("code", code);
+        error.put("message", message);
+        return body;
+    }
+
+    private record CatalogDetailRequest(Long itemId,
+                                        BffItemType itemType,
+                                        CatalogSalesChannel salesChannel,
+                                        Long hotDealId,
+                                        Long campaignId) {
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailDownstreamClient.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailDownstreamClient.java
@@ -1,0 +1,18 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+
+public interface CatalogDetailDownstreamClient {
+
+    Mono<ResponseEntity<JsonNode>> fetchHotDealDetail(Long hotDealId, HttpHeaders headers);
+
+    Mono<ResponseEntity<JsonNode>> fetchFundingDetail(Long campaignId, HttpHeaders headers);
+
+    Mono<ResponseEntity<JsonNode>> fetchFundingDetailByItem(Long itemId, HttpHeaders headers);
+
+    Mono<ResponseEntity<JsonNode>> fetchNormalDetail(BffItemType itemType, Long itemId, HttpHeaders headers);
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogResponseMapper.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogResponseMapper.java
@@ -11,6 +11,7 @@ import com.example.gateway.bff.dto.catalog.CatalogSalesChannel;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -101,11 +102,19 @@ public class CatalogResponseMapper {
         return switch (salesChannel) {
             case HOT_DEAL -> {
                 if (activeHotDealId != null && activeHotDealId > 0) {
+                    if (itemType != null) {
+                        yield new CatalogDetailTargetResponse("HOT_DEAL",
+                                buildCatalogDetailRoutePath(itemId, itemType, CatalogSalesChannel.HOT_DEAL, activeHotDealId, null));
+                    }
                     yield new CatalogDetailTargetResponse("HOT_DEAL", "/api/v1/hot-deals/" + activeHotDealId);
                 }
                 yield new CatalogDetailTargetResponse("NORMAL", buildNormalDetailPath(itemId, itemType));
             }
             case FUNDING -> {
+                if (itemType != null) {
+                    yield new CatalogDetailTargetResponse("FUNDING",
+                            buildCatalogDetailRoutePath(itemId, itemType, CatalogSalesChannel.FUNDING, null, activeCampaignId));
+                }
                 if (activeCampaignId != null && activeCampaignId > 0) {
                     yield new CatalogDetailTargetResponse("FUNDING", "/api/campaigns/" + activeCampaignId);
                 }
@@ -113,6 +122,25 @@ public class CatalogResponseMapper {
             }
             case NORMAL, ALL -> new CatalogDetailTargetResponse("NORMAL", buildNormalDetailPath(itemId, itemType));
         };
+    }
+
+    private String buildCatalogDetailRoutePath(Long itemId,
+                                               BffItemType itemType,
+                                               CatalogSalesChannel salesChannel,
+                                               Long hotDealId,
+                                               Long campaignId) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromPath("/bff/v1/catalog/items/{itemId}/detail")
+                .queryParam("itemType", itemType.name())
+                .queryParam("salesChannel", salesChannel.name());
+
+        if (hotDealId != null && hotDealId > 0) {
+            builder.queryParam("hotDealId", hotDealId);
+        }
+        if (campaignId != null && campaignId > 0) {
+            builder.queryParam("campaignId", campaignId);
+        }
+        return builder.buildAndExpand(itemId).toUriString();
     }
 
     private String buildNormalDetailPath(Long itemId, BffItemType itemType) {

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/WebClientCatalogDetailDownstreamClient.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/WebClientCatalogDetailDownstreamClient.java
@@ -1,0 +1,62 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class WebClientCatalogDetailDownstreamClient implements CatalogDetailDownstreamClient {
+
+    private final WebClient hotDealWebClient;
+    private final WebClient fundingWebClient;
+    private final WebClient productWebClient;
+    private final ObjectMapper objectMapper;
+
+    public WebClientCatalogDetailDownstreamClient(
+            WebClient.Builder webClientBuilder,
+            ObjectMapper objectMapper,
+            @Value("${app.service.hot-deal-url:http://localhost:8089}") String hotDealServiceUrl,
+            @Value("${app.service.funding-url:http://localhost:8086}") String fundingServiceUrl,
+            @Value("${app.service.product-url:http://localhost:8084}") String productServiceUrl
+    ) {
+        this.hotDealWebClient = webClientBuilder.baseUrl(hotDealServiceUrl).build();
+        this.fundingWebClient = webClientBuilder.baseUrl(fundingServiceUrl).build();
+        this.productWebClient = webClientBuilder.baseUrl(productServiceUrl).build();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Mono<ResponseEntity<JsonNode>> fetchHotDealDetail(Long hotDealId, HttpHeaders headers) {
+        return callGet(hotDealWebClient, "/api/v1/hot-deals/" + hotDealId, headers);
+    }
+
+    @Override
+    public Mono<ResponseEntity<JsonNode>> fetchFundingDetail(Long campaignId, HttpHeaders headers) {
+        return callGet(fundingWebClient, "/api/campaigns/" + campaignId, headers);
+    }
+
+    @Override
+    public Mono<ResponseEntity<JsonNode>> fetchFundingDetailByItem(Long itemId, HttpHeaders headers) {
+        return callGet(fundingWebClient, "/api/campaigns/item/" + itemId, headers);
+    }
+
+    @Override
+    public Mono<ResponseEntity<JsonNode>> fetchNormalDetail(BffItemType itemType, Long itemId, HttpHeaders headers) {
+        return callGet(productWebClient, itemType.collectionPath() + "/" + itemId, headers);
+    }
+
+    private Mono<ResponseEntity<JsonNode>> callGet(WebClient client, String path, HttpHeaders headers) {
+        return client.get()
+                .uri(path)
+                .headers(requestHeaders -> requestHeaders.addAll(headers))
+                .exchangeToMono(response -> response.bodyToMono(JsonNode.class)
+                        .defaultIfEmpty(objectMapper.createObjectNode())
+                        .map(payload -> ResponseEntity.status(response.statusCode()).body(payload)));
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogDetailBffServiceTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogDetailBffServiceTest.java
@@ -1,0 +1,129 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.BffItemType;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogDetailBffServiceTest {
+
+    @Mock
+    private CatalogDetailDownstreamClient downstreamClient;
+
+    private CatalogDetailBffService service;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        GatewaySecurityProperties securityProperties = new GatewaySecurityProperties();
+        securityProperties.setInternalAuthHeader("X-Gateway-Auth");
+        securityProperties.setInternalAuthToken("internal-secret");
+
+        objectMapper = new ObjectMapper();
+        service = new CatalogDetailBffService(downstreamClient, securityProperties, objectMapper);
+    }
+
+    @Test
+    void getCatalogDetail_returnsHotDealDetailWhenPrimarySuccess() {
+        when(downstreamClient.fetchHotDealDetail(eq(901L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.OK, "hot-deal")));
+
+        ResponseEntity<JsonNode> response = service
+                .getCatalogDetail(11L, "PRODUCT", "HOT_DEAL", 901L, null)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().path("source").asText()).isEqualTo("hot-deal");
+        verify(downstreamClient, never()).fetchNormalDetail(any(), any(), any());
+    }
+
+    @Test
+    void getCatalogDetail_fallbacksToNormalWhenHotDeal404() {
+        when(downstreamClient.fetchHotDealDetail(eq(901L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.NOT_FOUND, "hot-deal-404")));
+        when(downstreamClient.fetchNormalDetail(eq(BffItemType.PRODUCT), eq(11L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.OK, "normal")));
+
+        ResponseEntity<JsonNode> response = service
+                .getCatalogDetail(11L, "PRODUCT", "HOT_DEAL", 901L, null)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().path("source").asText()).isEqualTo("normal");
+        verify(downstreamClient).fetchNormalDetail(eq(BffItemType.PRODUCT), eq(11L), any(HttpHeaders.class));
+    }
+
+    @Test
+    void getCatalogDetail_fallbacksToNormalWhenFundingItemLookup404() {
+        when(downstreamClient.fetchFundingDetailByItem(eq(22L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.NOT_FOUND, "funding-404")));
+        when(downstreamClient.fetchNormalDetail(eq(BffItemType.GOODS), eq(22L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.OK, "normal")));
+
+        ResponseEntity<JsonNode> response = service
+                .getCatalogDetail(22L, "GOODS", "FUNDING", null, null)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().path("source").asText()).isEqualTo("normal");
+        verify(downstreamClient).fetchFundingDetailByItem(eq(22L), any(HttpHeaders.class));
+        verify(downstreamClient, never()).fetchFundingDetail(any(), any(HttpHeaders.class));
+    }
+
+    @Test
+    void getCatalogDetail_returnsNormalDirectlyWhenChannelNormal() {
+        when(downstreamClient.fetchNormalDetail(eq(BffItemType.PERFORMANCE), eq(33L), any(HttpHeaders.class)))
+                .thenReturn(Mono.just(response(HttpStatus.OK, "normal")));
+
+        ResponseEntity<JsonNode> response = service
+                .getCatalogDetail(33L, "PERFORMANCE", "NORMAL", null, null)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().path("source").asText()).isEqualTo("normal");
+        verify(downstreamClient, never()).fetchHotDealDetail(any(), any(HttpHeaders.class));
+        verify(downstreamClient, never()).fetchFundingDetail(any(), any(HttpHeaders.class));
+        verify(downstreamClient, never()).fetchFundingDetailByItem(any(), any(HttpHeaders.class));
+    }
+
+    @Test
+    void getCatalogDetail_returns400WhenRequestInvalid() {
+        ResponseEntity<JsonNode> response = service
+                .getCatalogDetail(0L, "PRODUCT", "HOT_DEAL", 1L, null)
+                .block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().path("success").asBoolean()).isFalse();
+        verifyNoInteractions(downstreamClient);
+    }
+
+    private ResponseEntity<JsonNode> response(HttpStatus status, String source) {
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("source", source);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogResponseMapperTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogResponseMapperTest.java
@@ -65,12 +65,14 @@ class CatalogResponseMapperTest {
         CatalogItemCardResponse hotDeal = response.data().items().get(0);
         assertThat(hotDeal.salesChannel()).isEqualTo(CatalogSalesChannel.HOT_DEAL);
         assertThat(hotDeal.detailTarget().type()).isEqualTo("HOT_DEAL");
-        assertThat(hotDeal.detailTarget().path()).isEqualTo("/api/v1/hot-deals/901");
+        assertThat(hotDeal.detailTarget().path())
+                .isEqualTo("/bff/v1/catalog/items/11/detail?itemType=PRODUCT&salesChannel=HOT_DEAL&hotDealId=901");
 
         CatalogItemCardResponse funding = response.data().items().get(1);
         assertThat(funding.salesChannel()).isEqualTo(CatalogSalesChannel.FUNDING);
         assertThat(funding.detailTarget().type()).isEqualTo("FUNDING");
-        assertThat(funding.detailTarget().path()).isEqualTo("/api/campaigns/301");
+        assertThat(funding.detailTarget().path())
+                .isEqualTo("/bff/v1/catalog/items/22/detail?itemType=GOODS&salesChannel=FUNDING&campaignId=301");
 
         CatalogItemCardResponse normal = response.data().items().get(2);
         assertThat(normal.salesChannel()).isEqualTo(CatalogSalesChannel.NORMAL);
@@ -130,6 +132,30 @@ class CatalogResponseMapperTest {
 
         assertThat(response.data().items()).hasSize(1);
         assertThat(response.data().items().get(0).salesChannel()).isEqualTo(CatalogSalesChannel.FUNDING);
+    }
+
+    @Test
+    void toCatalogResponse_mapsFundingRouteWithoutCampaignId() throws Exception {
+        JsonNode searchBody = objectMapper.readTree("""
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {"itemId": 2, "domainType": "PRODUCT", "status": "FUNDING", "price": 14000}
+                    ],
+                    "nextCursor": null,
+                    "totalCount": 1
+                  }
+                }
+                """);
+
+        CatalogItemsResponse response = mapper.toCatalogResponse(searchBody, defaultParams());
+
+        assertThat(response.data().items()).hasSize(1);
+        CatalogItemCardResponse funding = response.data().items().get(0);
+        assertThat(funding.detailTarget().type()).isEqualTo("FUNDING");
+        assertThat(funding.detailTarget().path())
+                .isEqualTo("/bff/v1/catalog/items/2/detail?itemType=PRODUCT&salesChannel=FUNDING");
     }
 
     @Test


### PR DESCRIPTION
## 개요

통합 카탈로그 카드의 `detailTarget`을 채널 기반 라우팅 경로로 고정하고, HOT_DEAL/FUNDING 상세가 404일 때 일반상품 상세로 fallback 하도록 Gateway BFF를 구현했습니다.

### 관련 이슈
- Closes #743
- Related #737
- Related #736

### 작업 / 변경 내용
- `GET /bff/v1/catalog/items/{itemId}/detail` 엔드포인트를 추가했습니다.
- `CatalogDetailBffService`를 추가해 채널별 상세 호출을 분기했습니다.
- HOT_DEAL/FUNDING 경로에서 404가 발생하면 NORMAL 상세로 fallback 하도록 처리했고, fallback 시 로그를 남기도록 구현했습니다.
- `CatalogDetailDownstreamClient` 인터페이스 + WebClient 구현체를 분리해 호출 로직을 캡슐화했습니다.
- `CatalogResponseMapper`의 `detailTarget.path`를 HOT_DEAL/FUNDING에 대해 새 BFF 상세 라우팅 경로로 변경했습니다.
- 테스트를 추가/수정했습니다.
  - `CatalogDetailBffServiceTest` 신설
  - `CatalogResponseMapperTest` 기대 경로 및 시나리오 보강

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:gateways:client-gateway:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 기존 `/bff/v1/items/{itemId}?type=...` 경로는 NORMAL 채널에서 그대로 유지됩니다.
- HOT_DEAL/FUNDING은 `detailTarget.path`가 BFF 상세 라우팅 엔드포인트를 가리키며, 내부적으로 404 fallback을 수행합니다.
