### PR TITLE
[MZC-699] [TASK] 통합 조회 관측성 메트릭/테스트 추가

### DIFF
--- a/servers/gateways/client-gateway/build.gradle.kts
+++ b/servers/gateways/client-gateway/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     // Shared modules
     implementation(project(":libs:contracts:http"))

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogBffService.java
@@ -20,10 +20,11 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 
 @Slf4j
@@ -39,6 +40,7 @@ public class CatalogBffService {
     private final GatewaySecurityProperties securityProperties;
     private final SearchThumbnailFallbackEnricher fallbackEnricher;
     private final CatalogResponseMapper responseMapper;
+    private final CatalogMetricsService catalogMetricsService;
     private final ObjectMapper objectMapper;
     private final LongAdder degradeFallbackCounter = new LongAdder();
 
@@ -47,6 +49,7 @@ public class CatalogBffService {
             GatewaySecurityProperties securityProperties,
             SearchThumbnailFallbackEnricher fallbackEnricher,
             CatalogResponseMapper responseMapper,
+            CatalogMetricsService catalogMetricsService,
             ObjectMapper objectMapper,
             @Value("${app.service.search-url:http://localhost:8088}") String searchServiceUrl,
             @Value("${app.service.media-url:http://localhost:8094}") String mediaServiceUrl
@@ -56,10 +59,12 @@ public class CatalogBffService {
         this.securityProperties = securityProperties;
         this.fallbackEnricher = fallbackEnricher;
         this.responseMapper = responseMapper;
+        this.catalogMetricsService = catalogMetricsService;
         this.objectMapper = objectMapper;
     }
 
     public Mono<ResponseEntity<CatalogItemsResponse>> listCatalogItems(ServerHttpRequest request) {
+        long startedAtNanos = System.nanoTime();
         CatalogQueryParams params;
         try {
             params = CatalogQueryParams.from(request);
@@ -90,7 +95,15 @@ public class CatalogBffService {
                             HttpStatus.BAD_GATEWAY,
                             "통합 목록 조회에 실패했습니다"
                     );
-                });
+                })
+                .doOnSuccess(response -> catalogMetricsService.recordQueryCompleted(
+                        Duration.ofNanos(System.nanoTime() - startedAtNanos),
+                        response
+                ))
+                .doOnError(e -> catalogMetricsService.recordQueryException(
+                        Duration.ofNanos(System.nanoTime() - startedAtNanos),
+                        "exception"
+                ));
     }
 
     private Mono<ResponseEntity<JsonNode>> callSearch(MultiValueMap<String, String> queryParams,
@@ -221,6 +234,7 @@ public class CatalogBffService {
         }
 
         long fallbackCount = incrementDegradeFallbackCount();
+        catalogMetricsService.recordDegradeFallback(reason);
         log.warn("[CatalogBff] degrade fallback activated. reason={}, count={}, q={}, channel={}",
                 reason, fallbackCount, params.query(), params.channel());
 

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
@@ -24,13 +24,16 @@ public class CatalogDetailBffService {
 
     private final CatalogDetailDownstreamClient downstreamClient;
     private final GatewaySecurityProperties securityProperties;
+    private final CatalogMetricsService catalogMetricsService;
     private final ObjectMapper objectMapper;
 
     public CatalogDetailBffService(CatalogDetailDownstreamClient downstreamClient,
                                    GatewaySecurityProperties securityProperties,
+                                   CatalogMetricsService catalogMetricsService,
                                    ObjectMapper objectMapper) {
         this.downstreamClient = downstreamClient;
         this.securityProperties = securityProperties;
+        this.catalogMetricsService = catalogMetricsService;
         this.objectMapper = objectMapper;
     }
 
@@ -95,6 +98,7 @@ public class CatalogDetailBffService {
     private Mono<ResponseEntity<JsonNode>> fallbackToNormal(CatalogDetailRequest request,
                                                             HttpHeaders headers,
                                                             String reason) {
+        catalogMetricsService.recordDetailFallback(request.salesChannel().name(), reason);
         log.info("[CatalogDetail] fallback applied. itemId={}, salesChannel={}, reason={}",
                 request.itemId(), request.salesChannel(), reason);
         return downstreamClient.fetchNormalDetail(request.itemType(), request.itemId(), headers)

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogMetricsService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogMetricsService.java
@@ -1,0 +1,66 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class CatalogMetricsService {
+
+    private final MeterRegistry meterRegistry;
+
+    public void recordQueryCompleted(Duration duration, ResponseEntity<CatalogItemsResponse> responseEntity) {
+        Timer.builder("catalog.query.latency")
+                .description("Catalog query latency")
+                .register(meterRegistry)
+                .record(duration);
+
+        if (responseEntity == null || !responseEntity.getStatusCode().is2xxSuccessful()) {
+            meterRegistry.counter("catalog.query.error", "type", "downstream").increment();
+            return;
+        }
+
+        CatalogItemsResponse body = responseEntity.getBody();
+        if (body == null || !body.success() || body.data() == null) {
+            meterRegistry.counter("catalog.query.error", "type", "mapping").increment();
+            return;
+        }
+
+        if (body.data().items() == null || body.data().items().isEmpty()) {
+            meterRegistry.counter("catalog.query.empty").increment();
+        }
+    }
+
+    public void recordQueryException(Duration duration, String type) {
+        Timer.builder("catalog.query.latency")
+                .description("Catalog query latency")
+                .register(meterRegistry)
+                .record(duration);
+        meterRegistry.counter("catalog.query.error", "type", safe(type, "exception")).increment();
+    }
+
+    public void recordDegradeFallback(String reason) {
+        meterRegistry.counter("catalog.query.fallback.count", "reason", safe(reason, "unknown")).increment();
+    }
+
+    public void recordDetailFallback(String salesChannel, String reason) {
+        meterRegistry.counter(
+                "catalog.detail.fallback.count",
+                "salesChannel", safe(salesChannel, "UNKNOWN"),
+                "reason", safe(reason, "unknown")
+        ).increment();
+    }
+
+    private String safe(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value;
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/controller/CatalogBffE2eTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/controller/CatalogBffE2eTest.java
@@ -1,0 +1,255 @@
+package com.example.gateway.bff.controller;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class CatalogBffE2eTest {
+
+    private static final int DOWNSTREAM_PORT = findAvailablePort();
+    private static final String DOWNSTREAM_BASE_URL = "http://127.0.0.1:" + DOWNSTREAM_PORT;
+
+    private static final AtomicReference<DownstreamDispatcher> DISPATCHER = new AtomicReference<>();
+    private static final List<RequestRecord> REQUESTS = new CopyOnWriteArrayList<>();
+
+    private static HttpServer downstreamServer;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("app.service.search-url", () -> DOWNSTREAM_BASE_URL);
+        registry.add("app.service.media-url", () -> DOWNSTREAM_BASE_URL);
+        registry.add("app.service.product-url", () -> DOWNSTREAM_BASE_URL);
+        registry.add("app.service.funding-url", () -> DOWNSTREAM_BASE_URL);
+        registry.add("app.service.hot-deal-url", () -> DOWNSTREAM_BASE_URL);
+        registry.add("gateway.auth.enabled", () -> "false");
+        registry.add("gateway.session.enabled", () -> "false");
+    }
+
+    @BeforeAll
+    static void startDownstreamServer() throws IOException {
+        downstreamServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), DOWNSTREAM_PORT), 0);
+        downstreamServer.createContext("/", new DispatchingHandler());
+        downstreamServer.setExecutor(Executors.newCachedThreadPool());
+        downstreamServer.start();
+    }
+
+    @AfterAll
+    static void stopDownstreamServer() {
+        if (downstreamServer != null) {
+            downstreamServer.stop(0);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        REQUESTS.clear();
+        DISPATCHER.set(request -> StubResponse.json(404, "{\"success\":false,\"error\":{\"message\":\"not found\"}}"));
+    }
+
+    @Test
+    void listCatalogItems_returnsChannelPriorityOrderAndEventReflectedTargets() {
+        DISPATCHER.set(request -> {
+            if ("GET".equals(request.method()) && "/api/v1/search".equals(request.path())) {
+                String body = """
+                        {
+                          "success": true,
+                          "data": {
+                            "items": [
+                              {
+                                "itemId": 101,
+                                "title": "hot",
+                                "domainType": "PRODUCT",
+                                "status": "HOT_DEAL",
+                                "salesChannel": "HOT_DEAL",
+                                "activeHotDealId": 9001,
+                                "basePrice": 20000,
+                                "effectivePrice": 15000,
+                                "stock": 11,
+                                "thumbnailMediaId": 501,
+                                "thumbnailUrl": "https://cdn.example/hot.webp"
+                              },
+                              {
+                                "itemId": 102,
+                                "title": "funding",
+                                "domainType": "PRODUCT",
+                                "status": "FUNDING",
+                                "salesChannel": "FUNDING",
+                                "activeCampaignId": 7001,
+                                "basePrice": 30000,
+                                "effectivePrice": 30000,
+                                "stock": 8,
+                                "thumbnailMediaId": 502,
+                                "thumbnailUrl": "https://cdn.example/funding.webp"
+                              },
+                              {
+                                "itemId": 103,
+                                "title": "normal",
+                                "domainType": "PRODUCT",
+                                "status": "ON_SALE",
+                                "salesChannel": "NORMAL",
+                                "basePrice": 10000,
+                                "effectivePrice": 10000,
+                                "stock": 20,
+                                "thumbnailMediaId": 503,
+                                "thumbnailUrl": "https://cdn.example/normal.webp"
+                              }
+                            ],
+                            "nextCursor": null,
+                            "totalCount": 3
+                          }
+                        }
+                        """;
+                return StubResponse.json(200, body);
+            }
+            return StubResponse.json(404, "{\"success\":false}");
+        });
+
+        webTestClient.get()
+                .uri("/bff/v1/catalog/items?q=running&size=3")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.success").isEqualTo(true)
+                .jsonPath("$.data.items.length()").isEqualTo(3)
+                .jsonPath("$.data.items[0].itemId").isEqualTo(101)
+                .jsonPath("$.data.items[0].salesChannel").isEqualTo("HOT_DEAL")
+                .jsonPath("$.data.items[0].detailTarget.path")
+                .isEqualTo("/bff/v1/catalog/items/101/detail?itemType=PRODUCT&salesChannel=HOT_DEAL&hotDealId=9001")
+                .jsonPath("$.data.items[1].itemId").isEqualTo(102)
+                .jsonPath("$.data.items[1].salesChannel").isEqualTo("FUNDING")
+                .jsonPath("$.data.items[1].detailTarget.path")
+                .isEqualTo("/bff/v1/catalog/items/102/detail?itemType=PRODUCT&salesChannel=FUNDING&campaignId=7001")
+                .jsonPath("$.data.items[2].itemId").isEqualTo(103)
+                .jsonPath("$.data.items[2].salesChannel").isEqualTo("NORMAL");
+
+        List<RequestRecord> searchRequests = REQUESTS.stream()
+                .filter(request -> "/api/v1/search".equals(request.path()))
+                .toList();
+        assertThat(searchRequests).hasSize(1);
+        assertThat(searchRequests.get(0).query()).contains("sort=LATEST");
+    }
+
+    @Test
+    void getCatalogDetail_fallbacksToNormalWhenHotDealReturns404() {
+        DISPATCHER.set(request -> {
+            if ("GET".equals(request.method()) && "/api/v1/hot-deals/9001".equals(request.path())) {
+                return StubResponse.json(404, "{\"success\":false,\"error\":{\"message\":\"hot-deal not found\"}}");
+            }
+            if ("GET".equals(request.method()) && "/api/products/101".equals(request.path())) {
+                return StubResponse.json(200, """
+                        {
+                          "success": true,
+                          "data": {
+                            "itemId": 101,
+                            "title": "fallback-normal"
+                          }
+                        }
+                        """);
+            }
+            return StubResponse.json(404, "{\"success\":false}");
+        });
+
+        webTestClient.get()
+                .uri("/bff/v1/catalog/items/101/detail?itemType=PRODUCT&salesChannel=HOT_DEAL&hotDealId=9001")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.success").isEqualTo(true)
+                .jsonPath("$.data.itemId").isEqualTo(101)
+                .jsonPath("$.data.title").isEqualTo("fallback-normal");
+
+        List<String> paths = REQUESTS.stream()
+                .map(RequestRecord::path)
+                .toList();
+        assertThat(paths).containsExactly("/api/v1/hot-deals/9001", "/api/products/101");
+    }
+
+    private static int findAvailablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("사용 가능한 포트를 찾지 못했습니다", e);
+        }
+    }
+
+    private static byte[] readBody(InputStream inputStream) throws IOException {
+        return inputStream.readAllBytes();
+    }
+
+    private static final class DispatchingHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            byte[] requestBody = readBody(exchange.getRequestBody());
+            URI requestUri = exchange.getRequestURI();
+            REQUESTS.add(new RequestRecord(
+                    exchange.getRequestMethod(),
+                    requestUri.getPath(),
+                    requestUri.getRawQuery(),
+                    new String(requestBody, StandardCharsets.UTF_8)
+            ));
+
+            DownstreamDispatcher dispatcher = DISPATCHER.get();
+            StubResponse response = dispatcher == null
+                    ? StubResponse.json(500, "{\"success\":false}")
+                    : dispatcher.dispatch(new RequestRecord(
+                    exchange.getRequestMethod(),
+                    requestUri.getPath(),
+                    requestUri.getRawQuery(),
+                    new String(requestBody, StandardCharsets.UTF_8)
+            ));
+
+            byte[] payload = response.body().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(response.status(), payload.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(payload);
+            } finally {
+                exchange.close();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface DownstreamDispatcher {
+        StubResponse dispatch(RequestRecord request);
+    }
+
+    private record StubResponse(int status, String body) {
+        static StubResponse json(int status, String body) {
+            return new StubResponse(status, body);
+        }
+    }
+
+    private record RequestRecord(String method, String path, String query, String body) {
+    }
+}

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogBffServiceTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogBffServiceTest.java
@@ -3,6 +3,7 @@ package com.example.gateway.bff.service;
 import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
 import com.example.gateway.config.GatewaySecurityProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -40,11 +41,13 @@ class CatalogBffServiceTest {
         securityProperties.setInternalAuthToken("internal-secret");
 
         WebClient.Builder webClientBuilder = WebClient.builder().exchangeFunction(exchangeFunction);
+        CatalogMetricsService catalogMetricsService = new CatalogMetricsService(new SimpleMeterRegistry());
         catalogBffService = new CatalogBffService(
                 webClientBuilder,
                 securityProperties,
                 new SearchThumbnailFallbackEnricher(objectMapper),
                 new CatalogResponseMapper(),
+                catalogMetricsService,
                 objectMapper,
                 "http://search",
                 "http://media"

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogDetailBffServiceTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogDetailBffServiceTest.java
@@ -5,6 +5,7 @@ import com.example.gateway.config.GatewaySecurityProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +40,8 @@ class CatalogDetailBffServiceTest {
         securityProperties.setInternalAuthToken("internal-secret");
 
         objectMapper = new ObjectMapper();
-        service = new CatalogDetailBffService(downstreamClient, securityProperties, objectMapper);
+        CatalogMetricsService catalogMetricsService = new CatalogMetricsService(new SimpleMeterRegistry());
+        service = new CatalogDetailBffService(downstreamClient, securityProperties, catalogMetricsService, objectMapper);
     }
 
     @Test

--- a/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogMetricsServiceTest.java
+++ b/servers/gateways/client-gateway/src/test/java/com/example/gateway/bff/service/CatalogMetricsServiceTest.java
@@ -1,0 +1,78 @@
+package com.example.gateway.bff.service;
+
+import com.example.gateway.bff.dto.catalog.CatalogItemsDataResponse;
+import com.example.gateway.bff.dto.catalog.CatalogItemsResponse;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogMetricsServiceTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private CatalogMetricsService metricsService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        metricsService = new CatalogMetricsService(meterRegistry);
+    }
+
+    @Test
+    void recordQueryCompleted_recordsLatencyAndEmptyCounter() {
+        CatalogItemsResponse body = CatalogItemsResponse.success(
+                new CatalogItemsDataResponse(List.of(), null, 0L)
+        );
+
+        metricsService.recordQueryCompleted(Duration.ofMillis(25), ResponseEntity.ok(body));
+
+        Timer timer = meterRegistry.find("catalog.query.latency").timer();
+        Counter emptyCounter = meterRegistry.find("catalog.query.empty").counter();
+
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+        assertThat(emptyCounter).isNotNull();
+        assertThat(emptyCounter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordQueryCompleted_recordsErrorOnNon2xx() {
+        metricsService.recordQueryCompleted(
+                Duration.ofMillis(12),
+                ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(null)
+        );
+
+        Counter errorCounter = meterRegistry.find("catalog.query.error")
+                .tags("type", "downstream")
+                .counter();
+
+        assertThat(errorCounter).isNotNull();
+        assertThat(errorCounter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordFallbackCounters_areRecorded() {
+        metricsService.recordDegradeFallback("primary_exception");
+        metricsService.recordDetailFallback("HOT_DEAL", "hot_deal_404");
+
+        Counter degradeCounter = meterRegistry.find("catalog.query.fallback.count")
+                .tags("reason", "primary_exception")
+                .counter();
+        Counter detailCounter = meterRegistry.find("catalog.detail.fallback.count")
+                .tags("salesChannel", "HOT_DEAL", "reason", "hot_deal_404")
+                .counter();
+
+        assertThat(degradeCounter).isNotNull();
+        assertThat(degradeCounter.count()).isEqualTo(1.0);
+        assertThat(detailCounter).isNotNull();
+        assertThat(detailCounter.count()).isEqualTo(1.0);
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/metrics/SearchMetricsService.java
@@ -46,11 +46,22 @@ public class SearchMetricsService {
     }
 
     public void recordIndexingEvent(String eventType, boolean success) {
+        String safeEventType = eventType == null ? "UNKNOWN" : eventType;
         meterRegistry.counter(
                 "search.indexing.events",
-                "eventType", eventType == null ? "UNKNOWN" : eventType,
+                "eventType", safeEventType,
                 "result", success ? "success" : "failure"
         ).increment();
+
+        meterRegistry.counter(
+                "catalog.projection.events",
+                "eventType", safeEventType,
+                "result", success ? "success" : "failure"
+        ).increment();
+
+        if (!success) {
+            meterRegistry.counter("catalog.projection.failures", "eventType", safeEventType).increment();
+        }
     }
 
     public void updateKafkaLag(long lag) {

--- a/servers/services/search/src/test/java/com/example/search/service/metrics/SearchMetricsServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/metrics/SearchMetricsServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.search.service.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchMetricsServiceTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private SearchMetricsService searchMetricsService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        searchMetricsService = new SearchMetricsService(meterRegistry);
+    }
+
+    @Test
+    void recordIndexingEvent_recordsCatalogProjectionMetricsOnSuccess() {
+        searchMetricsService.recordIndexingEvent("HOT_DEAL_STARTED", true);
+
+        Counter projectionCounter = meterRegistry.find("catalog.projection.events")
+                .tags("eventType", "HOT_DEAL_STARTED", "result", "success")
+                .counter();
+        Counter failureCounter = meterRegistry.find("catalog.projection.failures")
+                .tags("eventType", "HOT_DEAL_STARTED")
+                .counter();
+
+        assertThat(projectionCounter).isNotNull();
+        assertThat(projectionCounter.count()).isEqualTo(1.0);
+        assertThat(failureCounter).isNull();
+    }
+
+    @Test
+    void recordIndexingEvent_recordsCatalogProjectionFailureMetricOnFailure() {
+        searchMetricsService.recordIndexingEvent("FUNDING_FAILED", false);
+
+        Counter projectionCounter = meterRegistry.find("catalog.projection.events")
+                .tags("eventType", "FUNDING_FAILED", "result", "failure")
+                .counter();
+        Counter failureCounter = meterRegistry.find("catalog.projection.failures")
+                .tags("eventType", "FUNDING_FAILED")
+                .counter();
+
+        assertThat(projectionCounter).isNotNull();
+        assertThat(projectionCounter.count()).isEqualTo(1.0);
+        assertThat(failureCounter).isNotNull();
+        assertThat(failureCounter.count()).isEqualTo(1.0);
+    }
+}


### PR DESCRIPTION
## 개요

### 관련 이슈
- Closes #746

### 작업 / 변경 내용
- Gateway catalog query/detail 경로에 공통 메트릭 서비스(CatalogMetricsService) 추가
- query latency/error/empty, degrade fallback, detail fallback 카운터 기록 로직 반영
- SearchMetricsService에 catalog.projection.events / catalog.projection.failures 계열 메트릭 반영
- Gateway API 통합 테스트(CatalogBffE2eTest) 추가
- 채널 우선순위(HotDeal > Funding > Normal) 및 projection 필드(event 반영 필드) 기반 detailTarget 매핑 검증
- 상세 조회 hot-deal 404 발생 시 normal 상세로 fallback 되는 E2E 시나리오 검증

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (./gradlew build)
- [x] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

실행 테스트:
- ./gradlew :servers:gateways:client-gateway:test --tests "com.example.gateway.bff.controller.CatalogBffE2eTest" --tests "com.example.gateway.bff.service.CatalogMetricsServiceTest" --tests "com.example.gateway.bff.service.CatalogBffServiceTest" --tests "com.example.gateway.bff.service.CatalogDetailBffServiceTest"
- ./gradlew :servers:services:search:test --tests "com.example.search.service.metrics.SearchMetricsServiceTest"

### 참고사항
- 이 PR은 #753(task/745) 위에 쌓인 스택 PR입니다. 먼저 #753 머지 후 본 PR을 머지해 주세요.