### PR TITLE
[MZC-701] [TASK] 통합 조회 하위호환 및 degrade 경로 구현

### DIFF
--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogQueryParams.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/dto/catalog/CatalogQueryParams.java
@@ -122,6 +122,25 @@ public record CatalogQueryParams(
         return params;
     }
 
+    public MultiValueMap<String, String> toDegradeSearchQueryParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("q", query);
+        addIfPresent(params, "category", category);
+        if (itemType != null) {
+            params.add("domainType", itemType.name());
+        }
+        if (minPrice != null) {
+            params.add("minPrice", String.valueOf(minPrice));
+        }
+        if (maxPrice != null) {
+            params.add("maxPrice", String.valueOf(maxPrice));
+        }
+        addIfPresent(params, "sort", sort);
+        addIfPresent(params, "cursor", cursor);
+        params.add("size", String.valueOf(size));
+        return params;
+    }
+
     private static void addIfPresent(MultiValueMap<String, String> params, String key, String value) {
         if (StringUtils.hasText(value)) {
             params.add(key, value);

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
@@ -23,6 +23,8 @@ import reactor.core.publisher.Mono;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
+import java.util.concurrent.atomic.LongAdder;
 
 @Slf4j
 @Service
@@ -30,6 +32,7 @@ public class CatalogBffService {
 
     private static final String CODE_INVALID_REQUEST = "BFF-CATALOG-400";
     private static final String CODE_DOWNSTREAM_ERROR = "BFF-CATALOG-502";
+    private static final String DEGRADE_QUERY_PARAM = "degrade";
 
     private final WebClient searchWebClient;
     private final WebClient mediaWebClient;
@@ -37,6 +40,7 @@ public class CatalogBffService {
     private final SearchThumbnailFallbackEnricher fallbackEnricher;
     private final CatalogResponseMapper responseMapper;
     private final ObjectMapper objectMapper;
+    private final LongAdder degradeFallbackCounter = new LongAdder();
 
     public CatalogBffService(
             WebClient.Builder webClientBuilder,
@@ -63,15 +67,29 @@ public class CatalogBffService {
             return Mono.just(badRequest(e.getMessage()));
         }
 
+        boolean degradeRequested = isDegradeRequested(request);
         HttpHeaders downstreamHeaders = buildDownstreamHeaders();
-        MultiValueMap<String, String> searchQueryParams = params.toSearchQueryParams();
+        MultiValueMap<String, String> primaryQueryParams = params.toSearchQueryParams();
 
-        return callSearch(searchQueryParams, downstreamHeaders)
-                .flatMap(searchResponse -> enrichWithMediaFallback(searchResponse, downstreamHeaders))
-                .map(searchResponse -> mapCatalogResponse(searchResponse, params))
+        return queryCatalog(primaryQueryParams, params, downstreamHeaders)
+                .onErrorResume(CatalogQueryException.class, e -> handleCatalogQueryFailure(
+                        params,
+                        downstreamHeaders,
+                        degradeRequested,
+                        e.reason(),
+                        e.status(),
+                        e.getMessage()
+                ))
                 .onErrorResume(e -> {
-                    log.warn("[CatalogBff] catalog query failed", e);
-                    return Mono.just(badGateway("통합 목록 조회에 실패했습니다"));
+                    log.warn("[CatalogBff] catalog query failed with exception", e);
+                    return handleCatalogQueryFailure(
+                            params,
+                            downstreamHeaders,
+                            degradeRequested,
+                            "primary_exception",
+                            HttpStatus.BAD_GATEWAY,
+                            "통합 목록 조회에 실패했습니다"
+                    );
                 });
     }
 
@@ -155,20 +173,69 @@ public class CatalogBffService {
         return builder.build();
     }
 
-    private ResponseEntity<CatalogItemsResponse> mapCatalogResponse(ResponseEntity<JsonNode> searchResponse,
-                                                                    CatalogQueryParams params) {
+    private Mono<ResponseEntity<CatalogItemsResponse>> queryCatalog(MultiValueMap<String, String> queryParams,
+                                                                    CatalogQueryParams params,
+                                                                    HttpHeaders downstreamHeaders) {
+        return callSearch(queryParams, downstreamHeaders)
+                .flatMap(searchResponse -> enrichWithMediaFallback(searchResponse, downstreamHeaders))
+                .flatMap(searchResponse -> mapCatalogResponse(searchResponse, params));
+    }
+
+    private Mono<ResponseEntity<CatalogItemsResponse>> mapCatalogResponse(ResponseEntity<JsonNode> searchResponse,
+                                                                          CatalogQueryParams params) {
         if (!searchResponse.getStatusCode().is2xxSuccessful()) {
-            return ResponseEntity.status(searchResponse.getStatusCode())
-                    .body(CatalogItemsResponse.error(CODE_DOWNSTREAM_ERROR,
-                            extractDownstreamErrorMessage(searchResponse.getBody())));
+            HttpStatus status = HttpStatus.resolve(searchResponse.getStatusCode().value());
+            if (status == null) {
+                status = HttpStatus.BAD_GATEWAY;
+            }
+            return Mono.error(new CatalogQueryException(
+                    "primary_non_2xx",
+                    status,
+                    extractDownstreamErrorMessage(searchResponse.getBody())
+            ));
         }
 
         try {
             CatalogItemsResponse response = responseMapper.toCatalogResponse(searchResponse.getBody(), params);
-            return ResponseEntity.ok(response);
+            return Mono.just(ResponseEntity.ok(response));
         } catch (IllegalArgumentException e) {
-            return badGateway(e.getMessage());
+            return Mono.error(new CatalogQueryException(
+                    "primary_mapping_error",
+                    HttpStatus.BAD_GATEWAY,
+                    e.getMessage()
+            ));
         }
+    }
+
+    private Mono<ResponseEntity<CatalogItemsResponse>> handleCatalogQueryFailure(CatalogQueryParams params,
+                                                                                 HttpHeaders downstreamHeaders,
+                                                                                 boolean degradeRequested,
+                                                                                 String reason,
+                                                                                 HttpStatus status,
+                                                                                 String message) {
+        if (!degradeRequested) {
+            if (status == HttpStatus.BAD_GATEWAY) {
+                return Mono.just(badGateway(message));
+            }
+            return Mono.just(downstreamError(status, message));
+        }
+
+        long fallbackCount = incrementDegradeFallbackCount();
+        log.warn("[CatalogBff] degrade fallback activated. reason={}, count={}, q={}, channel={}",
+                reason, fallbackCount, params.query(), params.channel());
+
+        return queryCatalog(params.toDegradeSearchQueryParams(), params, downstreamHeaders)
+                .onErrorResume(CatalogQueryException.class, e -> {
+                    log.warn("[CatalogBff] degrade query failed. reason={}, status={}", e.reason(), e.status().value());
+                    if (e.status() == HttpStatus.BAD_GATEWAY) {
+                        return Mono.just(badGateway(e.getMessage()));
+                    }
+                    return Mono.just(downstreamError(e.status(), e.getMessage()));
+                })
+                .onErrorResume(e -> {
+                    log.warn("[CatalogBff] degrade query failed with exception. reason={}", reason, e);
+                    return Mono.just(badGateway("통합 목록 조회에 실패했습니다"));
+                });
     }
 
     private String extractDownstreamErrorMessage(JsonNode body) {
@@ -198,9 +265,31 @@ public class CatalogBffService {
         return value.trim();
     }
 
+    private boolean isDegradeRequested(ServerHttpRequest request) {
+        String raw = request.getQueryParams().getFirst(DEGRADE_QUERY_PARAM);
+        if (!StringUtils.hasText(raw)) {
+            return false;
+        }
+        String normalized = raw.trim().toLowerCase(Locale.ROOT);
+        return "true".equals(normalized)
+                || "1".equals(normalized)
+                || "yes".equals(normalized)
+                || "y".equals(normalized);
+    }
+
+    private long incrementDegradeFallbackCount() {
+        degradeFallbackCounter.increment();
+        return degradeFallbackCounter.sum();
+    }
+
     private ResponseEntity<CatalogItemsResponse> badRequest(String message) {
         return ResponseEntity.badRequest()
                 .body(CatalogItemsResponse.error(CODE_INVALID_REQUEST, message));
+    }
+
+    private ResponseEntity<CatalogItemsResponse> downstreamError(HttpStatus status, String message) {
+        return ResponseEntity.status(status)
+                .body(CatalogItemsResponse.error(CODE_DOWNSTREAM_ERROR, message));
     }
 
     private ResponseEntity<CatalogItemsResponse> badGateway(String message) {
@@ -216,5 +305,25 @@ public class CatalogBffService {
             headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
         }
         return headers;
+    }
+
+    private static final class CatalogQueryException extends RuntimeException {
+
+        private final String reason;
+        private final HttpStatus status;
+
+        private CatalogQueryException(String reason, HttpStatus status, String message) {
+            super(message);
+            this.reason = reason;
+            this.status = status;
+        }
+
+        private String reason() {
+            return reason;
+        }
+
+        private HttpStatus status() {
+            return status;
+        }
     }
 }

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/dto/catalog/CatalogQueryParamsTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/dto/catalog/CatalogQueryParamsTest.java
@@ -20,6 +20,7 @@ class CatalogQueryParamsTest {
 
         CatalogQueryParams params = CatalogQueryParams.from(request);
         MultiValueMap<String, String> searchParams = params.toSearchQueryParams();
+        MultiValueMap<String, String> degradeParams = params.toDegradeSearchQueryParams();
 
         assertThat(params.query()).isEqualTo("shoe");
         assertThat(params.channel()).isEqualTo(CatalogSalesChannel.FUNDING);
@@ -35,6 +36,10 @@ class CatalogQueryParamsTest {
         assertThat(searchParams.getFirst("domainType")).isEqualTo("PRODUCT");
         assertThat(searchParams.get("status")).containsExactly("FUNDING");
         assertThat(searchParams.getFirst("sort")).isEqualTo("PRICE_DESC");
+
+        assertThat(degradeParams.getFirst("q")).isEqualTo("shoe");
+        assertThat(degradeParams.getFirst("domainType")).isEqualTo("PRODUCT");
+        assertThat(degradeParams.containsKey("status")).isFalse();
     }
 
     @Test

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogBffServiceTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogBffServiceTest.java
@@ -1,0 +1,156 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogBffServiceTest {
+
+    private ObjectMapper objectMapper;
+    private StubExchangeFunction exchangeFunction;
+    private CatalogBffService catalogBffService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        exchangeFunction = new StubExchangeFunction();
+
+        GatewaySecurityProperties securityProperties = new GatewaySecurityProperties();
+        securityProperties.setInternalAuthHeader("X-Gateway-Auth");
+        securityProperties.setInternalAuthToken("internal-secret");
+
+        WebClient.Builder webClientBuilder = WebClient.builder().exchangeFunction(exchangeFunction);
+        catalogBffService = new CatalogBffService(
+                webClientBuilder,
+                securityProperties,
+                new SearchThumbnailFallbackEnricher(objectMapper),
+                new CatalogResponseMapper(),
+                objectMapper,
+                "http://search",
+                "http://media"
+        );
+    }
+
+    @Test
+    void listCatalogItems_usesDegradeFallbackWhenRequestedAndPrimaryFails() {
+        exchangeFunction.enqueueSearch(HttpStatus.INTERNAL_SERVER_ERROR, """
+                {"success":false,"error":{"message":"projection unavailable"}}
+                """);
+        exchangeFunction.enqueueSearch(HttpStatus.OK, """
+                {
+                  "success": true,
+                  "data": {
+                    "items": [
+                      {
+                        "itemId": 11,
+                        "title": "hot",
+                        "domainType": "PRODUCT",
+                        "status": "HOT_DEAL",
+                        "activeHotDealId": 901,
+                        "price": 10000
+                      }
+                    ],
+                    "nextCursor": null,
+                    "totalCount": 1
+                  }
+                }
+                """);
+
+        ServerHttpRequest request = MockServerHttpRequest.get(
+                        "/bff/v1/catalog/items?q=shoe&channel=HOT_DEAL&status=HOT_DEAL&itemType=PRODUCT&degrade=true")
+                .build();
+
+        ResponseEntity<CatalogItemsResponse> response = catalogBffService.listCatalogItems(request).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isTrue();
+        assertThat(response.getBody().data().items()).hasSize(1);
+
+        assertThat(exchangeFunction.searchRequestUris).hasSize(2);
+        String primaryQuery = exchangeFunction.searchRequestUris.get(0).getQuery();
+        String degradeQuery = exchangeFunction.searchRequestUris.get(1).getQuery();
+        assertThat(primaryQuery).contains("status=HOT_DEAL");
+        assertThat(degradeQuery).doesNotContain("status=");
+    }
+
+    @Test
+    void listCatalogItems_keepsDownstreamErrorWhenDegradeNotRequested() {
+        exchangeFunction.enqueueSearch(HttpStatus.INTERNAL_SERVER_ERROR, """
+                {"success":false,"error":{"message":"projection unavailable"}}
+                """);
+
+        ServerHttpRequest request = MockServerHttpRequest.get(
+                        "/bff/v1/catalog/items?q=shoe&channel=HOT_DEAL&status=HOT_DEAL&itemType=PRODUCT")
+                .build();
+
+        ResponseEntity<CatalogItemsResponse> response = catalogBffService.listCatalogItems(request).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().success()).isFalse();
+        assertThat(exchangeFunction.searchRequestUris).hasSize(1);
+    }
+
+    private static class StubExchangeFunction implements ExchangeFunction {
+
+        private final Queue<ResponseStub> searchResponses = new ArrayDeque<>();
+        private final List<URI> searchRequestUris = new ArrayList<>();
+
+        @Override
+        public Mono<ClientResponse> exchange(ClientRequest request) {
+            String path = request.url().getPath();
+
+            if ("/api/v1/search".equals(path)) {
+                searchRequestUris.add(request.url());
+                ResponseStub stub = searchResponses.poll();
+                if (stub == null) {
+                    return Mono.error(new IllegalStateException("search response stub is empty"));
+                }
+                return Mono.just(buildResponse(stub.status(), stub.body()));
+            }
+
+            if ("/internal/v1/media/urls/batch".equals(path)) {
+                return Mono.just(buildResponse(HttpStatus.OK, "{\"success\":true,\"data\":[]}"));
+            }
+
+            return Mono.error(new IllegalStateException("unexpected path: " + path));
+        }
+
+        void enqueueSearch(HttpStatus status, String body) {
+            searchResponses.add(new ResponseStub(status, body));
+        }
+
+        private ClientResponse buildResponse(HttpStatus status, String body) {
+            return ClientResponse.create(status)
+                    .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .body(body)
+                    .build();
+        }
+    }
+
+    private record ResponseStub(HttpStatus status, String body) {
+    }
+}


### PR DESCRIPTION
## 개요

통합 카탈로그 조회(`/bff/v1/catalog/items`)에서 projection 장애가 발생했을 때, 요청자가 `degrade=true`를 주면 기본 검색 파라미터로 재조회하는 degrade 경로를 추가했습니다.

### 관련 이슈
- Closes #745
- Related #738
- Related #736

### 작업 / 변경 내용
- `CatalogBffService`에 primary 조회 실패 시 degrade fallback 흐름을 추가했습니다.
  - `degrade=true` 요청에서만 fallback 동작
  - fallback 시 로그 + 내부 카운터 증가
- degrade용 쿼리 빌더(`toDegradeSearchQueryParams`)를 `CatalogQueryParams`에 추가했습니다.
  - 기존 status/channel 의존 필터를 제외한 기본 검색 파라미터로 구성
- `degrade` 미요청 시 기존 동작(다운스트림 에러 전달)을 유지하도록 했습니다.
- 단위 테스트를 추가/보강했습니다.
  - `CatalogBffServiceTest` 신설: degrade on/off 시나리오 검증
  - `CatalogQueryParamsTest` 보강: degrade 쿼리 파라미터 검증

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:gateways:client-gateway:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 기존 `/bff/v1/search` 엔드포인트/계약은 변경하지 않았습니다.
- `degrade` 파라미터가 없는 요청은 기존과 동일하게 처리됩니다.
