### PR TITLE
[MZC-700] [TASK] projection 멱등 및 out-of-order 방어 구현

### DIFF
--- a/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
+++ b/libs/event/outbox/src/main/java/com/example/event/outbox/OutboxService.java
@@ -31,6 +31,7 @@ public class OutboxService implements EventPublisher {
         Map<String, Object> envelope = new LinkedHashMap<>();
         envelope.put("eventId", event.getEventId());
         envelope.put("eventType", event.getEventTypeName());
+        envelope.put("occurredAt", event.getOccurredAt().toString());
         envelope.putAll(event.getPayload());
         String payload = JsonUtils.toJson(envelope);
 

--- a/servers/services/search/src/main/java/com/example/search/consumer/FundingEventConsumer.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/FundingEventConsumer.java
@@ -3,6 +3,7 @@ package com.example.search.consumer;
 import com.example.config.kafka.IdempotentConsumerService;
 import com.example.core.util.JsonUtils;
 import com.example.search.service.index.SearchIndexingFailureService;
+import com.example.search.service.index.SearchEventTimeParser;
 import com.example.search.service.index.SearchIndexingService;
 import com.example.search.service.metrics.SearchMetricsService;
 import com.example.search.service.query.cache.SearchResultCacheService;
@@ -64,21 +65,41 @@ public class FundingEventConsumer {
 
     private boolean route(FundingEventMessage event) {
         String normalizedType = normalizeEventType(event.getEventType());
+        Long occurredAtMillis = SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt());
         return switch (normalizedType) {
             case "FUNDING_CREATED" -> {
-                searchIndexingService.applyFundingCreated(event.getItemId(), event.getCampaignId());
+                searchIndexingService.applyFundingCreatedByEventTime(
+                        event.getItemId(),
+                        event.getCampaignId(),
+                        occurredAtMillis
+                );
                 yield true;
             }
             case "FUNDING_SUCCEEDED" -> {
-                searchIndexingService.applyFundingClosed(event.getItemId(), event.getCampaignId(), "FUNDED");
+                searchIndexingService.applyFundingClosedByEventTime(
+                        event.getItemId(),
+                        event.getCampaignId(),
+                        "FUNDED",
+                        occurredAtMillis
+                );
                 yield true;
             }
             case "FUNDING_FAILED" -> {
-                searchIndexingService.applyFundingClosed(event.getItemId(), event.getCampaignId(), "FUND_FAILED");
+                searchIndexingService.applyFundingClosedByEventTime(
+                        event.getItemId(),
+                        event.getCampaignId(),
+                        "FUND_FAILED",
+                        occurredAtMillis
+                );
                 yield true;
             }
             case "FUNDING_CANCELLED" -> {
-                searchIndexingService.applyFundingClosed(event.getItemId(), event.getCampaignId(), "CLOSED");
+                searchIndexingService.applyFundingClosedByEventTime(
+                        event.getItemId(),
+                        event.getCampaignId(),
+                        "CLOSED",
+                        occurredAtMillis
+                );
                 yield true;
             }
             default -> {

--- a/servers/services/search/src/main/java/com/example/search/consumer/FundingEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/FundingEventMessage.java
@@ -9,6 +9,7 @@ public class FundingEventMessage {
 
     private String eventId;
     private String eventType;
+    private String occurredAt;
 
     private Long campaignId;
     private Long itemId;

--- a/servers/services/search/src/main/java/com/example/search/consumer/HotDealEventConsumer.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/HotDealEventConsumer.java
@@ -3,6 +3,7 @@ package com.example.search.consumer;
 import com.example.config.kafka.IdempotentConsumerService;
 import com.example.core.util.JsonUtils;
 import com.example.search.service.index.SearchIndexingFailureService;
+import com.example.search.service.index.SearchEventTimeParser;
 import com.example.search.service.index.SearchIndexingService;
 import com.example.search.service.metrics.SearchMetricsService;
 import com.example.search.service.query.cache.SearchResultCacheService;
@@ -64,13 +65,23 @@ public class HotDealEventConsumer {
 
     private boolean route(HotDealEventMessage event) {
         String normalizedType = normalizeEventType(event.getEventType());
+        Long occurredAtMillis = SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt());
         return switch (normalizedType) {
             case "HOT_DEAL_STARTED" -> {
-                searchIndexingService.applyHotDealStarted(event.getItemId(), event.getHotDealId(), event.getDiscountedPrice());
+                searchIndexingService.applyHotDealStartedByEventTime(
+                        event.getItemId(),
+                        event.getHotDealId(),
+                        event.getDiscountedPrice(),
+                        occurredAtMillis
+                );
                 yield true;
             }
             case "HOT_DEAL_ENDED", "HOT_DEAL_CANCELLED" -> {
-                searchIndexingService.applyHotDealEnded(event.getItemId(), event.getHotDealId());
+                searchIndexingService.applyHotDealEndedByEventTime(
+                        event.getItemId(),
+                        event.getHotDealId(),
+                        occurredAtMillis
+                );
                 yield true;
             }
             default -> {

--- a/servers/services/search/src/main/java/com/example/search/consumer/HotDealEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/HotDealEventMessage.java
@@ -9,6 +9,7 @@ public class HotDealEventMessage {
 
     private String eventId;
     private String eventType;
+    private String occurredAt;
 
     private Long hotDealId;
     private Long itemId;

--- a/servers/services/search/src/main/java/com/example/search/consumer/ItemEventConsumer.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/ItemEventConsumer.java
@@ -5,6 +5,7 @@ import com.example.core.util.JsonUtils;
 import com.example.search.service.metrics.SearchMetricsService;
 import com.example.search.service.index.SearchIndexingService;
 import com.example.search.service.index.SearchIndexingFailureService;
+import com.example.search.service.index.SearchEventTimeParser;
 import com.example.search.service.thumbnail.SearchThumbnailEnrichmentTaskService;
 import com.example.search.service.query.cache.SearchResultCacheService;
 import lombok.RequiredArgsConstructor;
@@ -112,7 +113,11 @@ public class ItemEventConsumer {
             log.warn("[SearchItemConsumer] newStatus 누락으로 상태 업데이트 스킵. itemId={}", event.getItemId());
             return;
         }
-        searchIndexingService.updateItemStatus(event.getItemId(), event.getNewStatus());
+        searchIndexingService.updateItemStatusByEventTime(
+                event.getItemId(),
+                event.getNewStatus(),
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
+        );
         searchResultCacheService.evictAll();
     }
 

--- a/servers/services/search/src/main/java/com/example/search/consumer/ItemEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/ItemEventMessage.java
@@ -11,6 +11,7 @@ public class ItemEventMessage {
 
     private String eventId;
     private String eventType;
+    private String occurredAt;
 
     private Long itemId;
     private String title;

--- a/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
+++ b/servers/services/search/src/main/java/com/example/search/consumer/StockEventMessage.java
@@ -9,6 +9,7 @@ public class StockEventMessage {
 
     private String eventId;
     private String eventType;
+    private String occurredAt;
 
     private Long stockItemId;
     private Long itemId;

--- a/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
+++ b/servers/services/search/src/main/java/com/example/search/document/ItemDocument.java
@@ -76,6 +76,9 @@ public class ItemDocument {
     @Field(type = FieldType.Long)
     private Long stockVersion;
 
+    @Field(type = FieldType.Long)
+    private Long channelEventOccurredAt;
+
     @Field(type = FieldType.Keyword)
     private List<String> tags;
 

--- a/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/ElasticsearchIndexingService.java
@@ -122,6 +122,11 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
 
     @Override
     public void updateItemStatus(Long itemId, String status) {
+        updateItemStatusByEventTime(itemId, status, null);
+    }
+
+    @Override
+    public void updateItemStatusByEventTime(Long itemId, String status, Long eventOccurredAtMillis) {
         if (itemId == null || !StringUtils.hasText(status)) {
             return;
         }
@@ -140,11 +145,16 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         params.put("fundingPriority", CHANNEL_PRIORITY_FUNDING);
         params.put("normalChannel", CHANNEL_NORMAL);
         params.put("normalPriority", CHANNEL_PRIORITY_NORMAL);
+        params.put("eventOccurredAtMillis", eventOccurredAtMillis);
 
         Map<String, Object> script = new LinkedHashMap<>();
         script.put("lang", "painless");
         script.put("source",
-                "ctx._source.itemId = params.itemId; " +
+                "if (params.eventOccurredAtMillis != null && ctx._source.channelEventOccurredAt != null && " +
+                        "params.eventOccurredAtMillis < ctx._source.channelEventOccurredAt) { " +
+                        "ctx.op = 'none'; " +
+                        "} else { " +
+                        "ctx._source.itemId = params.itemId; " +
                         "ctx._source.status = params.status; " +
                         "boolean hasHotDeal = ctx._source.activeHotDealId != null; " +
                         "boolean hasCampaign = ctx._source.activeCampaignId != null; " +
@@ -163,6 +173,10 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
                         "} " +
                         "if (ctx._source.effectivePrice == null && ctx._source.price != null) { " +
                         "ctx._source.effectivePrice = ctx._source.price; " +
+                        "} " +
+                        "if (params.eventOccurredAtMillis != null) { " +
+                        "ctx._source.channelEventOccurredAt = params.eventOccurredAtMillis; " +
+                        "} " +
                         "}");
         script.put("params", params);
 
@@ -171,6 +185,7 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         upsert.put("status", normalizedStatus);
         upsert.put("salesChannel", statusChannel.name());
         upsert.put("channelPriority", statusChannel.priority());
+        putIfNotNull(upsert, "channelEventOccurredAt", eventOccurredAtMillis);
         upsert.put("createdAt", Instant.now().toString());
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -185,6 +200,14 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
 
     @Override
     public void applyHotDealStarted(Long itemId, Long hotDealId, Long discountedPrice) {
+        applyHotDealStartedByEventTime(itemId, hotDealId, discountedPrice, null);
+    }
+
+    @Override
+    public void applyHotDealStartedByEventTime(Long itemId,
+                                               Long hotDealId,
+                                               Long discountedPrice,
+                                               Long eventOccurredAtMillis) {
         if (itemId == null) {
             return;
         }
@@ -195,11 +218,16 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         params.put("discountedPrice", discountedPrice);
         params.put("hotDealChannel", CHANNEL_HOT_DEAL);
         params.put("hotDealPriority", CHANNEL_PRIORITY_HOT_DEAL);
+        params.put("eventOccurredAtMillis", eventOccurredAtMillis);
 
         Map<String, Object> script = new LinkedHashMap<>();
         script.put("lang", "painless");
         script.put("source",
-                "ctx._source.itemId = params.itemId; " +
+                "if (params.eventOccurredAtMillis != null && ctx._source.channelEventOccurredAt != null && " +
+                        "params.eventOccurredAtMillis < ctx._source.channelEventOccurredAt) { " +
+                        "ctx.op = 'none'; " +
+                        "} else { " +
+                        "ctx._source.itemId = params.itemId; " +
                         "ctx._source.salesChannel = params.hotDealChannel; " +
                         "ctx._source.channelPriority = params.hotDealPriority; " +
                         "ctx._source.status = 'HOT_DEAL'; " +
@@ -208,6 +236,10 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
                         "ctx._source.effectivePrice = params.discountedPrice; " +
                         "} else if (ctx._source.effectivePrice == null && ctx._source.price != null) { " +
                         "ctx._source.effectivePrice = ctx._source.price; " +
+                        "} " +
+                        "if (params.eventOccurredAtMillis != null) { " +
+                        "ctx._source.channelEventOccurredAt = params.eventOccurredAtMillis; " +
+                        "} " +
                         "}");
         script.put("params", params);
 
@@ -218,6 +250,7 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         upsert.put("status", "HOT_DEAL");
         putIfNotNull(upsert, "activeHotDealId", hotDealId);
         putIfNotNull(upsert, "effectivePrice", discountedPrice);
+        putIfNotNull(upsert, "channelEventOccurredAt", eventOccurredAtMillis);
         upsert.put("createdAt", Instant.now().toString());
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -232,6 +265,11 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
 
     @Override
     public void applyHotDealEnded(Long itemId, Long hotDealId) {
+        applyHotDealEndedByEventTime(itemId, hotDealId, null);
+    }
+
+    @Override
+    public void applyHotDealEndedByEventTime(Long itemId, Long hotDealId, Long eventOccurredAtMillis) {
         if (itemId == null) {
             return;
         }
@@ -245,11 +283,16 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         params.put("fundingPriority", CHANNEL_PRIORITY_FUNDING);
         params.put("normalChannel", CHANNEL_NORMAL);
         params.put("normalPriority", CHANNEL_PRIORITY_NORMAL);
+        params.put("eventOccurredAtMillis", eventOccurredAtMillis);
 
         Map<String, Object> script = new LinkedHashMap<>();
         script.put("lang", "painless");
         script.put("source",
-                "ctx._source.itemId = params.itemId; " +
+                "if (params.eventOccurredAtMillis != null && ctx._source.channelEventOccurredAt != null && " +
+                        "params.eventOccurredAtMillis < ctx._source.channelEventOccurredAt) { " +
+                        "ctx.op = 'none'; " +
+                        "} else { " +
+                        "ctx._source.itemId = params.itemId; " +
                         "if (params.hotDealId == null || ctx._source.activeHotDealId == null || " +
                         "ctx._source.activeHotDealId.equals(params.hotDealId)) { " +
                         "ctx._source.activeHotDealId = null; " +
@@ -275,6 +318,10 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
                         "} " +
                         "if (ctx._source.effectivePrice == null && ctx._source.price != null) { " +
                         "ctx._source.effectivePrice = ctx._source.price; " +
+                        "} " +
+                        "if (params.eventOccurredAtMillis != null) { " +
+                        "ctx._source.channelEventOccurredAt = params.eventOccurredAtMillis; " +
+                        "} " +
                         "}");
         script.put("params", params);
 
@@ -283,6 +330,7 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         upsert.put("salesChannel", CHANNEL_NORMAL);
         upsert.put("channelPriority", CHANNEL_PRIORITY_NORMAL);
         upsert.put("status", "ON_SALE");
+        putIfNotNull(upsert, "channelEventOccurredAt", eventOccurredAtMillis);
         upsert.put("createdAt", Instant.now().toString());
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -297,6 +345,11 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
 
     @Override
     public void applyFundingCreated(Long itemId, Long campaignId) {
+        applyFundingCreatedByEventTime(itemId, campaignId, null);
+    }
+
+    @Override
+    public void applyFundingCreatedByEventTime(Long itemId, Long campaignId, Long eventOccurredAtMillis) {
         if (itemId == null) {
             return;
         }
@@ -308,11 +361,16 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         params.put("hotDealPriority", CHANNEL_PRIORITY_HOT_DEAL);
         params.put("fundingChannel", CHANNEL_FUNDING);
         params.put("fundingPriority", CHANNEL_PRIORITY_FUNDING);
+        params.put("eventOccurredAtMillis", eventOccurredAtMillis);
 
         Map<String, Object> script = new LinkedHashMap<>();
         script.put("lang", "painless");
         script.put("source",
-                "ctx._source.itemId = params.itemId; " +
+                "if (params.eventOccurredAtMillis != null && ctx._source.channelEventOccurredAt != null && " +
+                        "params.eventOccurredAtMillis < ctx._source.channelEventOccurredAt) { " +
+                        "ctx.op = 'none'; " +
+                        "} else { " +
+                        "ctx._source.itemId = params.itemId; " +
                         "if (params.campaignId != null) { ctx._source.activeCampaignId = params.campaignId; } " +
                         "boolean hasHotDeal = ctx._source.activeHotDealId != null; " +
                         "if (hasHotDeal) { " +
@@ -327,6 +385,10 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
                         "} " +
                         "if (ctx._source.effectivePrice == null && ctx._source.price != null) { " +
                         "ctx._source.effectivePrice = ctx._source.price; " +
+                        "} " +
+                        "if (params.eventOccurredAtMillis != null) { " +
+                        "ctx._source.channelEventOccurredAt = params.eventOccurredAtMillis; " +
+                        "} " +
                         "}");
         script.put("params", params);
 
@@ -336,6 +398,7 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         upsert.put("channelPriority", CHANNEL_PRIORITY_FUNDING);
         upsert.put("status", "FUNDING");
         putIfNotNull(upsert, "activeCampaignId", campaignId);
+        putIfNotNull(upsert, "channelEventOccurredAt", eventOccurredAtMillis);
         upsert.put("createdAt", Instant.now().toString());
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -350,6 +413,14 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
 
     @Override
     public void applyFundingClosed(Long itemId, Long campaignId, String terminalStatus) {
+        applyFundingClosedByEventTime(itemId, campaignId, terminalStatus, null);
+    }
+
+    @Override
+    public void applyFundingClosedByEventTime(Long itemId,
+                                              Long campaignId,
+                                              String terminalStatus,
+                                              Long eventOccurredAtMillis) {
         if (itemId == null) {
             return;
         }
@@ -365,11 +436,16 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         params.put("fundingPriority", CHANNEL_PRIORITY_FUNDING);
         params.put("normalChannel", CHANNEL_NORMAL);
         params.put("normalPriority", CHANNEL_PRIORITY_NORMAL);
+        params.put("eventOccurredAtMillis", eventOccurredAtMillis);
 
         Map<String, Object> script = new LinkedHashMap<>();
         script.put("lang", "painless");
         script.put("source",
-                "ctx._source.itemId = params.itemId; " +
+                "if (params.eventOccurredAtMillis != null && ctx._source.channelEventOccurredAt != null && " +
+                        "params.eventOccurredAtMillis < ctx._source.channelEventOccurredAt) { " +
+                        "ctx.op = 'none'; " +
+                        "} else { " +
+                        "ctx._source.itemId = params.itemId; " +
                         "boolean campaignClosed = false; " +
                         "if (params.campaignId == null || ctx._source.activeCampaignId == null || " +
                         "ctx._source.activeCampaignId.equals(params.campaignId)) { " +
@@ -396,6 +472,10 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
                         "} " +
                         "if (ctx._source.effectivePrice == null && ctx._source.price != null) { " +
                         "ctx._source.effectivePrice = ctx._source.price; " +
+                        "} " +
+                        "if (params.eventOccurredAtMillis != null) { " +
+                        "ctx._source.channelEventOccurredAt = params.eventOccurredAtMillis; " +
+                        "} " +
                         "}");
         script.put("params", params);
 
@@ -404,6 +484,7 @@ public class ElasticsearchIndexingService implements SearchIndexingService {
         upsert.put("salesChannel", CHANNEL_NORMAL);
         upsert.put("channelPriority", CHANNEL_PRIORITY_NORMAL);
         putIfNotNull(upsert, "status", normalizedStatus);
+        putIfNotNull(upsert, "channelEventOccurredAt", eventOccurredAtMillis);
         upsert.put("createdAt", Instant.now().toString());
 
         Map<String, Object> body = new LinkedHashMap<>();

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchEventTimeParser.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchEventTimeParser.java
@@ -1,0 +1,37 @@
+package com.example.search.service.index;
+
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+public final class SearchEventTimeParser {
+
+    private SearchEventTimeParser() {
+    }
+
+    public static Long parseOccurredAtMillis(String occurredAt) {
+        if (!StringUtils.hasText(occurredAt)) {
+            return null;
+        }
+
+        String raw = occurredAt.trim();
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+
+        try {
+            return Instant.parse(raw).toEpochMilli();
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+
+        try {
+            return LocalDateTime.parse(raw).toInstant(ZoneOffset.UTC).toEpochMilli();
+        } catch (DateTimeParseException ignored) {
+            return null;
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingFailureService.java
@@ -143,7 +143,11 @@ public class SearchIndexingFailureService {
 
     private void replayItemStatusChanged(String payload) {
         ItemEventMessage event = JsonUtils.fromJson(payload, ItemEventMessage.class);
-        searchIndexingService.updateItemStatus(event.getItemId(), event.getNewStatus());
+        searchIndexingService.updateItemStatusByEventTime(
+                event.getItemId(),
+                event.getNewStatus(),
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
+        );
     }
 
     private void replayItemDeleted(String payload) {
@@ -173,35 +177,39 @@ public class SearchIndexingFailureService {
 
     private void replayHotDealStarted(String payload) {
         HotDealEventMessage event = JsonUtils.fromJson(payload, HotDealEventMessage.class);
-        searchIndexingService.applyHotDealStarted(
+        searchIndexingService.applyHotDealStartedByEventTime(
                 event.getItemId(),
                 event.getHotDealId(),
-                event.getDiscountedPrice()
+                event.getDiscountedPrice(),
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
         );
     }
 
     private void replayHotDealEnded(String payload) {
         HotDealEventMessage event = JsonUtils.fromJson(payload, HotDealEventMessage.class);
-        searchIndexingService.applyHotDealEnded(
+        searchIndexingService.applyHotDealEndedByEventTime(
                 event.getItemId(),
-                event.getHotDealId()
+                event.getHotDealId(),
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
         );
     }
 
     private void replayFundingCreated(String payload) {
         FundingEventMessage event = JsonUtils.fromJson(payload, FundingEventMessage.class);
-        searchIndexingService.applyFundingCreated(
+        searchIndexingService.applyFundingCreatedByEventTime(
                 event.getItemId(),
-                event.getCampaignId()
+                event.getCampaignId(),
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
         );
     }
 
     private void replayFundingClosed(String payload, String terminalStatus) {
         FundingEventMessage event = JsonUtils.fromJson(payload, FundingEventMessage.class);
-        searchIndexingService.applyFundingClosed(
+        searchIndexingService.applyFundingClosedByEventTime(
                 event.getItemId(),
                 event.getCampaignId(),
-                terminalStatus
+                terminalStatus,
+                SearchEventTimeParser.parseOccurredAtMillis(event.getOccurredAt())
         );
     }
 

--- a/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/index/SearchIndexingService.java
@@ -16,17 +16,27 @@ public interface SearchIndexingService {
 
     void updateItemStatus(Long itemId, String status);
 
+    void updateItemStatusByEventTime(Long itemId, String status, Long eventOccurredAtMillis);
+
     void updateItemStock(Long itemId, Integer stock);
 
     void updateItemStockVersioned(Long itemId, Integer stock, Long stockVersion);
 
     void applyHotDealStarted(Long itemId, Long hotDealId, Long discountedPrice);
 
+    void applyHotDealStartedByEventTime(Long itemId, Long hotDealId, Long discountedPrice, Long eventOccurredAtMillis);
+
     void applyHotDealEnded(Long itemId, Long hotDealId);
+
+    void applyHotDealEndedByEventTime(Long itemId, Long hotDealId, Long eventOccurredAtMillis);
 
     void applyFundingCreated(Long itemId, Long campaignId);
 
+    void applyFundingCreatedByEventTime(Long itemId, Long campaignId, Long eventOccurredAtMillis);
+
     void applyFundingClosed(Long itemId, Long campaignId, String terminalStatus);
+
+    void applyFundingClosedByEventTime(Long itemId, Long campaignId, String terminalStatus, Long eventOccurredAtMillis);
 
     void updateThumbnailSnapshot(Long itemId, Long thumbnailMediaId, String thumbnailUrlSnapshot, Long mediaVersion);
 

--- a/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
+++ b/servers/services/search/src/main/resources/elasticsearch/items-index-template.json
@@ -117,6 +117,9 @@
       "stockVersion": {
         "type": "long"
       },
+      "channelEventOccurredAt": {
+        "type": "long"
+      },
       "tags": {
         "type": "keyword"
       },

--- a/servers/services/search/src/test/java/com/example/search/consumer/FundingEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/FundingEventConsumerTest.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,7 +57,7 @@ class FundingEventConsumerTest {
 
         fundingEventConsumer.consume(message);
 
-        verify(searchIndexingService).applyFundingCreated(101L, 8001L);
+        verify(searchIndexingService).applyFundingCreatedByEventTime(101L, 8001L, null);
         verify(searchResultCacheService).evictAll();
     }
 
@@ -75,7 +76,7 @@ class FundingEventConsumerTest {
 
         fundingEventConsumer.consume(message);
 
-        verify(searchIndexingService).applyFundingClosed(101L, 8001L, "FUNDED");
+        verify(searchIndexingService).applyFundingClosedByEventTime(101L, 8001L, "FUNDED", null);
         verify(searchResultCacheService).evictAll();
     }
 
@@ -94,7 +95,7 @@ class FundingEventConsumerTest {
 
         fundingEventConsumer.consume(message);
 
-        verify(searchIndexingService).applyFundingClosed(101L, 8001L, "FUND_FAILED");
+        verify(searchIndexingService).applyFundingClosedByEventTime(101L, 8001L, "FUND_FAILED", null);
         verify(searchResultCacheService).evictAll();
     }
 
@@ -110,8 +111,8 @@ class FundingEventConsumerTest {
         fundingEventConsumer.consume(message);
 
         verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
-        verify(searchIndexingService, never()).applyFundingCreated(any(), any());
-        verify(searchIndexingService, never()).applyFundingClosed(any(), any(), any());
+        verify(searchIndexingService, never()).applyFundingCreatedByEventTime(any(), any(), isNull());
+        verify(searchIndexingService, never()).applyFundingClosedByEventTime(any(), any(), any(), isNull());
     }
 
     private void stubIdempotentExecution() {

--- a/servers/services/search/src/test/java/com/example/search/consumer/HotDealEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/HotDealEventConsumerTest.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +58,7 @@ class HotDealEventConsumerTest {
 
         hotDealEventConsumer.consume(message);
 
-        verify(searchIndexingService).applyHotDealStarted(101L, 9001L, 9900L);
+        verify(searchIndexingService).applyHotDealStartedByEventTime(101L, 9001L, 9900L, null);
         verify(searchResultCacheService).evictAll();
     }
 
@@ -76,7 +77,7 @@ class HotDealEventConsumerTest {
 
         hotDealEventConsumer.consume(message);
 
-        verify(searchIndexingService).applyHotDealEnded(101L, 9001L);
+        verify(searchIndexingService).applyHotDealEndedByEventTime(101L, 9001L, null);
         verify(searchResultCacheService).evictAll();
     }
 
@@ -92,8 +93,8 @@ class HotDealEventConsumerTest {
         hotDealEventConsumer.consume(message);
 
         verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
-        verify(searchIndexingService, never()).applyHotDealStarted(any(), any(), any());
-        verify(searchIndexingService, never()).applyHotDealEnded(any(), any());
+        verify(searchIndexingService, never()).applyHotDealStartedByEventTime(any(), any(), any(), isNull());
+        verify(searchIndexingService, never()).applyHotDealEndedByEventTime(any(), any(), isNull());
     }
 
     private void stubIdempotentExecution() {

--- a/servers/services/search/src/test/java/com/example/search/consumer/ItemEventConsumerTest.java
+++ b/servers/services/search/src/test/java/com/example/search/consumer/ItemEventConsumerTest.java
@@ -125,7 +125,7 @@ class ItemEventConsumerTest {
 
         itemEventConsumer.consume(message);
 
-        verify(searchIndexingService).updateItemStatus(101L, "SELLING");
+        verify(searchIndexingService).updateItemStatusByEventTime(101L, "SELLING", null);
         verify(searchResultCacheService).evictAll();
     }
 

--- a/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/index/SearchIndexingFailureServiceTest.java
@@ -167,7 +167,7 @@ class SearchIndexingFailureServiceTest {
 
         IndexingFailureRetryResponse response = searchIndexingFailureService.retryFailure(3L);
 
-        verify(searchIndexingService).applyFundingClosed(101L, 77L, "FUNDED");
+        verify(searchIndexingService).applyFundingClosedByEventTime(101L, 77L, "FUNDED", null);
         verify(searchResultCacheService).evictAll();
         assertThat(response.getStatus()).isEqualTo(SearchIndexingFailureStatus.RESOLVED);
     }


### PR DESCRIPTION
## 개요

Search projection에서 채널 상태 이벤트(HOT_DEAL/FUNDING/ITEM_STATUS_CHANGED)를 처리할 때, `occurredAt` 기준으로 오래된 이벤트를 `noop` 처리하도록 방어 로직을 추가했습니다.

### 관련 이슈
- Closes #744
- Related #739
- Related #736

### 작업 / 변경 내용
- Kafka 이벤트 envelope에 `occurredAt`를 포함하도록 outbox 공통 직렬화를 보강했습니다.
- Search 이벤트 메시지 DTO에 `occurredAt` 필드를 추가했습니다.
- `SearchEventTimeParser` 유틸을 추가해 `occurredAt -> epoch millis` 변환을 표준화했습니다.
- `SearchIndexingService`에 이벤트 시간 전달용 메서드를 추가하고, 컨슈머/재처리 서비스에서 해당 메서드를 사용하도록 변경했습니다.
- `ElasticsearchIndexingService` 스크립트에 `channelEventOccurredAt` 비교를 추가했습니다.
  - incoming `eventOccurredAtMillis`가 기존 `channelEventOccurredAt`보다 오래되면 `ctx.op = none`
  - 최신 이벤트만 채널 상태/우선순위 필드를 갱신
- 인덱스 매핑에 `channelEventOccurredAt` 필드를 추가했습니다.
- 관련 단위 테스트를 갱신했습니다.

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :libs:event:outbox:test :servers:services:search:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 기존 `eventId` 기반 멱등 처리(`processed_events`)는 그대로 유지되며, 이번 변경은 "중복 외"의 순서 역전(out-of-order) 방어를 추가합니다.
