### PR TITLE
[MZC-702] [EPIC] 셀러 운영 대시보드 MVP/확장 구현 및 운영 시나리오 E2E 보강

### DIFF
--- a/EPIC-757-progress.md
+++ b/EPIC-757-progress.md
@@ -64,6 +64,21 @@
 - Verification:
   - `./gradlew :servers:services:analytics-dashboard:test :servers:gateways:client-gateway:compileJava` 통과
 
+6. `epic/757-seller-ops-dashboard-mvp` (통합 진행)
+- Scope (진행 중):
+  - analytics ingest 컨슈머 추가:
+    - `AnalyticsItemEventConsumer` (`item-events`)
+    - `AnalyticsSalesEventConsumer` (`sales-events`)
+    - `AnalyticsSearchEventConsumer` (`search-events`)
+  - ingest 서비스 추가:
+    - `AnalyticsEventIngestService`
+    - item 이벤트 -> `analytics_dim_item_snapshot` upsert
+    - sales/search 이벤트 -> raw 테이블 적재
+  - 컨슈머/ingest 단위 테스트 추가
+- Verification:
+  - `./gradlew :servers:services:analytics-dashboard:test` 통과
+  - `./gradlew :servers:gateways:client-gateway:compileJava` 통과
+
 ## 2) Common Module Reuse Status
 
 다음 공통 모듈을 그대로 재사용했다.
@@ -106,6 +121,7 @@
 
 1. `task/772-analytics-ingest-consumers`
 - sales/search/item 이벤트 컨슈머 + raw/dim 적재
+- 현재 epic 브랜치에서 1차 구현 완료, 추후 이벤트 계약 확장(`sales seller/store 필드`, `search event producer`) 보강 필요
 
 2. `task/773-dashboard-kpi-aggregation`
 - minute/daily/monthly 집계 계산 로직

--- a/EPIC-757-progress.md
+++ b/EPIC-757-progress.md
@@ -1,0 +1,117 @@
+# Seller Ops Dashboard Epic Progress (Issue #757)
+
+이 문서는 `#757` 에픽 기준으로 현재 구현 상태를 브랜치 단위로 모아 검토하기 위한 진행 현황이다.
+
+## 1) Branch Breakdown
+
+1. `task/762-analytics-dashboard-bootstrap`
+- Commit: `7e20502`
+- Scope:
+  - `analytics-dashboard` 모듈 추가
+  - `settings.gradle.kts` 등록
+  - `application.yml`, `application-test.yml` 추가
+  - `@SpringBootTest` 컨텍스트 로딩 테스트 추가
+- Verification:
+  - `./gradlew :servers:services:analytics-dashboard:test` 통과
+
+2. `task/765-dashboard-query-mode-validation`
+- Commit: `088474c`
+- Scope:
+  - `DAILY|MONTHLY|RANGE` 조회 모드 파서
+  - `date/yearMonth/from/to/bucket/timezone` 검증
+  - RANGE 최대 93일 제약
+  - `AnalyticsDashboardErrorCode` 도입
+- Verification:
+  - `SellerDashboardOverviewQueryTest` 추가 및 통과
+
+3. `task/764-dashboard-overview-api-bff`
+- Commit: `b386158`
+- Scope:
+  - analytics 내부 API:
+    - `GET /internal/v1/analytics/sellers/{sellerId}/dashboard/overview`
+  - BFF API:
+    - `GET /bff/v1/seller/dashboard/overview`
+  - 응답 기본 구조:
+    - `asOf`, `lagStatus`, `partial`, `sales/item/search`, `series`, `extensions`
+  - gateway 설정:
+    - `app.service.analytics-dashboard-url`
+- Verification:
+  - `./gradlew :servers:services:analytics-dashboard:test :servers:gateways:client-gateway:compileJava` 통과
+
+4. `task/763-analytics-schema-entities`
+- Commit: `c5987c2`
+- Scope:
+  - raw/dim/agg 엔티티 추가:
+    - `analytics_raw_sales_event`
+    - `analytics_raw_search_event`
+    - `analytics_dim_item_snapshot`
+    - `analytics_agg_seller_kpi_minute`
+    - `analytics_agg_seller_kpi_daily`
+    - `analytics_agg_seller_kpi_monthly`
+  - 대응 JPA Repository 추가
+- Verification:
+  - `./gradlew :servers:services:analytics-dashboard:test` 통과
+
+5. `task/771-dashboard-storeid-context` (현재 작업 브랜치)
+- Scope (진행 중):
+  - `storeId 중심 + sellerId 행위자` 모델 확장
+  - 공통 헤더 상수 `X-Store-Id` 추가 (`libs/contracts/http`)
+  - BFF -> analytics 호출을 store 경로 기반으로 확장:
+    - `GET /internal/v1/analytics/stores/{storeId}/dashboard/overview`
+  - analytics raw/dim/agg 엔티티에 `storeId` 컬럼 추가
+  - agg unique index를 `bucket + store_id`로 전환
+  - store 기반 repository 메서드 추가
+- Verification:
+  - `./gradlew :servers:services:analytics-dashboard:test :servers:gateways:client-gateway:compileJava` 통과
+
+## 2) Common Module Reuse Status
+
+다음 공통 모듈을 그대로 재사용했다.
+
+1. `libs/api/response`
+- 공통 `ApiResponse` 규격 유지
+
+2. `libs/api/exception-handler`
+- `BusinessException` + 공통 예외 처리 체계 유지
+
+3. `libs/security/security-starter`
+- 내부 API 보호 기본 체계 유지
+
+4. `libs/contracts/http`
+- `HttpHeaderNames` 재사용
+- `STORE_ID` 상수 추가로 헤더 문자열 하드코딩 제거
+
+## 3) Epic Review Checklist (with you)
+
+검토 시 아래 순서로 확인 권장:
+
+1. 경계/책임
+- BFF는 조합/파싱만, 도메인/분석 책임 분리 유지 여부
+
+2. 계약
+- 공통 응답 포맷(`success/data/error/timestamp`) 유지 여부
+- `DAILY/MONTHLY/RANGE` 입력 검증 규칙 일치 여부
+
+3. 멀티 스토어 확장
+- `storeId`를 집계 키로 보는 설계가 현재 운영 모델과 맞는지
+- `sellerId`를 행위자/권한 컨텍스트로 유지하는 방향 합의 여부
+
+4. 남은 구현
+- 이벤트 ingest(sales/search/item)
+- 실집계(minute/daily/monthly 계산)
+- 지연/partial/fallback 정책
+- E2E 시나리오
+
+## 4) Next Implementation Queue
+
+1. `task/772-analytics-ingest-consumers`
+- sales/search/item 이벤트 컨슈머 + raw/dim 적재
+
+2. `task/773-dashboard-kpi-aggregation`
+- minute/daily/monthly 집계 계산 로직
+
+3. `task/774-dashboard-overview-read-model`
+- repository 기반 실데이터 조회로 현재 empty 응답 대체
+
+4. `task/775-dashboard-e2e`
+- BFF end-to-end 검증 스크립트 및 테스트

--- a/docker/scripts/full_commerce_scope_e2e.sh
+++ b/docker/scripts/full_commerce_scope_e2e.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/full_commerce_scope_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+COMPOSE_FILE="$ROOT/docker/docker-compose-local.yml"
+
+INCLUDE_FULL_STACK="${INCLUDE_FULL_STACK:-true}"
+STOP_ON_FAIL="${STOP_ON_FAIL:-false}"
+
+PASSES=0
+FAILURES=0
+
+ALL_PORTS=(
+  18084 18085 18086 18087 18088 18089
+  18093 18095
+  18173 18180 18181
+  18284 18285 18286 18289
+  18484
+  18673 18684 18686 18688 18689
+  18884 18888
+)
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+kill_listeners_on_known_ports() {
+  local port pids
+  for port in "${ALL_PORTS[@]}"; do
+    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    if [[ -n "$pids" ]]; then
+      echo "[INFO] killing listeners on port ${port}: ${pids}"
+      # shellcheck disable=SC2086
+      kill -9 $pids >/dev/null 2>&1 || true
+    fi
+  done
+}
+
+restart_postgres_if_running() {
+  local pg_state=""
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "project03-postgres"; then
+    return 0
+  fi
+
+  echo "[INFO] restarting postgres to reset leaked client connections"
+  docker compose -f "$COMPOSE_FILE" restart postgres >/dev/null 2>&1 || true
+
+  for _ in {1..30}; do
+    pg_state="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' project03-postgres 2>/dev/null || true)"
+    if [[ "$pg_state" == "healthy" || "$pg_state" == "running" ]]; then
+      echo "[INFO] postgres state: ${pg_state}"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "[WARN] postgres health wait timed out (state=${pg_state:-unknown})"
+  return 0
+}
+
+cleanup_between_scenarios() {
+  echo "[INFO] scenario cleanup: listeners + postgres reset"
+  kill_listeners_on_known_ports
+  sleep 1
+  restart_postgres_if_running
+}
+
+run_script() {
+  local script_name="$1"
+  local script_path="$ROOT/docker/scripts/${script_name}"
+  local log_file="$LOG_DIR/${script_name%.sh}.log"
+  local started_at ended_at duration
+
+  if [[ ! -f "$script_path" ]]; then
+    fail "missing script: ${script_name}"
+    return 1
+  fi
+
+  started_at="$(date +%s)"
+  echo "[INFO] running ${script_name}"
+  if bash "$script_path" >"$log_file" 2>&1; then
+    ended_at="$(date +%s)"
+    duration=$((ended_at - started_at))
+    pass "${script_name} (${duration}s)"
+    return 0
+  fi
+
+  ended_at="$(date +%s)"
+  duration=$((ended_at - started_at))
+  fail "${script_name} (${duration}s)"
+  echo "[INFO] last 80 lines from ${script_name}:"
+  tail -n 80 "$log_file" || true
+  return 1
+}
+
+main() {
+  local -a scripts=(
+    "gateway_session_trusted_auth_verify.sh"
+    "gateway_session_userid_itemsearch_e2e.sh"
+    "gateway_session_forced_trigger_catalog_e2e.sh"
+    "funding_hotdeal_business_e2e.sh"
+    "search_consumer_dlq_retry_e2e.sh"
+    "outbox_broker_recovery_e2e.sh"
+    "gateway_seller_dashboard_e2e_verify.sh"
+  )
+
+  if [[ "$INCLUDE_FULL_STACK" == "true" ]]; then
+    scripts+=("full_stack_publish_chain_e2e.sh")
+  fi
+
+  cleanup_between_scenarios
+  for script_name in "${scripts[@]}"; do
+    if ! run_script "$script_name"; then
+      if [[ "$STOP_ON_FAIL" == "true" ]]; then
+        echo "[INFO] stop on fail enabled"
+        break
+      fi
+    fi
+    cleanup_between_scenarios
+  done
+
+  echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}"
+  echo "[INFO] logs: ${LOG_DIR}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/docker/scripts/full_stack_publish_chain_e2e.sh
+++ b/docker/scripts/full_stack_publish_chain_e2e.sh
@@ -1,0 +1,637 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/full_stack_publish_chain_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+GW_PORT="${GW_PORT:-18181}"
+PRODUCT_PORT="${PRODUCT_PORT:-18084}"
+STOCK_PORT="${STOCK_PORT:-18085}"
+FUNDING_PORT="${FUNDING_PORT:-18086}"
+SALES_PORT="${SALES_PORT:-18087}"
+SEARCH_PORT="${SEARCH_PORT:-18088}"
+HOTDEAL_PORT="${HOTDEAL_PORT:-18089}"
+ANALYTICS_PORT="${ANALYTICS_PORT:-18095}"
+ELASTICSEARCH_PORT="${ELASTICSEARCH_PORT:-23173}"
+
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-project03-postgres}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-project03-redis}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-project03-kafka}"
+
+INTERNAL_AUTH_TOKEN="${INTERNAL_AUTH_TOKEN:-full-chain-e2e-token}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex-e2e}"
+
+NOW_TS="$(date +%s)"
+STORE_ID="${STORE_ID:-$((990000 + NOW_TS % 100000))}"
+SELLER_ID="${SELLER_ID:-$((880000 + NOW_TS % 100000))}"
+BUYER_ID="${BUYER_ID:-$((770000 + NOW_TS % 100000))}"
+TARGET_DATE="${TARGET_DATE:-$(date +%Y-%m-%d)}"
+SEARCH_SESSION_ID="${SEARCH_SESSION_ID:-full-chain-sess-${NOW_TS}}"
+CONSUMER_GROUP_SUFFIX="${CONSUMER_GROUP_SUFFIX:-$NOW_TS}"
+STOCK_CONSUMER_GROUP="${STOCK_CONSUMER_GROUP:-stock-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+PRODUCT_CONSUMER_GROUP="${PRODUCT_CONSUMER_GROUP:-product-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+SALES_CONSUMER_GROUP="${SALES_CONSUMER_GROUP:-sales-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+FUNDING_CONSUMER_GROUP="${FUNDING_CONSUMER_GROUP:-funding-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+HOTDEAL_CONSUMER_GROUP="${HOTDEAL_CONSUMER_GROUP:-hot-deal-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+SEARCH_CONSUMER_GROUP="${SEARCH_CONSUMER_GROUP:-search-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+ANALYTICS_CONSUMER_GROUP="${ANALYTICS_CONSUMER_GROUP:-analytics-dashboard-service-group-e2e-${CONSUMER_GROUP_SUFFIX}}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+WARNINGS=0
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+warn() {
+  WARNINGS=$((WARNINGS + 1))
+  echo "[WARN] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  sleep 1
+
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $port is already in use"
+    return 1
+  fi
+  pass "port $port is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..240}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "$name health is UP"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "$name health timeout"
+  return 1
+}
+
+wait_es_up() {
+  for _ in {1..120}; do
+    local status
+    status="$(curl -sS "http://127.0.0.1:${ELASTICSEARCH_PORT}/_cluster/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "green" || "$status" == "yellow" ]]; then
+      pass "elasticsearch health is ${status}"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "elasticsearch health timeout"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected=${expected}, actual=${actual})"
+  fi
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+  else
+    local code
+    code="$(echo "$body" | jq -r '.error.code // "UNKNOWN"')"
+    fail "$label (errorCode=${code})"
+  fi
+}
+
+ensure_jq_true() {
+  local label="$1"
+  local body="$2"
+  local expr="$3"
+  if echo "$body" | jq -e "$expr" >/dev/null; then
+    pass "$label"
+  else
+    fail "$label (expr=${expr})"
+  fi
+}
+
+psql_exec() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -v ON_ERROR_STOP=1 -c "$sql" >/dev/null
+}
+
+psql_query() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -At -c "$sql"
+}
+
+ensure_analytics_db() {
+  local exists
+  exists="$(docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d postgres -At -c "SELECT 1 FROM pg_database WHERE datname='analytics_db'" 2>/dev/null || true)"
+  if [[ "$exists" != "1" ]]; then
+    docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE analytics_db" >/dev/null
+    pass "analytics_db created"
+  else
+    pass "analytics_db already exists"
+  fi
+}
+
+topic_offset_sum() {
+  local topic="$1"
+  local offsets
+  offsets="$(docker exec -i "$KAFKA_CONTAINER" bash -lc "kafka-run-class kafka.tools.GetOffsetShell --broker-list localhost:9092 --topic ${topic} --time -1 2>/dev/null" || true)"
+  echo "$offsets" | awk -F: '{sum+=$3} END {print sum+0}'
+}
+
+wait_stock_item_id() {
+  local item_id="$1"
+  for _ in {1..120}; do
+    local raw body status stock_item_id
+    raw="$(curl -sS -w '\n%{http_code}' \
+      "http://127.0.0.1:${STOCK_PORT}/internal/v1/stock/items/${item_id}" \
+      -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}" \
+      -H "X-User-Id: ${SELLER_ID}" || true)"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    if [[ "$status" == "200" ]] && [[ "$(echo "$body" | jq -r '.success // false')" == "true" ]]; then
+      stock_item_id="$(echo "$body" | jq -r '.data.stocks[0].stockItemId // empty')"
+      if [[ -n "$stock_item_id" && "$stock_item_id" != "null" ]]; then
+        echo "$stock_item_id"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+wait_count_ge() {
+  local db="$1"
+  local sql="$2"
+  local threshold="$3"
+  local label="$4"
+
+  for _ in {1..120}; do
+    local value
+    value="$(psql_query "$db" "$sql" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && (( value >= threshold )); then
+      pass "$label (value=${value})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "$label (threshold=${threshold})"
+  return 1
+}
+
+wait_count_eq() {
+  local db="$1"
+  local sql="$2"
+  local expected="$3"
+  local label="$4"
+
+  for _ in {1..120}; do
+    local value
+    value="$(psql_query "$db" "$sql" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && (( value == expected )); then
+      pass "$label (value=${value})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "$label (expected=${expected})"
+  return 1
+}
+
+wait_consumer_assignment() {
+  local group="$1"
+  local topic="$2"
+  local label="$3"
+
+  for _ in {1..180}; do
+    local desc
+    desc="$(docker exec -i "$KAFKA_CONTAINER" bash -lc "kafka-consumer-groups --bootstrap-server localhost:9092 --describe --group ${group} 2>/dev/null" || true)"
+
+    if echo "$desc" | awk -v g="$group" -v t="$topic" '
+      $1 == g && $2 == t {found=1}
+      END {exit(found ? 0 : 1)}
+    '; then
+      pass "$label"
+      return 0
+    fi
+
+    sleep 1
+  done
+
+  fail "$label timeout"
+  return 1
+}
+
+start_services() {
+  echo "[INFO] starting stock-service on ${STOCK_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$STOCK_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$STOCK_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:stock:bootRun --no-daemon >"$LOG_DIR/stock.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting product-service on ${PRODUCT_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$PRODUCT_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$PRODUCT_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:product:bootRun --no-daemon >"$LOG_DIR/product.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting sales-service on ${SALES_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$SALES_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$SALES_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      PRODUCT_SERVICE_URL="http://127.0.0.1:${PRODUCT_PORT}" \
+      STOCK_SERVICE_URL="http://127.0.0.1:${STOCK_PORT}" \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:sales:bootRun --no-daemon >"$LOG_DIR/sales.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting funding-service on ${FUNDING_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$FUNDING_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$FUNDING_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      STOCK_SERVICE_URL="http://127.0.0.1:${STOCK_PORT}" \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:funding:bootRun --no-daemon >"$LOG_DIR/funding.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting hot-deal-service on ${HOTDEAL_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$HOTDEAL_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$HOTDEAL_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      PRODUCT_SERVICE_URL="http://127.0.0.1:${PRODUCT_PORT}" \
+      STOCK_SERVICE_URL="http://127.0.0.1:${STOCK_PORT}" \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:hot-deal:bootRun --no-daemon >"$LOG_DIR/hotdeal.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting search-service on ${SEARCH_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$SEARCH_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$SEARCH_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      ELASTICSEARCH_URIS="http://127.0.0.1:${ELASTICSEARCH_PORT}" \
+      SEARCH_THUMBNAIL_ENRICHER_ENABLED=false \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:search:bootRun --no-daemon >"$LOG_DIR/search.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting analytics-dashboard on ${ANALYTICS_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$ANALYTICS_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$ANALYTICS_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      DB_URL="jdbc:postgresql://127.0.0.1:5432/analytics_db" \
+      DB_USERNAME="postgres" \
+      DB_PASSWORD="postgres" \
+      APP_GATEWAY_SECURITY_ENABLED=true \
+      APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED=true \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:analytics-dashboard:bootRun --no-daemon >"$LOG_DIR/analytics.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting client-gateway on ${GW_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$GW_PORT" \
+      GATEWAY_AUTH_ENABLED=false \
+      GATEWAY_SESSION_ENABLED=false \
+      GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      APP_SERVICE_PRODUCT_URL="http://127.0.0.1:${PRODUCT_PORT}" \
+      APP_SERVICE_STOCK_URL="http://127.0.0.1:${STOCK_PORT}" \
+      APP_SERVICE_FUNDING_URL="http://127.0.0.1:${FUNDING_PORT}" \
+      APP_SERVICE_SALES_URL="http://127.0.0.1:${SALES_PORT}" \
+      APP_SERVICE_HOT_DEAL_URL="http://127.0.0.1:${HOTDEAL_PORT}" \
+      APP_SERVICE_SEARCH_URL="http://127.0.0.1:${SEARCH_PORT}" \
+      ANALYTICS_DASHBOARD_SERVICE_URL="http://127.0.0.1:${ANALYTICS_PORT}" \
+      ./gradlew :servers:gateways:client-gateway:bootRun --no-daemon >"$LOG_DIR/gateway.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+run_publish_chain() {
+  local ts keyword product_payload create_raw create_body create_status item_id
+  local status_raw status_body status_code stock_item_id
+  local purchase_payload purchase_raw purchase_body purchase_status purchase_id
+  local cancel_raw cancel_body cancel_status
+  local overview_raw overview_body overview_status
+
+  ts="$(date +%s)"
+  keyword="full-chain-${ts}"
+
+  product_payload="$(cat <<JSON
+{"title":"Full Chain Product ${keyword}","description":"full stack publish chain e2e","price":12345,"storeId":${STORE_ID},"options":[{"optionName":"default","additionalPrice":0,"stockQuantity":7}],"shippingInfo":{"shippingFee":2500,"freeShippingThreshold":30000,"estimatedDays":2,"returnPolicy":"returnable"}}
+JSON
+)"
+
+  create_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${PRODUCT_PORT}/api/products" \
+    -H "Content-Type: application/json" \
+    -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$product_payload")"
+  create_body="$(extract_http_body "$create_raw")"
+  create_status="$(extract_http_status "$create_raw")"
+  ensure_http_status "product create status" "$create_status" "200"
+  ensure_json_success "product create success" "$create_body"
+
+  item_id="$(echo "$create_body" | jq -r '.data.id // empty')"
+  if [[ -z "$item_id" || "$item_id" == "null" ]]; then
+    fail "resolved created item id"
+    return 1
+  fi
+  pass "resolved created item id (${item_id})"
+
+  status_raw="$(curl -sS -w '\n%{http_code}' -X PATCH "http://127.0.0.1:${PRODUCT_PORT}/api/items/${item_id}/status" \
+    -H "Content-Type: application/json" \
+    -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d '{"status":"ON_SALE","reason":"full chain e2e"}')"
+  status_body="$(extract_http_body "$status_raw")"
+  status_code="$(extract_http_status "$status_raw")"
+  ensure_http_status "item status change DRAFT->ON_SALE" "$status_code" "200"
+  ensure_json_success "item status change success" "$status_body"
+
+  if ! stock_item_id="$(wait_stock_item_id "$item_id")"; then
+    fail "stock item initialization from item-events"
+    return 1
+  fi
+  pass "stock item initialization from item-events (stockItemId=${stock_item_id})"
+
+  purchase_payload="$(cat <<JSON
+{"itemId":${item_id},"stockItemId":${stock_item_id},"quantity":1}
+JSON
+)"
+
+  purchase_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${SALES_PORT}/api/v1/sales/purchase" \
+    -H "Content-Type: application/json" \
+    -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}" \
+    -H "X-User-Id: ${BUYER_ID}" \
+    -d "$purchase_payload")"
+  purchase_body="$(extract_http_body "$purchase_raw")"
+  purchase_status="$(extract_http_status "$purchase_raw")"
+  ensure_http_status "sales purchase status" "$purchase_status" "200"
+  ensure_json_success "sales purchase success" "$purchase_body"
+
+  purchase_id="$(echo "$purchase_body" | jq -r '.data.id // empty')"
+  if [[ -z "$purchase_id" || "$purchase_id" == "null" ]]; then
+    fail "resolved purchase id"
+    return 1
+  fi
+  pass "resolved purchase id (${purchase_id})"
+
+  cancel_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${SALES_PORT}/internal/v1/sales/purchases/${purchase_id}/cancel?userId=${BUYER_ID}" \
+    -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}")"
+  cancel_body="$(extract_http_body "$cancel_raw")"
+  cancel_status="$(extract_http_status "$cancel_raw")"
+  ensure_http_status "sales cancel status" "$cancel_status" "200"
+  ensure_json_success "sales cancel success" "$cancel_body"
+
+  wait_count_ge "product_db" \
+    "SELECT COUNT(*) FROM outbox_messages WHERE aggregate_type='Item' AND aggregate_id='${item_id}' AND event_type IN ('ITEM_CREATED','ITEM_STATUS_CHANGED') AND status='PUBLISHED'" \
+    2 \
+    "product outbox published events"
+
+  wait_count_eq "product_db" \
+    "SELECT COUNT(*) FROM outbox_messages WHERE aggregate_type='Item' AND aggregate_id='${item_id}' AND status='FAILED'" \
+    0 \
+    "product outbox failed events"
+
+  wait_count_ge "sales_db" \
+    "SELECT COUNT(*) FROM outbox_messages WHERE aggregate_type='Purchase' AND aggregate_id='${purchase_id}' AND event_type IN ('PURCHASE_CREATED','PURCHASE_CANCELLED') AND status='PUBLISHED'" \
+    2 \
+    "sales outbox published events"
+
+  wait_count_eq "sales_db" \
+    "SELECT COUNT(*) FROM outbox_messages WHERE aggregate_type='Purchase' AND aggregate_id='${purchase_id}' AND status='FAILED'" \
+    0 \
+    "sales outbox failed events"
+
+  wait_count_ge "analytics_db" \
+    "SELECT COUNT(*) FROM analytics_dim_item_snapshot WHERE item_id=${item_id} AND store_id=${STORE_ID} AND seller_id=${SELLER_ID}" \
+    1 \
+    "analytics item snapshot ingested"
+
+  wait_count_ge "analytics_db" \
+    "SELECT COUNT(*) FROM analytics_raw_sales_event WHERE purchase_id=${purchase_id}" \
+    2 \
+    "analytics sales events ingested"
+
+  overview_raw="$(curl -sS -w '\n%{http_code}' \
+    "http://127.0.0.1:${GW_PORT}/bff/v1/seller/dashboard/overview?storeId=${STORE_ID}&mode=DAILY&date=${TARGET_DATE}" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -H "X-Store-Id: ${STORE_ID}")"
+  overview_body="$(extract_http_body "$overview_raw")"
+  overview_status="$(extract_http_status "$overview_raw")"
+  ensure_http_status "gateway dashboard overview status" "$overview_status" "200"
+  ensure_json_success "gateway dashboard overview success" "$overview_body"
+  ensure_jq_true "gateway dashboard reflects sales chain" "$overview_body" '.data.sales.orderCount >= 1 and .data.sales.cancelCount >= 1 and .data.mode == "DAILY"'
+  ensure_jq_true "gateway dashboard reflects item snapshot" "$overview_body" '.data.item.onSaleCount >= 1'
+}
+
+check_search_publish_gap() {
+  local offset_before offset_after search_raw search_body search_status query
+
+  offset_before="$(topic_offset_sum "search-events" | tr -d '[:space:]')"
+
+  query="chain-gap-$(date +%s)"
+  search_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${SEARCH_PORT}/api/v1/search?q=${query}&size=5" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -H "X-Store-Id: ${STORE_ID}" \
+    -H "X-Session-Id: ${SEARCH_SESSION_ID}" || true)"
+  search_body="$(extract_http_body "$search_raw")"
+  search_status="$(extract_http_status "$search_raw")"
+
+  if [[ "$search_status" == "200" ]] && [[ "$(echo "$search_body" | jq -r '.success // false')" == "true" ]]; then
+    pass "search query endpoint call"
+  else
+    fail "search query endpoint call not successful (status=${search_status})"
+    return 1
+  fi
+
+  sleep 2
+
+  offset_after="$(topic_offset_sum "search-events" | tr -d '[:space:]')"
+  if [[ "$offset_before" =~ ^[0-9]+$ && "$offset_after" =~ ^[0-9]+$ ]]; then
+    if (( offset_after > offset_before )); then
+      pass "search-events topic increased (${offset_before} -> ${offset_after})"
+    else
+      fail "search-events topic did not increase (${offset_before} -> ${offset_after})"
+      return 1
+    fi
+  else
+    fail "unable to read search-events topic offsets"
+    return 1
+  fi
+
+  wait_count_ge "analytics_db" \
+    "SELECT COUNT(*) FROM analytics_raw_search_event WHERE store_id=${STORE_ID} AND seller_id=${SELLER_ID} AND event_type='SEARCH_EXECUTED'" \
+    1 \
+    "analytics search events ingested"
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+  require_cmd docker
+  require_cmd lsof
+
+  check_port_free "$GW_PORT" || true
+  check_port_free "$PRODUCT_PORT" || true
+  check_port_free "$STOCK_PORT" || true
+  check_port_free "$FUNDING_PORT" || true
+  check_port_free "$SALES_PORT" || true
+  check_port_free "$SEARCH_PORT" || true
+  check_port_free "$HOTDEAL_PORT" || true
+  check_port_free "$ANALYTICS_PORT" || true
+
+  echo "[INFO] preparing docker infra"
+  (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka elasticsearch >/dev/null)
+  pass "docker infra up (postgres/redis/zookeeper/kafka/elasticsearch)"
+
+  wait_es_up
+  ensure_analytics_db
+
+  psql_exec analytics_db "TRUNCATE TABLE analytics_raw_sales_event RESTART IDENTITY CASCADE"
+  psql_exec analytics_db "TRUNCATE TABLE analytics_raw_search_event RESTART IDENTITY CASCADE"
+  psql_exec analytics_db "TRUNCATE TABLE analytics_dim_item_snapshot CASCADE"
+  pass "analytics dashboard tables reset"
+
+  pass "using unique Kafka consumer groups with auto-offset-reset=latest"
+
+  start_services
+
+  wait_health "stock-service" "$STOCK_PORT"
+  wait_health "product-service" "$PRODUCT_PORT"
+  wait_health "sales-service" "$SALES_PORT"
+  wait_health "funding-service" "$FUNDING_PORT"
+  wait_health "hot-deal-service" "$HOTDEAL_PORT"
+  wait_health "search-service" "$SEARCH_PORT"
+  wait_health "analytics-dashboard" "$ANALYTICS_PORT"
+  wait_health "client-gateway" "$GW_PORT"
+
+  wait_consumer_assignment "$STOCK_CONSUMER_GROUP" "item-events" "stock consumer assignment ready (item-events)"
+  wait_consumer_assignment "$STOCK_CONSUMER_GROUP" "payment-events" "stock consumer assignment ready (payment-events)"
+  wait_consumer_assignment "$ANALYTICS_CONSUMER_GROUP" "item-events" "analytics consumer assignment ready (item-events)"
+  wait_consumer_assignment "$ANALYTICS_CONSUMER_GROUP" "sales-events" "analytics consumer assignment ready (sales-events)"
+  wait_consumer_assignment "$ANALYTICS_CONSUMER_GROUP" "search-events" "analytics consumer assignment ready (search-events)"
+
+  run_publish_chain
+  check_search_publish_gap
+
+  echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}, warnings=${WARNINGS}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/docker/scripts/funding_hotdeal_business_e2e.sh
+++ b/docker/scripts/funding_hotdeal_business_e2e.sh
@@ -1,0 +1,654 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/funding_hotdeal_business_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+PRODUCT_PORT="${PRODUCT_PORT:-18284}"
+STOCK_PORT="${STOCK_PORT:-18285}"
+FUNDING_PORT="${FUNDING_PORT:-18286}"
+HOTDEAL_PORT="${HOTDEAL_PORT:-18289}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-project03-kafka}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex-e2e}"
+
+NOW_TS="$(date +%s)"
+SELLER_ID="${SELLER_ID:-610001}"
+BUYER_ID="${BUYER_ID:-620001}"
+BUYER2_ID="${BUYER2_ID:-620002}"
+BUYER3_ID="${BUYER3_ID:-620003}"
+STORE_ID="${STORE_ID:-630001}"
+CONSUMER_GROUP_SUFFIX="${CONSUMER_GROUP_SUFFIX:-$NOW_TS}"
+STOCK_CONSUMER_GROUP="${STOCK_CONSUMER_GROUP:-stock-business-e2e-${CONSUMER_GROUP_SUFFIX}}"
+PRODUCT_CONSUMER_GROUP="${PRODUCT_CONSUMER_GROUP:-product-business-e2e-${CONSUMER_GROUP_SUFFIX}}"
+FUNDING_CONSUMER_GROUP="${FUNDING_CONSUMER_GROUP:-funding-business-e2e-${CONSUMER_GROUP_SUFFIX}}"
+HOTDEAL_CONSUMER_GROUP="${HOTDEAL_CONSUMER_GROUP:-hotdeal-business-e2e-${CONSUMER_GROUP_SUFFIX}}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port ${port} is already in use"
+    return 1
+  fi
+  pass "port ${port} is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..180}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "${name} health is UP"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "${name} health timeout"
+  return 1
+}
+
+wait_consumer_assignment() {
+  local group="$1"
+  local topic="$2"
+  local label="$3"
+
+  for _ in {1..180}; do
+    local desc
+    desc="$(docker exec -i "$KAFKA_CONTAINER" bash -lc "kafka-consumer-groups --bootstrap-server localhost:9092 --describe --group ${group} 2>/dev/null" || true)"
+    if echo "$desc" | awk -v g="$group" -v t="$topic" '
+      $1 == g && $2 == t {found=1}
+      END {exit(found ? 0 : 1)}
+    '; then
+      pass "$label"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "${label} timeout"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  local body="${4:-}"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+    return 0
+  fi
+  fail "$label (expected=${expected}, actual=${actual})"
+  if [[ -n "$body" ]]; then
+    echo "[DEBUG] ${label} response=${body}"
+  fi
+  return 1
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+    return 0
+  fi
+  local code message
+  code="$(echo "$body" | jq -r '.error.code // "UNKNOWN"')"
+  message="$(echo "$body" | jq -r '.error.message // ""')"
+  fail "$label (code=${code}, message=${message})"
+  return 1
+}
+
+ensure_error_code() {
+  local label="$1"
+  local body="$2"
+  local expected="$3"
+  local actual
+  actual="$(echo "$body" | jq -r '.error.code // empty')"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected=${expected}, actual=${actual})"
+  fi
+}
+
+format_local_from_epoch() {
+  local epoch="$1"
+  date -r "$epoch" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date -d "@${epoch}" '+%Y-%m-%dT%H:%M:%S'
+}
+
+wait_stock_item_id_by_reference() {
+  local item_id="$1"
+  local reference_id="$2"
+  for _ in {1..120}; do
+    local raw body status stock_item_id
+    raw="$(curl -sS -w '\n%{http_code}' \
+      "http://127.0.0.1:${STOCK_PORT}/internal/v1/stock/items/${item_id}" || true)"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    if [[ "$status" == "200" ]] && [[ "$(echo "$body" | jq -r '.success // false')" == "true" ]]; then
+      stock_item_id="$(echo "$body" | jq -r --arg ref "$reference_id" '.data.stocks[]? | select((.referenceId|tostring) == $ref) | .stockItemId // empty' | head -n1)"
+      if [[ -n "$stock_item_id" && "$stock_item_id" != "null" ]]; then
+        echo "$stock_item_id"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_participation_status() {
+  local campaign_id="$1"
+  local participation_id="$2"
+  local expected_status="$3"
+  local timeout_seconds="${4:-60}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local raw body status value
+    raw="$(curl -sS -w '\n%{http_code}' \
+      "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/${campaign_id}/participations" || true)"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    if [[ "$status" == "200" ]] && [[ "$(echo "$body" | jq -r '.success // false')" == "true" ]]; then
+      value="$(echo "$body" | jq -r --arg id "$participation_id" '.data[]? | select((.id|tostring) == $id) | .status // empty' | head -n1)"
+      if [[ "$value" == "$expected_status" ]]; then
+        pass "participation status became ${expected_status}"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  fail "participation status ${expected_status} wait timeout"
+  return 1
+}
+
+wait_funding_progress_quantity() {
+  local campaign_id="$1"
+  local expected_quantity="$2"
+  local timeout_seconds="${3:-60}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local raw body status quantity
+    raw="$(curl -sS -w '\n%{http_code}' \
+      "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/${campaign_id}/progress" || true)"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    if [[ "$status" == "200" ]] && [[ "$(echo "$body" | jq -r '.success // false')" == "true" ]]; then
+      quantity="$(echo "$body" | jq -r '.data.currentQuantity // -1')"
+      if [[ "$quantity" == "$expected_quantity" ]]; then
+        pass "funding currentQuantity is ${expected_quantity}"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  fail "funding currentQuantity ${expected_quantity} wait timeout"
+  return 1
+}
+
+wait_queue_admitted() {
+  local hotdeal_id="$1"
+  local user_id="$2"
+  local timeout_seconds="${3:-60}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local raw body status can_purchase
+    raw="$(curl -sS -w '\n%{http_code}' \
+      "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/queue" \
+      -H "X-User-Id: ${user_id}" || true)"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    if [[ "$status" == "200" ]] && [[ "$(echo "$body" | jq -r '.success // false')" == "true" ]]; then
+      can_purchase="$(echo "$body" | jq -r '.data.canPurchase // false')"
+      if [[ "$can_purchase" == "true" ]]; then
+        pass "queue admitted (hotDealId=${hotdeal_id}, userId=${user_id})"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  fail "queue admission timeout (hotDealId=${hotdeal_id}, userId=${user_id})"
+  return 1
+}
+
+start_services() {
+  echo "[INFO] starting stock-service on ${STOCK_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$STOCK_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$STOCK_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:stock:bootRun --no-daemon >"$LOG_DIR/stock.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting product-service on ${PRODUCT_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$PRODUCT_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$PRODUCT_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:product:bootRun --no-daemon >"$LOG_DIR/product.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting funding-service on ${FUNDING_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$FUNDING_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$FUNDING_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      STOCK_SERVICE_URL="http://127.0.0.1:${STOCK_PORT}" \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:funding:bootRun --no-daemon >"$LOG_DIR/funding.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting hot-deal-service on ${HOTDEAL_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$HOTDEAL_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$HOTDEAL_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      PRODUCT_SERVICE_URL="http://127.0.0.1:${PRODUCT_PORT}" \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:hot-deal:bootRun --no-daemon >"$LOG_DIR/hotdeal.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+run_funding_business_flow() {
+  local ts keyword product_payload create_raw create_body create_status
+  local funding_item_id funding_option_id status_raw status_body status_code
+  local start_at end_at campaign_payload campaign_raw campaign_body campaign_status campaign_id
+  local participate_raw participate_body participate_status participation_id reservation_id
+  local me_raw me_body me_status contains_me
+  local refund_raw refund_body refund_status
+
+  echo "[INFO] funding business flow"
+
+  ts="$(date +%s)"
+  keyword="funding-business-${ts}"
+
+  product_payload="$(cat <<JSON
+{"title":"Funding Product ${keyword}","description":"funding business e2e","price":12000,"storeId":${STORE_ID},"options":[{"optionName":"기본","additionalPrice":0,"stockQuantity":5}],"shippingInfo":{"shippingFee":2500,"freeShippingThreshold":40000,"estimatedDays":2,"returnPolicy":"returnable"}}
+JSON
+)"
+
+  create_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${PRODUCT_PORT}/api/products" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$product_payload")"
+  create_body="$(extract_http_body "$create_raw")"
+  create_status="$(extract_http_status "$create_raw")"
+  ensure_http_status "funding product create status" "$create_status" "200" "$create_body" || return 1
+  ensure_json_success "funding product create success" "$create_body" || return 1
+
+  funding_item_id="$(echo "$create_body" | jq -r '.data.id // empty')"
+  funding_option_id="$(echo "$create_body" | jq -r '.data.options[0].id // empty')"
+  if [[ -z "$funding_item_id" || "$funding_item_id" == "null" ]]; then
+    fail "funding item id resolved"
+    return 1
+  fi
+  if [[ -z "$funding_option_id" || "$funding_option_id" == "null" ]]; then
+    fail "funding option id resolved"
+    return 1
+  fi
+  pass "funding item/option resolved (itemId=${funding_item_id}, optionId=${funding_option_id})"
+
+  status_raw="$(curl -sS -w '\n%{http_code}' -X PATCH "http://127.0.0.1:${PRODUCT_PORT}/api/items/${funding_item_id}/status" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d '{"status":"FUNDING","reason":"funding business e2e"}')"
+  status_body="$(extract_http_body "$status_raw")"
+  status_code="$(extract_http_status "$status_raw")"
+  ensure_http_status "item status DRAFT->FUNDING status" "$status_code" "200" "$status_body" || return 1
+  ensure_json_success "item status DRAFT->FUNDING success" "$status_body" || return 1
+
+  if wait_stock_item_id_by_reference "$funding_item_id" "$funding_option_id" >/dev/null; then
+    pass "stock initialized for funding item option"
+  else
+    fail "stock initialization for funding item option"
+    return 1
+  fi
+
+  start_at="$(format_local_from_epoch $((ts - 60)))"
+  end_at="$(format_local_from_epoch $((ts + 1800)))"
+  campaign_payload="$(cat <<JSON
+{"itemId":${funding_item_id},"title":"Funding Campaign ${keyword}","summary":"quantity based campaign","makerName":"MZC","category":"TEST","fundingType":"QUANTITY_BASED","goalAmount":20000,"goalQuantity":2,"minAmount":1000,"startAt":"${start_at}","endAt":"${end_at}"}
+JSON
+)"
+
+  campaign_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${FUNDING_PORT}/api/campaigns" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$campaign_payload")"
+  campaign_body="$(extract_http_body "$campaign_raw")"
+  campaign_status="$(extract_http_status "$campaign_raw")"
+  ensure_http_status "campaign create status" "$campaign_status" "200" "$campaign_body" || return 1
+  ensure_json_success "campaign create success" "$campaign_body" || return 1
+
+  campaign_id="$(echo "$campaign_body" | jq -r '.data.id // empty')"
+  if [[ -z "$campaign_id" || "$campaign_id" == "null" ]]; then
+    fail "campaign id resolved"
+    return 1
+  fi
+  pass "campaign id resolved (${campaign_id})"
+
+  ensure_http_status "campaign detail status" \
+    "$(curl -sS -o "$LOG_DIR/campaign_detail.json" -w '%{http_code}' "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/${campaign_id}")" \
+    "200" || return 1
+  ensure_jq_true_campaign_detail="$(jq -r '.success // false' "$LOG_DIR/campaign_detail.json" 2>/dev/null || true)"
+  if [[ "$ensure_jq_true_campaign_detail" == "true" ]]; then
+    pass "campaign detail success payload"
+  else
+    fail "campaign detail success payload"
+    return 1
+  fi
+
+  ensure_http_status "campaign by item status" \
+    "$(curl -sS -o "$LOG_DIR/campaign_by_item.json" -w '%{http_code}' "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/item/${funding_item_id}")" \
+    "200" || return 1
+  ensure_jq_true_campaign_item="$(jq -r '.success // false' "$LOG_DIR/campaign_by_item.json" 2>/dev/null || true)"
+  if [[ "$ensure_jq_true_campaign_item" == "true" ]]; then
+    pass "campaign by item success payload"
+  else
+    fail "campaign by item success payload"
+    return 1
+  fi
+
+  participate_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/${campaign_id}/participate" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${BUYER_ID}" \
+    -d "{\"amount\":12000,\"quantity\":1,\"itemOptionId\":${funding_option_id}}")"
+  participate_body="$(extract_http_body "$participate_raw")"
+  participate_status="$(extract_http_status "$participate_raw")"
+  ensure_http_status "funding participate status" "$participate_status" "200" "$participate_body" || return 1
+  ensure_json_success "funding participate success" "$participate_body" || return 1
+
+  participation_id="$(echo "$participate_body" | jq -r '.data.id // empty')"
+  reservation_id="$(echo "$participate_body" | jq -r '.data.reservationId // empty')"
+  if [[ -z "$participation_id" || "$participation_id" == "null" ]]; then
+    fail "participation id resolved"
+    return 1
+  fi
+  if [[ -z "$reservation_id" || "$reservation_id" == "null" ]]; then
+    fail "reservation id resolved for quantity-based participation"
+    return 1
+  fi
+  pass "participation/reservation resolved (${participation_id}/${reservation_id})"
+
+  wait_funding_progress_quantity "$campaign_id" "1" 60 || return 1
+
+  me_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${FUNDING_PORT}/api/campaigns/participations/me?size=20" \
+    -H "X-User-Id: ${BUYER_ID}")"
+  me_body="$(extract_http_body "$me_raw")"
+  me_status="$(extract_http_status "$me_raw")"
+  ensure_http_status "my participations status" "$me_status" "200" "$me_body" || return 1
+  ensure_json_success "my participations success" "$me_body" || return 1
+  contains_me="$(echo "$me_body" | jq -r --arg id "$participation_id" '((.data.items // .data.content // []) | map(.id|tostring) | index($id)) != null')"
+  if [[ "$contains_me" == "true" ]]; then
+    pass "my participations includes created participation"
+  else
+    fail "my participations includes created participation"
+    return 1
+  fi
+
+  refund_raw="$(curl -sS -w '\n%{http_code}' -X POST \
+    "http://127.0.0.1:${FUNDING_PORT}/internal/v1/funding/participations/${participation_id}/refund?userId=${BUYER_ID}")"
+  refund_body="$(extract_http_body "$refund_raw")"
+  refund_status="$(extract_http_status "$refund_raw")"
+  ensure_http_status "participation refund status" "$refund_status" "200" "$refund_body" || return 1
+  ensure_json_success "participation refund success" "$refund_body" || return 1
+
+  wait_participation_status "$campaign_id" "$participation_id" "REFUNDED" 60 || return 1
+  wait_funding_progress_quantity "$campaign_id" "0" 60 || return 1
+}
+
+run_hotdeal_business_flow() {
+  local ts keyword product_payload create_raw create_body create_status
+  local hotdeal_item_id status_raw status_body status_code
+  local hotdeal_payload hotdeal_raw hotdeal_body hotdeal_status hotdeal_id
+  local queue_raw queue_body queue_status
+  local purchase_raw purchase_body purchase_status
+  local repurchase_raw repurchase_body repurchase_status
+  local purchase2_raw purchase2_body purchase2_status
+  local soldout_raw soldout_body soldout_status
+  local list_raw list_body list_status contains_hotdeal
+  local detail_raw detail_body detail_status
+
+  echo "[INFO] hot-deal business flow"
+
+  ts="$(date +%s)"
+  keyword="hotdeal-business-${ts}"
+  product_payload="$(cat <<JSON
+{"title":"HotDeal Product ${keyword}","description":"hotdeal business e2e","price":18000,"storeId":${STORE_ID},"options":[{"optionName":"기본","additionalPrice":0,"stockQuantity":10}],"shippingInfo":{"shippingFee":2500,"freeShippingThreshold":40000,"estimatedDays":2,"returnPolicy":"returnable"}}
+JSON
+)"
+
+  create_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${PRODUCT_PORT}/api/products" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$product_payload")"
+  create_body="$(extract_http_body "$create_raw")"
+  create_status="$(extract_http_status "$create_raw")"
+  ensure_http_status "hotdeal product create status" "$create_status" "200" "$create_body" || return 1
+  ensure_json_success "hotdeal product create success" "$create_body" || return 1
+
+  hotdeal_item_id="$(echo "$create_body" | jq -r '.data.id // empty')"
+  if [[ -z "$hotdeal_item_id" || "$hotdeal_item_id" == "null" ]]; then
+    fail "hotdeal item id resolved"
+    return 1
+  fi
+  pass "hotdeal item id resolved (${hotdeal_item_id})"
+
+  status_raw="$(curl -sS -w '\n%{http_code}' -X PATCH "http://127.0.0.1:${PRODUCT_PORT}/api/items/${hotdeal_item_id}/status" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d '{"status":"ON_SALE","reason":"hotdeal business e2e"}')"
+  status_body="$(extract_http_body "$status_raw")"
+  status_code="$(extract_http_status "$status_raw")"
+  ensure_http_status "item status DRAFT->ON_SALE for hotdeal" "$status_code" "200" "$status_body" || return 1
+  ensure_json_success "item status DRAFT->ON_SALE for hotdeal success" "$status_body" || return 1
+
+  hotdeal_payload="$(cat <<JSON
+{"itemId":${hotdeal_item_id},"discountRate":20,"maxQuantity":2,"maxPerUser":1}
+JSON
+)"
+  hotdeal_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$hotdeal_payload")"
+  hotdeal_body="$(extract_http_body "$hotdeal_raw")"
+  hotdeal_status="$(extract_http_status "$hotdeal_raw")"
+  ensure_http_status "hotdeal create status" "$hotdeal_status" "200" "$hotdeal_body" || return 1
+  ensure_json_success "hotdeal create success" "$hotdeal_body" || return 1
+
+  hotdeal_id="$(echo "$hotdeal_body" | jq -r '.data.id // empty')"
+  if [[ -z "$hotdeal_id" || "$hotdeal_id" == "null" ]]; then
+    fail "hotdeal id resolved"
+    return 1
+  fi
+  pass "hotdeal id resolved (${hotdeal_id})"
+
+  detail_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}")"
+  detail_body="$(extract_http_body "$detail_raw")"
+  detail_status="$(extract_http_status "$detail_raw")"
+  ensure_http_status "hotdeal detail status" "$detail_status" "200" "$detail_body" || return 1
+  ensure_json_success "hotdeal detail success" "$detail_body" || return 1
+
+  list_raw="$(curl -sS -w '\n%{http_code}' "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals?size=20")"
+  list_body="$(extract_http_body "$list_raw")"
+  list_status="$(extract_http_status "$list_raw")"
+  ensure_http_status "hotdeal list status" "$list_status" "200" "$list_body" || return 1
+  ensure_json_success "hotdeal list success" "$list_body" || return 1
+  contains_hotdeal="$(echo "$list_body" | jq -r --arg id "$hotdeal_id" '((.data // []) | map(.id|tostring) | index($id)) != null')"
+  if [[ "$contains_hotdeal" == "true" ]]; then
+    pass "hotdeal list includes created hotdeal"
+  else
+    fail "hotdeal list includes created hotdeal"
+    return 1
+  fi
+
+  queue_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/queue/enter" \
+    -H "X-User-Id: ${BUYER_ID}")"
+  queue_body="$(extract_http_body "$queue_raw")"
+  queue_status="$(extract_http_status "$queue_raw")"
+  ensure_http_status "hotdeal queue enter buyer1 status" "$queue_status" "200" "$queue_body" || return 1
+  ensure_json_success "hotdeal queue enter buyer1 success" "$queue_body" || return 1
+  wait_queue_admitted "$hotdeal_id" "$BUYER_ID" 60 || return 1
+
+  purchase_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/purchase" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${BUYER_ID}" \
+    -d '{"quantity":1}')"
+  purchase_body="$(extract_http_body "$purchase_raw")"
+  purchase_status="$(extract_http_status "$purchase_raw")"
+  ensure_http_status "hotdeal purchase buyer1 status" "$purchase_status" "200" "$purchase_body" || return 1
+  ensure_json_success "hotdeal purchase buyer1 success" "$purchase_body" || return 1
+
+  repurchase_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/purchase" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${BUYER_ID}" \
+    -d '{"quantity":1}')"
+  repurchase_body="$(extract_http_body "$repurchase_raw")"
+  repurchase_status="$(extract_http_status "$repurchase_raw")"
+  ensure_http_status "hotdeal repurchase buyer1 rejected status" "$repurchase_status" "400" "$repurchase_body" || return 1
+  ensure_error_code "hotdeal repurchase buyer1 rejected code" "$repurchase_body" "HOTDEAL-101"
+
+  queue_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/queue/enter" \
+    -H "X-User-Id: ${BUYER2_ID}")"
+  queue_body="$(extract_http_body "$queue_raw")"
+  queue_status="$(extract_http_status "$queue_raw")"
+  ensure_http_status "hotdeal queue enter buyer2 status" "$queue_status" "200" "$queue_body" || return 1
+  ensure_json_success "hotdeal queue enter buyer2 success" "$queue_body" || return 1
+  wait_queue_admitted "$hotdeal_id" "$BUYER2_ID" 60 || return 1
+
+  purchase2_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/purchase" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${BUYER2_ID}" \
+    -d '{"quantity":1}')"
+  purchase2_body="$(extract_http_body "$purchase2_raw")"
+  purchase2_status="$(extract_http_status "$purchase2_raw")"
+  ensure_http_status "hotdeal purchase buyer2 status" "$purchase2_status" "200" "$purchase2_body" || return 1
+  ensure_json_success "hotdeal purchase buyer2 success" "$purchase2_body" || return 1
+
+  queue_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/queue/enter" \
+    -H "X-User-Id: ${BUYER3_ID}")"
+  queue_body="$(extract_http_body "$queue_raw")"
+  queue_status="$(extract_http_status "$queue_raw")"
+  ensure_http_status "hotdeal queue enter buyer3 status" "$queue_status" "200" "$queue_body" || return 1
+  ensure_json_success "hotdeal queue enter buyer3 success" "$queue_body" || return 1
+  wait_queue_admitted "$hotdeal_id" "$BUYER3_ID" 60 || return 1
+
+  soldout_raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${HOTDEAL_PORT}/api/v1/hot-deals/${hotdeal_id}/purchase" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${BUYER3_ID}" \
+    -d '{"quantity":1}')"
+  soldout_body="$(extract_http_body "$soldout_raw")"
+  soldout_status="$(extract_http_status "$soldout_raw")"
+  ensure_http_status "hotdeal purchase sold-out rejected status" "$soldout_status" "409" "$soldout_body" || return 1
+  ensure_error_code "hotdeal purchase sold-out rejected code" "$soldout_body" "HOTDEAL-005"
+
+  pass "hotdeal sold-out business path verified by purchase rejection"
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+  require_cmd docker
+  require_cmd lsof
+
+  check_port_free "$PRODUCT_PORT" || true
+  check_port_free "$STOCK_PORT" || true
+  check_port_free "$FUNDING_PORT" || true
+  check_port_free "$HOTDEAL_PORT" || true
+
+  echo "[INFO] preparing docker infra"
+  (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka >/dev/null)
+  pass "docker infra up (postgres/redis/zookeeper/kafka)"
+
+  start_services
+
+  wait_health "stock-service" "$STOCK_PORT"
+  wait_health "product-service" "$PRODUCT_PORT"
+  wait_health "funding-service" "$FUNDING_PORT"
+  wait_health "hot-deal-service" "$HOTDEAL_PORT"
+
+  wait_consumer_assignment "$STOCK_CONSUMER_GROUP" "item-events" "stock consumer assignment ready (item-events)"
+
+  run_funding_business_flow
+  run_hotdeal_business_flow
+
+  echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/docker/scripts/gateway_seller_dashboard_e2e_verify.sh
+++ b/docker/scripts/gateway_seller_dashboard_e2e_verify.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/gateway_seller_dashboard_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+GW_PORT="${GW_PORT:-18180}"
+ANALYTICS_PORT="${ANALYTICS_PORT:-18095}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-project03-postgres}"
+
+STORE_ID="${STORE_ID:-920001}"
+SELLER_ID="${SELLER_ID:-910001}"
+TARGET_DATE="${TARGET_DATE:-2026-02-26}"
+INTERNAL_AUTH_TOKEN="${INTERNAL_AUTH_TOKEN:-gw-dashboard-e2e-token}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex-e2e}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $port is already in use"
+    return 1
+  fi
+  pass "port $port is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..180}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "$name health is UP"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "$name health timeout"
+  return 1
+}
+
+wait_bff_ready() {
+  local url="http://127.0.0.1:${GW_PORT}/bff/v1/seller/dashboard/overview?mode=DAILY&date=${TARGET_DATE}"
+  for _ in {1..180}; do
+    local status
+    status="$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" || true)"
+    if [[ "$status" == "400" || "$status" == "200" ]]; then
+      pass "client-gateway BFF endpoint is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "client-gateway BFF readiness timeout"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected=${expected}, actual=${actual})"
+  fi
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+ensure_jq_true() {
+  local label="$1"
+  local body="$2"
+  local expr="$3"
+  if echo "$body" | jq -e "$expr" >/dev/null; then
+    pass "$label"
+  else
+    fail "$label (expr: $expr)"
+  fi
+}
+
+psql_exec() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -v ON_ERROR_STOP=1 -c "$sql" >/dev/null
+}
+
+ensure_infra() {
+  (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka >/dev/null)
+  pass "docker infra up (postgres/redis/zookeeper/kafka)"
+}
+
+ensure_analytics_db() {
+  local exists
+  exists="$(docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d postgres -At -c "SELECT 1 FROM pg_database WHERE datname='analytics_db'" 2>/dev/null || true)"
+  if [[ "$exists" != "1" ]]; then
+    docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE analytics_db" >/dev/null
+    pass "analytics_db created"
+  else
+    pass "analytics_db already exists"
+  fi
+}
+
+seed_analytics_data() {
+  psql_exec analytics_db "TRUNCATE TABLE analytics_raw_sales_event RESTART IDENTITY CASCADE"
+  psql_exec analytics_db "TRUNCATE TABLE analytics_raw_search_event RESTART IDENTITY CASCADE"
+  psql_exec analytics_db "TRUNCATE TABLE analytics_dim_item_snapshot CASCADE"
+
+  psql_exec analytics_db "
+INSERT INTO analytics_dim_item_snapshot (
+  item_id, store_id, seller_id, item_type, item_status, price, stock_quantity, snapshot_at, created_at, updated_at, deleted_at
+) VALUES
+  (11001, ${STORE_ID}, ${SELLER_ID}, 'PRODUCT', 'ON_SALE', 10000, 12, '${TARGET_DATE} 09:00:00', NOW(), NOW(), NULL),
+  (11002, ${STORE_ID}, ${SELLER_ID}, 'PRODUCT', 'SOLD_OUT', 12000, 0, '${TARGET_DATE} 09:00:00', NOW(), NOW(), NULL),
+  (11003, ${STORE_ID}, ${SELLER_ID}, 'PRODUCT', 'HIDDEN', 8000, 3, '${TARGET_DATE} 09:00:00', NOW(), NOW(), NULL)
+"
+
+  psql_exec analytics_db "
+INSERT INTO analytics_raw_sales_event (
+  event_id, event_type, store_id, seller_id, item_id, order_id, purchase_id, quantity,
+  gross_amount, net_amount, occurred_at, ingested_at, created_at, updated_at, deleted_at
+) VALUES
+  ('sales-e2e-1', 'PURCHASE_CREATED', ${STORE_ID}, ${SELLER_ID}, 11001, 70001, 80001, 1, 10000, 9000, '${TARGET_DATE} 10:00:00', '${TARGET_DATE} 10:00:01', NOW(), NOW(), NULL),
+  ('sales-e2e-2', 'PURCHASE_CREATED', ${STORE_ID}, ${SELLER_ID}, 11002, 70002, 80002, 1, 5000, 4500, '${TARGET_DATE} 11:00:00', '${TARGET_DATE} 11:00:01', NOW(), NOW(), NULL),
+  ('sales-e2e-3', 'PURCHASE_CANCELLED', ${STORE_ID}, ${SELLER_ID}, 11002, 70002, 80002, 1, 0, -2000, '${TARGET_DATE} 12:00:00', '${TARGET_DATE} 12:00:01', NOW(), NOW(), NULL),
+  ('sales-e2e-4', 'PURCHASE_REFUNDED', ${STORE_ID}, ${SELLER_ID}, 11003, 70003, 80003, 1, 0, -1000, '${TARGET_DATE} 13:00:00', '${TARGET_DATE} 13:00:01', NOW(), NOW(), NULL)
+"
+
+  psql_exec analytics_db "
+INSERT INTO analytics_raw_search_event (
+  event_id, event_type, store_id, seller_id, item_id, query_hash, session_id,
+  occurred_at, ingested_at, created_at, updated_at, deleted_at
+) VALUES
+  ('search-e2e-1', 'SEARCH_EXECUTED', ${STORE_ID}, ${SELLER_ID}, NULL, 'hash-1', 'session-1', '${TARGET_DATE} 10:30:00', '${TARGET_DATE} 10:30:01', NOW(), NOW(), NULL),
+  ('search-e2e-2', 'SEARCH_EXECUTED', ${STORE_ID}, ${SELLER_ID}, NULL, 'hash-2', 'session-2', '${TARGET_DATE} 10:31:00', '${TARGET_DATE} 10:31:01', NOW(), NOW(), NULL),
+  ('search-e2e-3', 'SEARCH_ITEM_CLICKED', ${STORE_ID}, ${SELLER_ID}, 11001, 'hash-1', 'session-1', '${TARGET_DATE} 10:32:00', '${TARGET_DATE} 10:32:01', NOW(), NOW(), NULL)
+"
+
+  pass "seeded analytics dashboard test data"
+}
+
+start_analytics_service() {
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$ANALYTICS_PORT" \
+      DB_URL="jdbc:postgresql://127.0.0.1:5432/analytics_db" \
+      DB_USERNAME="postgres" \
+      DB_PASSWORD="postgres" \
+      SPRING_PROFILES_ACTIVE="local" \
+      SPRING_KAFKA_LISTENER_AUTO_STARTUP="false" \
+      APP_GATEWAY_SECURITY_ENABLED="true" \
+      APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED="true" \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_HEADER="X-Gateway-Auth" \
+      APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:services:analytics-dashboard:bootRun --no-daemon >"$LOG_DIR/analytics-dashboard.log" 2>&1
+  ) &
+  PIDS+=("$!")
+  pass "analytics-dashboard bootRun started"
+}
+
+start_gateway_service() {
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$GW_PORT" \
+      ANALYTICS_DASHBOARD_SERVICE_URL="http://127.0.0.1:${ANALYTICS_PORT}" \
+      GATEWAY_AUTH_ENABLED="false" \
+      GATEWAY_SESSION_ENABLED="false" \
+      APP_SECURITY_CONTEXT_PARSER_ENABLED="false" \
+      GATEWAY_SECURITY_INTERNAL_AUTH_HEADER="X-Gateway-Auth" \
+      GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN="$INTERNAL_AUTH_TOKEN" \
+      ./gradlew :servers:gateways:client-gateway:bootRun --no-daemon >"$LOG_DIR/client-gateway.log" 2>&1
+  ) &
+  PIDS+=("$!")
+  pass "client-gateway bootRun started"
+}
+
+run_assertions() {
+  local raw body status
+
+  raw="$(curl -sS -w '\n%{http_code}' \
+    "http://127.0.0.1:${ANALYTICS_PORT}/internal/v1/analytics/stores/${STORE_ID}/dashboard/overview?mode=DAILY&date=${TARGET_DATE}" \
+    -H "X-Gateway-Auth: ${INTERNAL_AUTH_TOKEN}" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -H "X-Store-Id: ${STORE_ID}")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+  ensure_http_status "internal overview status" "$status" "200"
+  ensure_json_success "internal overview success payload" "$body"
+  ensure_jq_true "internal KPI aggregation" "$body" '.data.sales.grossSales == 15000 and .data.sales.netSales == 10500 and .data.sales.orderCount == 2 and .data.sales.cancelCount == 1 and .data.sales.refundCount == 1'
+  ensure_jq_true "internal search KPI aggregation" "$body" '.data.search.searchCount == 2 and .data.search.clickCount == 1 and .data.search.ctr == 0.5'
+  ensure_jq_true "internal item KPI aggregation" "$body" '.data.item.onSaleCount == 1 and .data.item.soldOutCount == 1 and .data.item.hiddenCount == 1'
+  ensure_jq_true "internal series daily bucket" "$body" ".data.series | length == 1 and .[0].bucketStart == \"${TARGET_DATE}\" and .[0].grossSales == 15000 and .[0].netSales == 10500 and .[0].orderCount == 2"
+  ensure_jq_true "internal store/review scope placeholders are null" "$body" '.data.extensions.store == null and .data.extensions.review == null'
+
+  raw="$(curl -sS -w '\n%{http_code}' \
+    "http://127.0.0.1:${GW_PORT}/bff/v1/seller/dashboard/overview?mode=DAILY&date=${TARGET_DATE}" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -H "X-Store-Id: ${STORE_ID}")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+  ensure_http_status "gateway overview status" "$status" "200"
+  ensure_json_success "gateway overview success payload" "$body"
+  ensure_jq_true "gateway relays aggregated sales" "$body" '.data.sales.grossSales == 15000 and .data.sales.netSales == 10500 and .data.mode == "DAILY"'
+  ensure_jq_true "gateway queryRange/date" "$body" ".data.queryRange.from == \"${TARGET_DATE}\" and .data.queryRange.to == \"${TARGET_DATE}\" and .data.queryRange.bucket == \"DAY\""
+  ensure_jq_true "gateway store/review scope placeholders are null" "$body" '.data.extensions.store == null and .data.extensions.review == null'
+
+  raw="$(curl -sS -w '\n%{http_code}' \
+    "http://127.0.0.1:${GW_PORT}/bff/v1/seller/dashboard/overview?storeId=-1&mode=DAILY&date=${TARGET_DATE}" \
+    -H "X-User-Id: ${SELLER_ID}")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+  ensure_http_status "gateway invalid storeId status" "$status" "400"
+  ensure_jq_true "gateway invalid storeId code" "$body" '.success == false and .error.code == "BFF-DASHBOARD-400"'
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+  require_cmd docker
+  require_cmd lsof
+
+  check_port_free "$ANALYTICS_PORT" || true
+  check_port_free "$GW_PORT" || true
+
+  ensure_infra
+  ensure_analytics_db
+
+  start_analytics_service
+  wait_health "analytics-dashboard" "$ANALYTICS_PORT"
+
+  seed_analytics_data
+
+  start_gateway_service
+  wait_health "client-gateway" "$GW_PORT"
+  wait_bff_ready
+
+  run_assertions
+
+  echo "[INFO] e2e summary: passes=${PASSES}, failures=${FAILURES}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/docker/scripts/outbox_broker_recovery_e2e.sh
+++ b/docker/scripts/outbox_broker_recovery_e2e.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/outbox_broker_recovery_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+PRODUCT_PORT="${PRODUCT_PORT:-18484}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-project03-postgres}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-project03-kafka}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex-e2e}"
+
+SELLER_ID="${SELLER_ID:-640001}"
+STORE_ID="${STORE_ID:-650001}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+CREATED_ITEM_ID=""
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port ${port} is already in use"
+    return 1
+  fi
+  pass "port ${port} is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..180}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "${name} health is UP"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "${name} health timeout"
+  return 1
+}
+
+wait_kafka_ready() {
+  for _ in {1..90}; do
+    if docker exec -i "$KAFKA_CONTAINER" kafka-topics --bootstrap-server localhost:9092 --list >/dev/null 2>&1; then
+      pass "kafka is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "kafka readiness timeout"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  local body="${4:-}"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+    return 0
+  fi
+  fail "$label (expected=${expected}, actual=${actual})"
+  if [[ -n "$body" ]]; then
+    echo "[DEBUG] ${label} response=${body}"
+  fi
+  return 1
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+    return 0
+  fi
+  local code message
+  code="$(echo "$body" | jq -r '.error.code // "UNKNOWN"')"
+  message="$(echo "$body" | jq -r '.error.message // ""')"
+  fail "$label (code=${code}, message=${message})"
+  return 1
+}
+
+psql_query() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -At -c "$sql"
+}
+
+topic_offset_sum() {
+  local topic="$1"
+  local offsets
+  offsets="$(docker exec -i "$KAFKA_CONTAINER" bash -lc "kafka-run-class kafka.tools.GetOffsetShell --broker-list localhost:9092 --topic ${topic} --time -1 2>/dev/null" || true)"
+  echo "$offsets" | awk -F: '{sum+=$3} END {print sum+0}'
+}
+
+get_outbox_status() {
+  local item_id="$1"
+  psql_query product_db \
+    "SELECT status FROM outbox_messages WHERE aggregate_type='Item' AND aggregate_id='${item_id}' AND event_type='ITEM_CREATED' ORDER BY created_at DESC LIMIT 1;" | tr -d '[:space:]'
+}
+
+wait_outbox_status() {
+  local item_id="$1"
+  local expected="$2"
+  local timeout_seconds="${3:-120}"
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local status
+    status="$(get_outbox_status "$item_id")"
+    if [[ "$status" == "$expected" ]]; then
+      pass "outbox status=${expected} (itemId=${item_id})"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "outbox status=${expected} timeout (itemId=${item_id})"
+  return 1
+}
+
+wait_outbox_non_published() {
+  local item_id="$1"
+  local timeout_seconds="${2:-60}"
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local status
+    status="$(get_outbox_status "$item_id")"
+    if [[ "$status" == "PENDING" || "$status" == "SENDING" || "$status" == "FAILED" ]]; then
+      pass "outbox captured non-published status=${status} during broker outage (itemId=${item_id})"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "outbox non-published status not observed during broker outage (itemId=${item_id})"
+  return 1
+}
+
+start_product() {
+  echo "[INFO] starting product-service on ${PRODUCT_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$PRODUCT_PORT" \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      APP_OUTBOX_RELAY_FIXED_DELAY_MS=1000 \
+      APP_OUTBOX_RELAY_FETCH_BEFORE_SECONDS=1 \
+      APP_OUTBOX_RELAY_MAX_IN_FLIGHT=8 \
+      APP_OUTBOX_RELAY_SENDING_STALE_THRESHOLD_SECONDS=15 \
+      ./gradlew :servers:services:product:bootRun --no-daemon >"$LOG_DIR/product.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+create_product() {
+  local label="$1"
+  local ts payload raw body status item_id
+
+  ts="$(date +%s)"
+  payload="$(cat <<JSON
+{"title":"Outbox ${label} ${ts}","description":"outbox broker recovery e2e","price":9900,"storeId":${STORE_ID},"options":[{"optionName":"기본","additionalPrice":0,"stockQuantity":3}],"shippingInfo":{"shippingFee":2500,"freeShippingThreshold":30000,"estimatedDays":2,"returnPolicy":"returnable"}}
+JSON
+)"
+
+  raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${PRODUCT_PORT}/api/products" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$payload")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+
+  ensure_http_status "product create status (${label})" "$status" "200" "$body" || return 1
+  ensure_json_success "product create success (${label})" "$body" || return 1
+
+  item_id="$(echo "$body" | jq -r '.data.id // empty')"
+  if [[ -z "$item_id" || "$item_id" == "null" ]]; then
+    fail "created item id resolved (${label})"
+    return 1
+  fi
+
+  pass "created item id resolved (${label}, itemId=${item_id})"
+  CREATED_ITEM_ID="$item_id"
+  return 0
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+  require_cmd docker
+  require_cmd lsof
+
+  check_port_free "$PRODUCT_PORT" || true
+
+  echo "[INFO] preparing docker infra"
+  (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka >/dev/null)
+  pass "docker infra up (postgres/redis/zookeeper/kafka)"
+  wait_kafka_ready
+
+  start_product
+  wait_health "product-service" "$PRODUCT_PORT"
+
+  local baseline_item outage_item offset_before offset_after
+  create_product "baseline"
+  baseline_item="$CREATED_ITEM_ID"
+  wait_outbox_status "$baseline_item" "PUBLISHED" 120
+
+  offset_before="$(topic_offset_sum "item-events" | tr -d '[:space:]')"
+  if [[ "$offset_before" =~ ^[0-9]+$ ]]; then
+    pass "item-events offset captured before outage (${offset_before})"
+  else
+    fail "item-events offset read before outage"
+    return 1
+  fi
+
+  echo "[INFO] stopping kafka for broker outage injection"
+  (cd "$ROOT/docker" && docker compose stop kafka >/dev/null)
+  pass "kafka stopped for outage case"
+
+  create_product "kafka-outage"
+  outage_item="$CREATED_ITEM_ID"
+  wait_outbox_non_published "$outage_item" 90
+
+  echo "[INFO] recovering kafka broker"
+  (cd "$ROOT/docker" && docker compose up -d kafka >/dev/null)
+  wait_kafka_ready
+
+  wait_outbox_status "$outage_item" "PUBLISHED" 180
+
+  offset_after="$(topic_offset_sum "item-events" | tr -d '[:space:]')"
+  if [[ "$offset_after" =~ ^[0-9]+$ ]] && (( offset_after > offset_before )); then
+    pass "item-events offset increased after broker recovery (${offset_before} -> ${offset_after})"
+  else
+    fail "item-events offset did not increase after broker recovery (${offset_before} -> ${offset_after})"
+  fi
+
+  echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/docker/scripts/search_consumer_dlq_retry_e2e.sh
+++ b/docker/scripts/search_consumer_dlq_retry_e2e.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="${LOG_DIR:-/tmp/search_consumer_dlq_retry_e2e_logs_$(date +%Y%m%d_%H%M%S)}"
+mkdir -p "$LOG_DIR"
+
+PRODUCT_PORT="${PRODUCT_PORT:-18884}"
+SEARCH_PORT="${SEARCH_PORT:-18888}"
+ELASTICSEARCH_PORT="${ELASTICSEARCH_PORT:-23173}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-project03-postgres}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-project03-kafka}"
+GRADLE_USER_HOME="${GRADLE_USER_HOME:-/tmp/.gradle-codex-e2e}"
+
+SELLER_ID="${SELLER_ID:-660001}"
+STORE_ID="${STORE_ID:-670001}"
+NOW_TS="$(date +%s)"
+CONSUMER_GROUP_SUFFIX="${CONSUMER_GROUP_SUFFIX:-$NOW_TS}"
+SEARCH_CONSUMER_GROUP="${SEARCH_CONSUMER_GROUP:-search-dlq-retry-e2e-${CONSUMER_GROUP_SUFFIX}}"
+PRODUCT_CONSUMER_GROUP="${PRODUCT_CONSUMER_GROUP:-product-dlq-retry-e2e-${CONSUMER_GROUP_SUFFIX}}"
+
+PIDS=()
+PASSES=0
+FAILURES=0
+CREATED_ITEM_ID=""
+
+pass() {
+  PASSES=$((PASSES + 1))
+  echo "[PASS] $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "[FAIL] $1"
+}
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 1
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  echo "[INFO] logs: $LOG_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERR] command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+check_port_free() {
+  local port="$1"
+  if lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port ${port} is already in use"
+    return 1
+  fi
+  pass "port ${port} is free"
+}
+
+wait_health() {
+  local name="$1"
+  local port="$2"
+  for _ in {1..180}; do
+    local status
+    status="$(curl -sS --max-time 2 "http://127.0.0.1:${port}/actuator/health" | jq -r '.status' 2>/dev/null || true)"
+    if [[ "$status" == "UP" ]]; then
+      pass "${name} health is UP"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "${name} health timeout"
+  return 1
+}
+
+wait_es_up() {
+  for _ in {1..120}; do
+    local code
+    code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "http://127.0.0.1:${ELASTICSEARCH_PORT}/_cluster/health" || true)"
+    if [[ "$code" == "200" ]]; then
+      pass "elasticsearch is reachable"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "elasticsearch reachability timeout"
+  return 1
+}
+
+wait_consumer_assignment() {
+  local group="$1"
+  local topic="$2"
+  local label="$3"
+
+  for _ in {1..180}; do
+    local desc
+    desc="$(docker exec -i "$KAFKA_CONTAINER" bash -lc "kafka-consumer-groups --bootstrap-server localhost:9092 --describe --group ${group} 2>/dev/null" || true)"
+    if echo "$desc" | awk -v g="$group" -v t="$topic" '
+      $1 == g && $2 == t {found=1}
+      END {exit(found ? 0 : 1)}
+    '; then
+      pass "$label"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "${label} timeout"
+  return 1
+}
+
+extract_http_body() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed '$d'
+}
+
+extract_http_status() {
+  local raw="$1"
+  printf '%s\n' "$raw" | tail -n1
+}
+
+ensure_http_status() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  local body="${4:-}"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+    return 0
+  fi
+  fail "$label (expected=${expected}, actual=${actual})"
+  if [[ -n "$body" ]]; then
+    echo "[DEBUG] ${label} response=${body}"
+  fi
+  return 1
+}
+
+ensure_json_success() {
+  local label="$1"
+  local body="$2"
+  local success
+  success="$(echo "$body" | jq -r '.success // false')"
+  if [[ "$success" == "true" ]]; then
+    pass "$label"
+    return 0
+  fi
+  local code message
+  code="$(echo "$body" | jq -r '.error.code // "UNKNOWN"')"
+  message="$(echo "$body" | jq -r '.error.message // ""')"
+  fail "$label (code=${code}, message=${message})"
+  return 1
+}
+
+psql_exec() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -v ON_ERROR_STOP=1 -c "$sql" >/dev/null
+}
+
+psql_query() {
+  local db="$1"
+  local sql="$2"
+  docker exec -i "$POSTGRES_CONTAINER" psql -U postgres -d "$db" -At -c "$sql"
+}
+
+wait_count_gt() {
+  local db="$1"
+  local sql="$2"
+  local baseline="$3"
+  local label="$4"
+  local timeout_seconds="${5:-120}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local value
+    value="$(psql_query "$db" "$sql" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && (( value > baseline )); then
+      pass "$label (baseline=${baseline}, value=${value})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "$label timeout (baseline=${baseline})"
+  return 1
+}
+
+wait_count_eq() {
+  local db="$1"
+  local sql="$2"
+  local expected="$3"
+  local label="$4"
+  local timeout_seconds="${5:-60}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local value
+    value="$(psql_query "$db" "$sql" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && (( value == expected )); then
+      pass "$label (value=${value})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "$label timeout (expected=${expected})"
+  return 1
+}
+
+get_outbox_event_id() {
+  local item_id="$1"
+  psql_query product_db \
+    "SELECT event_id FROM outbox_messages WHERE aggregate_type='Item' AND aggregate_id='${item_id}' AND event_type='ITEM_CREATED' ORDER BY created_at DESC LIMIT 1;" | tr -d '[:space:]'
+}
+
+wait_processed_event_status() {
+  local event_id="$1"
+  local expected_status="$2"
+  local timeout_seconds="${3:-120}"
+
+  for _ in $(seq 1 "$timeout_seconds"); do
+    local status
+    status="$(psql_query search_db "SELECT status FROM processed_events WHERE event_id='${event_id}' LIMIT 1;" | tr -d '[:space:]')"
+    if [[ "$status" == "$expected_status" ]]; then
+      pass "processed_events status=${expected_status} (eventId=${event_id})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  fail "processed_events status=${expected_status} timeout (eventId=${event_id})"
+  return 1
+}
+
+recreate_search_index() {
+  local attempt max_attempts raw body status success
+  max_attempts=10
+  for attempt in $(seq 1 "$max_attempts"); do
+    raw="$(curl -sS -w '\n%{http_code}' -X POST \
+      "http://127.0.0.1:${SEARCH_PORT}/internal/v1/search/indexes/recreate?indexName=items")"
+    body="$(extract_http_body "$raw")"
+    status="$(extract_http_status "$raw")"
+    success="$(echo "$body" | jq -r '.success // false' 2>/dev/null || true)"
+    if [[ "$status" == "200" && "$success" == "true" ]]; then
+      pass "search index recreate success"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "search index recreate failed"
+  return 1
+}
+
+create_product() {
+  local label="$1"
+  local title="$2"
+  local payload raw body status item_id
+
+  payload="$(cat <<JSON
+{"title":"${title}","description":"${label}","price":15000,"storeId":${STORE_ID},"options":[{"optionName":"기본","additionalPrice":0,"stockQuantity":5}],"shippingInfo":{"shippingFee":2500,"freeShippingThreshold":30000,"estimatedDays":2,"returnPolicy":"returnable"}}
+JSON
+)"
+  raw="$(curl -sS -w '\n%{http_code}' -X POST "http://127.0.0.1:${PRODUCT_PORT}/api/products" \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${SELLER_ID}" \
+    -d "$payload")"
+  body="$(extract_http_body "$raw")"
+  status="$(extract_http_status "$raw")"
+  ensure_http_status "product create status (${label})" "$status" "200" "$body" || return 1
+  ensure_json_success "product create success (${label})" "$body" || return 1
+
+  item_id="$(echo "$body" | jq -r '.data.id // empty')"
+  if [[ -z "$item_id" || "$item_id" == "null" ]]; then
+    fail "product id resolved (${label})"
+    return 1
+  fi
+  pass "product id resolved (${label}, itemId=${item_id})"
+  CREATED_ITEM_ID="$item_id"
+  return 0
+}
+
+start_services() {
+  echo "[INFO] starting product-service on ${PRODUCT_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$PRODUCT_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$PRODUCT_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      ./gradlew :servers:services:product:bootRun --no-daemon >"$LOG_DIR/product.log" 2>&1
+  ) &
+  PIDS+=("$!")
+
+  echo "[INFO] starting search-service on ${SEARCH_PORT}"
+  (
+    cd "$ROOT"
+    env \
+      GRADLE_USER_HOME="$GRADLE_USER_HOME" \
+      SERVER_PORT="$SEARCH_PORT" \
+      SPRING_KAFKA_CONSUMER_GROUP_ID="$SEARCH_CONSUMER_GROUP" \
+      SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest \
+      ELASTICSEARCH_URIS="http://127.0.0.1:${ELASTICSEARCH_PORT}" \
+      SEARCH_THUMBNAIL_ENRICHER_ENABLED=false \
+      APP_GATEWAY_SECURITY_ENABLED=false \
+      APP_KAFKA_CONSUMER_MAX_RETRY_ATTEMPTS=2 \
+      APP_KAFKA_CONSUMER_INITIAL_BACKOFF_MS=200 \
+      APP_KAFKA_CONSUMER_BACKOFF_MULTIPLIER=1 \
+      APP_KAFKA_CONSUMER_MAX_BACKOFF_MS=400 \
+      ./gradlew :servers:services:search:bootRun --no-daemon >"$LOG_DIR/search.log" 2>&1
+  ) &
+  PIDS+=("$!")
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+  require_cmd docker
+  require_cmd lsof
+
+  check_port_free "$PRODUCT_PORT"
+  check_port_free "$SEARCH_PORT"
+
+  echo "[INFO] preparing infra"
+  (cd "$ROOT/docker" && docker compose up -d postgres redis zookeeper kafka elasticsearch >/dev/null)
+  wait_es_up
+
+  start_services
+  wait_health "product-service" "$PRODUCT_PORT"
+  wait_health "search-service" "$SEARCH_PORT"
+  recreate_search_index
+  wait_consumer_assignment "$SEARCH_CONSUMER_GROUP" "item-events" "search consumer assignment ready (item-events)"
+
+  psql_exec search_db "TRUNCATE TABLE dead_letter_messages RESTART IDENTITY CASCADE;"
+  psql_exec search_db "TRUNCATE TABLE processed_events RESTART IDENTITY CASCADE;"
+  pass "search dead-letter/processed tables reset"
+
+  local dlq_before dlq_after item_fail item_ok recovery_event_id
+  dlq_before="$(psql_query search_db "SELECT count(*) FROM dead_letter_messages WHERE topic='item-events';" | tr -d '[:space:]')"
+  if [[ ! "$dlq_before" =~ ^[0-9]+$ ]]; then
+    fail "failed to read initial DLQ count"
+    exit 1
+  fi
+  pass "initial item-events DLQ count=${dlq_before}"
+
+  echo "[INFO] stopping elasticsearch for failure injection"
+  (cd "$ROOT/docker" && docker compose stop elasticsearch >/dev/null)
+  pass "elasticsearch stopped"
+
+  create_product "dlq-failure" "search-dlq-failure-${NOW_TS}"
+  item_fail="$CREATED_ITEM_ID"
+  wait_count_gt "search_db" \
+    "SELECT count(*) FROM dead_letter_messages WHERE topic='item-events' AND event_type='ITEM_CREATED';" \
+    "$dlq_before" \
+    "DLQ row created after retry exhaustion" \
+    120
+
+  dlq_after="$(psql_query search_db "SELECT count(*) FROM dead_letter_messages WHERE topic='item-events';" | tr -d '[:space:]')"
+  pass "item-events DLQ count after failure=${dlq_after}"
+  pass "retry limit scenario uses app.kafka.consumer.maxRetryAttempts=2"
+
+  echo "[INFO] recovering elasticsearch"
+  (cd "$ROOT/docker" && docker compose up -d elasticsearch >/dev/null)
+  wait_es_up
+  recreate_search_index
+
+  create_product "recovery" "search-dlq-recover-${NOW_TS}"
+  item_ok="$CREATED_ITEM_ID"
+  recovery_event_id="$(get_outbox_event_id "$item_ok")"
+  if [[ -z "$recovery_event_id" ]]; then
+    fail "recovery item outbox event id resolved"
+    exit 1
+  fi
+  pass "recovery item outbox event id resolved (${recovery_event_id})"
+  wait_processed_event_status "$recovery_event_id" "PROCESSED" 120
+  wait_count_eq "search_db" \
+    "SELECT count(*) FROM dead_letter_messages WHERE topic='item-events';" \
+    "$dlq_after" \
+    "no additional DLQ rows after elasticsearch recovery" \
+    60
+
+  echo "[INFO] summary: passes=${PASSES}, failures=${FAILURES}"
+  if (( FAILURES > 0 )); then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/libs/contracts/http/src/main/java/com/example/contracts/http/HttpHeaderNames.java
+++ b/libs/contracts/http/src/main/java/com/example/contracts/http/HttpHeaderNames.java
@@ -6,6 +6,7 @@ public final class HttpHeaderNames {
     }
 
     public static final String USER_ID = "X-User-Id";
+    public static final String STORE_ID = "X-Store-Id";
     public static final String USER_ROLES = "X-User-Roles";
     public static final String NONCE = "X-Nonce";
     public static final String TIMESTAMP = "X-Timestamp";

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SellerDashboardBffController.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SellerDashboardBffController.java
@@ -1,0 +1,34 @@
+package com.example.gateway.bff.controller;
+
+import com.example.gateway.bff.service.SellerDashboardBffService;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/bff/v1/seller/dashboard")
+@RequiredArgsConstructor
+public class SellerDashboardBffController {
+
+    private final SellerDashboardBffService sellerDashboardBffService;
+
+    @GetMapping("/overview")
+    public Mono<ResponseEntity<JsonNode>> getOverview(
+            ServerHttpRequest request,
+            @RequestParam(required = false) String mode,
+            @RequestParam(required = false) String date,
+            @RequestParam(required = false) String yearMonth,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to,
+            @RequestParam(required = false) String bucket,
+            @RequestParam(required = false) String timezone
+    ) {
+        return sellerDashboardBffService.getOverview(request, mode, date, yearMonth, from, to, bucket, timezone);
+    }
+}

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SellerDashboardBffController.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/controller/SellerDashboardBffController.java
@@ -21,6 +21,7 @@ public class SellerDashboardBffController {
     @GetMapping("/overview")
     public Mono<ResponseEntity<JsonNode>> getOverview(
             ServerHttpRequest request,
+            @RequestParam(required = false) String storeId,
             @RequestParam(required = false) String mode,
             @RequestParam(required = false) String date,
             @RequestParam(required = false) String yearMonth,
@@ -29,6 +30,6 @@ public class SellerDashboardBffController {
             @RequestParam(required = false) String bucket,
             @RequestParam(required = false) String timezone
     ) {
-        return sellerDashboardBffService.getOverview(request, mode, date, yearMonth, from, to, bucket, timezone);
+        return sellerDashboardBffService.getOverview(request, storeId, mode, date, yearMonth, from, to, bucket, timezone);
     }
 }

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/CatalogDetailBffService.java
@@ -77,8 +77,12 @@ public class CatalogDetailBffService {
             return fallbackToNormal(request, headers, "hot_deal_id_missing");
         }
         return downstreamClient.fetchHotDealDetail(request.hotDealId(), headers)
-                .flatMap(primary -> apply404Fallback(request, headers, primary, "hot_deal_404"))
-                .flatMap(response -> enrichHotDealResponse(request, headers, response));
+                .flatMap(primaryResponse -> {
+                    if (primaryResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
+                        return fallbackToNormal(request, headers, "hot_deal_404");
+                    }
+                    return enrichHotDealResponse(request, headers, primaryResponse);
+                });
     }
 
     private Mono<ResponseEntity<JsonNode>> routeFunding(CatalogDetailRequest request, HttpHeaders headers) {
@@ -91,18 +95,12 @@ public class CatalogDetailBffService {
                 : "funding_item_404";
 
         return primaryMono
-                .flatMap(primary -> apply404Fallback(request, headers, primary, fallbackReason))
-                .flatMap(response -> enrichFundingResponse(request, headers, response));
-    }
-
-    private Mono<ResponseEntity<JsonNode>> apply404Fallback(CatalogDetailRequest request,
-                                                            HttpHeaders headers,
-                                                            ResponseEntity<JsonNode> primaryResponse,
-                                                            String reason) {
-        if (primaryResponse.getStatusCode() != HttpStatus.NOT_FOUND) {
-            return Mono.just(primaryResponse);
-        }
-        return fallbackToNormal(request, headers, reason);
+                .flatMap(primaryResponse -> {
+                    if (primaryResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
+                        return fallbackToNormal(request, headers, fallbackReason);
+                    }
+                    return enrichFundingResponse(request, headers, primaryResponse);
+                });
     }
 
     private Mono<ResponseEntity<JsonNode>> fallbackToNormal(CatalogDetailRequest request,

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SellerDashboardBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SellerDashboardBffService.java
@@ -43,6 +43,7 @@ public class SellerDashboardBffService {
     }
 
     public Mono<ResponseEntity<JsonNode>> getOverview(ServerHttpRequest request,
+                                                      String storeId,
                                                       String mode,
                                                       String date,
                                                       String yearMonth,
@@ -54,12 +55,16 @@ public class SellerDashboardBffService {
         if (sellerId == null) {
             return Mono.just(badRequest("X-User-Id 헤더가 없거나 유효하지 않습니다."));
         }
+        Long resolvedStoreId = resolveStoreId(request, storeId, sellerId);
+        if (resolvedStoreId == null) {
+            return Mono.just(badRequest("storeId는 양수여야 합니다."));
+        }
 
-        HttpHeaders downstreamHeaders = buildDownstreamHeaders(sellerId);
+        HttpHeaders downstreamHeaders = buildDownstreamHeaders(sellerId, resolvedStoreId);
         return analyticsDashboardWebClient.get()
                 .uri(uriBuilder -> buildOverviewUri(
                         uriBuilder,
-                        sellerId,
+                        resolvedStoreId,
                         mode,
                         date,
                         yearMonth,
@@ -73,13 +78,16 @@ public class SellerDashboardBffService {
                         .defaultIfEmpty(objectMapper.createObjectNode())
                         .map(payload -> ResponseEntity.status(response.statusCode()).body(payload)))
                 .onErrorResume(e -> {
-                    log.warn("[SellerDashboardBff] overview query failed. sellerId={}", sellerId, e);
+                    log.warn("[SellerDashboardBff] overview query failed. sellerId={}, storeId={}",
+                            sellerId,
+                            resolvedStoreId,
+                            e);
                     return Mono.just(badGateway("셀러 대시보드 조회에 실패했습니다."));
                 });
     }
 
     private java.net.URI buildOverviewUri(UriBuilder uriBuilder,
-                                          Long sellerId,
+                                          Long storeId,
                                           String mode,
                                           String date,
                                           String yearMonth,
@@ -87,7 +95,7 @@ public class SellerDashboardBffService {
                                           String to,
                                           String bucket,
                                           String timezone) {
-        UriBuilder builder = uriBuilder.path("/internal/v1/analytics/sellers/{sellerId}/dashboard/overview");
+        UriBuilder builder = uriBuilder.path("/internal/v1/analytics/stores/{storeId}/dashboard/overview");
         addQueryParam(builder, "mode", mode);
         addQueryParam(builder, "date", date);
         addQueryParam(builder, "yearMonth", yearMonth);
@@ -95,7 +103,7 @@ public class SellerDashboardBffService {
         addQueryParam(builder, "to", to);
         addQueryParam(builder, "bucket", bucket);
         addQueryParam(builder, "timezone", timezone);
-        return builder.build(sellerId);
+        return builder.build(storeId);
     }
 
     private void addQueryParam(UriBuilder builder, String name, String value) {
@@ -106,21 +114,37 @@ public class SellerDashboardBffService {
 
     private Long parseSellerId(ServerHttpRequest request) {
         String userIdHeader = request.getHeaders().getFirst(HttpHeaderNames.USER_ID);
-        if (!StringUtils.hasText(userIdHeader)) {
+        return parsePositiveLong(userIdHeader);
+    }
+
+    private Long resolveStoreId(ServerHttpRequest request, String storeId, Long fallbackStoreId) {
+        if (StringUtils.hasText(storeId)) {
+            return parsePositiveLong(storeId);
+        }
+        String storeIdHeader = request.getHeaders().getFirst(HttpHeaderNames.STORE_ID);
+        if (StringUtils.hasText(storeIdHeader)) {
+            return parsePositiveLong(storeIdHeader);
+        }
+        return fallbackStoreId;
+    }
+
+    private Long parsePositiveLong(String value) {
+        if (!StringUtils.hasText(value)) {
             return null;
         }
         try {
-            long parsed = Long.parseLong(userIdHeader.trim());
+            long parsed = Long.parseLong(value.trim());
             return parsed > 0 ? parsed : null;
         } catch (NumberFormatException e) {
             return null;
         }
     }
 
-    private HttpHeaders buildDownstreamHeaders(Long sellerId) {
+    private HttpHeaders buildDownstreamHeaders(Long sellerId, Long storeId) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(HttpHeaderNames.USER_ID, String.valueOf(sellerId));
+        headers.set(HttpHeaderNames.STORE_ID, String.valueOf(storeId));
         if (StringUtils.hasText(securityProperties.getInternalAuthToken())
                 && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
             headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());

--- a/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SellerDashboardBffService.java
+++ b/servers/gateways/client-gateway/src/main/java/com/example/gateway/bff/service/SellerDashboardBffService.java
@@ -1,0 +1,148 @@
+package com.example.gateway.bff.service;
+
+import com.example.contracts.http.HttpHeaderNames;
+import com.example.gateway.config.GatewaySecurityProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+public class SellerDashboardBffService {
+
+    private static final String CODE_INVALID_REQUEST = "BFF-DASHBOARD-400";
+    private static final String CODE_DOWNSTREAM_ERROR = "BFF-DASHBOARD-502";
+
+    private final WebClient analyticsDashboardWebClient;
+    private final GatewaySecurityProperties securityProperties;
+    private final ObjectMapper objectMapper;
+
+    public SellerDashboardBffService(
+            WebClient.Builder webClientBuilder,
+            GatewaySecurityProperties securityProperties,
+            ObjectMapper objectMapper,
+            @Value("${app.service.analytics-dashboard-url:http://localhost:8095}") String analyticsDashboardServiceUrl
+    ) {
+        this.analyticsDashboardWebClient = webClientBuilder.baseUrl(analyticsDashboardServiceUrl).build();
+        this.securityProperties = securityProperties;
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<ResponseEntity<JsonNode>> getOverview(ServerHttpRequest request,
+                                                      String mode,
+                                                      String date,
+                                                      String yearMonth,
+                                                      String from,
+                                                      String to,
+                                                      String bucket,
+                                                      String timezone) {
+        Long sellerId = parseSellerId(request);
+        if (sellerId == null) {
+            return Mono.just(badRequest("X-User-Id 헤더가 없거나 유효하지 않습니다."));
+        }
+
+        HttpHeaders downstreamHeaders = buildDownstreamHeaders(sellerId);
+        return analyticsDashboardWebClient.get()
+                .uri(uriBuilder -> buildOverviewUri(
+                        uriBuilder,
+                        sellerId,
+                        mode,
+                        date,
+                        yearMonth,
+                        from,
+                        to,
+                        bucket,
+                        timezone
+                ))
+                .headers(headers -> headers.addAll(downstreamHeaders))
+                .exchangeToMono(response -> response.bodyToMono(JsonNode.class)
+                        .defaultIfEmpty(objectMapper.createObjectNode())
+                        .map(payload -> ResponseEntity.status(response.statusCode()).body(payload)))
+                .onErrorResume(e -> {
+                    log.warn("[SellerDashboardBff] overview query failed. sellerId={}", sellerId, e);
+                    return Mono.just(badGateway("셀러 대시보드 조회에 실패했습니다."));
+                });
+    }
+
+    private java.net.URI buildOverviewUri(UriBuilder uriBuilder,
+                                          Long sellerId,
+                                          String mode,
+                                          String date,
+                                          String yearMonth,
+                                          String from,
+                                          String to,
+                                          String bucket,
+                                          String timezone) {
+        UriBuilder builder = uriBuilder.path("/internal/v1/analytics/sellers/{sellerId}/dashboard/overview");
+        addQueryParam(builder, "mode", mode);
+        addQueryParam(builder, "date", date);
+        addQueryParam(builder, "yearMonth", yearMonth);
+        addQueryParam(builder, "from", from);
+        addQueryParam(builder, "to", to);
+        addQueryParam(builder, "bucket", bucket);
+        addQueryParam(builder, "timezone", timezone);
+        return builder.build(sellerId);
+    }
+
+    private void addQueryParam(UriBuilder builder, String name, String value) {
+        if (StringUtils.hasText(value)) {
+            builder.queryParam(name, value);
+        }
+    }
+
+    private Long parseSellerId(ServerHttpRequest request) {
+        String userIdHeader = request.getHeaders().getFirst(HttpHeaderNames.USER_ID);
+        if (!StringUtils.hasText(userIdHeader)) {
+            return null;
+        }
+        try {
+            long parsed = Long.parseLong(userIdHeader.trim());
+            return parsed > 0 ? parsed : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private HttpHeaders buildDownstreamHeaders(Long sellerId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaderNames.USER_ID, String.valueOf(sellerId));
+        if (StringUtils.hasText(securityProperties.getInternalAuthToken())
+                && StringUtils.hasText(securityProperties.getInternalAuthHeader())) {
+            headers.set(securityProperties.getInternalAuthHeader(), securityProperties.getInternalAuthToken());
+        }
+        return headers;
+    }
+
+    private ResponseEntity<JsonNode> badRequest(String message) {
+        return ResponseEntity.badRequest().body(errorPayload(CODE_INVALID_REQUEST, message));
+    }
+
+    private ResponseEntity<JsonNode> badGateway(String message) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(errorPayload(CODE_DOWNSTREAM_ERROR, message));
+    }
+
+    private ObjectNode errorPayload(String code, String message) {
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("success", false);
+        ObjectNode error = body.putObject("error");
+        error.put("code", code);
+        error.put("message", message);
+        body.put("timestamp", Instant.now().toString());
+        return body;
+    }
+}

--- a/servers/gateways/client-gateway/src/main/resources/application.yml
+++ b/servers/gateways/client-gateway/src/main/resources/application.yml
@@ -83,6 +83,8 @@ gateway:
     keycloak-logout-auth-token: ${GATEWAY_SESSION_KEYCLOAK_LOGOUT_AUTH_TOKEN:}
 
 app:
+  service:
+    analytics-dashboard-url: ${ANALYTICS_DASHBOARD_SERVICE_URL:http://localhost:8095}
   security:
     context:
       signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}

--- a/servers/services/analytics-dashboard/build.gradle.kts
+++ b/servers/services/analytics-dashboard/build.gradle.kts
@@ -1,0 +1,51 @@
+dependencies {
+    // Web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // ─── 공통 모듈 ─────────────────────────────────
+    // Core
+    implementation(project(":libs:core:exception"))
+    implementation(project(":libs:core:util"))
+    implementation(project(":libs:core:id"))
+
+    // API
+    implementation(project(":libs:api:response"))
+    implementation(project(":libs:api:exception-handler"))
+
+    // Data
+    implementation(project(":libs:data:entity"))
+
+    // Config
+    implementation(project(":libs:config:kafka"))
+    implementation(project(":libs:config:redis"))
+    implementation(project(":libs:config:resilience"))
+    implementation(project(":libs:config:webclient"))
+
+    // Event
+    implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:outbox"))
+
+    // Security
+    implementation(project(":libs:security:security-starter"))
+
+    // OpenAPI
+    implementation(project(":libs:openapi:config"))
+
+    // ─── Spring Boot ─────────────────────────────────
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Database (runtime)
+    runtimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/AnalyticsDashboardApplication.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/AnalyticsDashboardApplication.java
@@ -1,0 +1,12 @@
+package com.example.analyticsdashboard;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.example")
+public class AnalyticsDashboardApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AnalyticsDashboardApplication.class, args);
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/config/JpaConfig.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.example.analyticsdashboard.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example.analyticsdashboard.repository")
+public class JpaConfig {
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventConsumer.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventConsumer.java
@@ -1,0 +1,47 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalyticsItemEventConsumer {
+
+    private static final String IDEMPOTENT_EVENT_TYPE = "ANALYTICS_ITEM_EVENT";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final AnalyticsEventIngestService analyticsEventIngestService;
+
+    @KafkaListener(topics = "item-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) {
+        AnalyticsItemEventMessage event = JsonUtils.fromJson(message, AnalyticsItemEventMessage.class);
+        if (!isValid(event, message)) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), IDEMPOTENT_EVENT_TYPE, () -> {
+            analyticsEventIngestService.ingestItemEvent(event);
+            return null;
+        });
+    }
+
+    private boolean isValid(AnalyticsItemEventMessage event, String message) {
+        if (event == null || event.getEventId() == null || event.getEventType() == null) {
+            log.error("[AnalyticsItemConsumer] eventId/eventType 누락. message={}", message);
+            return false;
+        }
+        if (event.getItemId() == null) {
+            log.warn("[AnalyticsItemConsumer] itemId 누락으로 스킵. eventId={}", event.getEventId());
+            return false;
+        }
+        return true;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventMessage.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventMessage.java
@@ -1,0 +1,21 @@
+package com.example.analyticsdashboard.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnalyticsItemEventMessage {
+
+    private String eventId;
+    private String eventType;
+
+    private Long itemId;
+    private String itemType;
+    private Long price;
+    private String status;
+    private String newStatus;
+
+    private Long sellerId;
+    private Long storeId;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventConsumer.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventConsumer.java
@@ -1,0 +1,43 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalyticsSalesEventConsumer {
+
+    private static final String IDEMPOTENT_EVENT_TYPE = "ANALYTICS_SALES_EVENT";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final AnalyticsEventIngestService analyticsEventIngestService;
+
+    @KafkaListener(topics = "sales-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) {
+        AnalyticsSalesEventMessage event = JsonUtils.fromJson(message, AnalyticsSalesEventMessage.class);
+        if (!isValid(event, message)) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), IDEMPOTENT_EVENT_TYPE, () -> {
+            analyticsEventIngestService.ingestSalesEvent(event);
+            return null;
+        });
+    }
+
+    private boolean isValid(AnalyticsSalesEventMessage event, String message) {
+        if (event == null || event.getEventId() == null || event.getEventType() == null) {
+            log.error("[AnalyticsSalesConsumer] eventId/eventType 누락. message={}", message);
+            return false;
+        }
+        return true;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventMessage.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventMessage.java
@@ -1,0 +1,24 @@
+package com.example.analyticsdashboard.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnalyticsSalesEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private String occurredAt;
+
+    private Long purchaseId;
+    private Long orderId;
+    private Long userId;
+    private Long itemId;
+    private Long totalAmount;
+    private Integer quantity;
+    private Long reservationId;
+
+    private Long sellerId;
+    private Long storeId;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventConsumer.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventConsumer.java
@@ -1,0 +1,43 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalyticsSearchEventConsumer {
+
+    private static final String IDEMPOTENT_EVENT_TYPE = "ANALYTICS_SEARCH_EVENT";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final AnalyticsEventIngestService analyticsEventIngestService;
+
+    @KafkaListener(topics = "search-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) {
+        AnalyticsSearchEventMessage event = JsonUtils.fromJson(message, AnalyticsSearchEventMessage.class);
+        if (!isValid(event, message)) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), IDEMPOTENT_EVENT_TYPE, () -> {
+            analyticsEventIngestService.ingestSearchEvent(event);
+            return null;
+        });
+    }
+
+    private boolean isValid(AnalyticsSearchEventMessage event, String message) {
+        if (event == null || event.getEventId() == null || event.getEventType() == null) {
+            log.error("[AnalyticsSearchConsumer] eventId/eventType 누락. message={}", message);
+            return false;
+        }
+        return true;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventMessage.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventMessage.java
@@ -1,0 +1,20 @@
+package com.example.analyticsdashboard.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnalyticsSearchEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private String occurredAt;
+
+    private Long itemId;
+    private Long storeId;
+    private Long sellerId;
+
+    private String queryHash;
+    private String sessionId;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/controller/query/InternalSellerDashboardQueryController.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/controller/query/InternalSellerDashboardQueryController.java
@@ -1,0 +1,47 @@
+package com.example.analyticsdashboard.controller.query;
+
+import com.example.analyticsdashboard.dto.query.SellerDashboardOverviewQuery;
+import com.example.analyticsdashboard.dto.response.SellerDashboardOverviewResponse;
+import com.example.analyticsdashboard.service.query.SellerDashboardOverviewQueryService;
+import com.example.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Internal", description = "셀러 대시보드 내부 조회 API")
+@RestController
+@RequestMapping("/internal/v1/analytics/sellers")
+@RequiredArgsConstructor
+public class InternalSellerDashboardQueryController {
+
+    private final SellerDashboardOverviewQueryService sellerDashboardOverviewQueryService;
+
+    @Operation(summary = "셀러 대시보드 overview 조회 (내부)")
+    @GetMapping("/{sellerId}/dashboard/overview")
+    public ApiResponse<SellerDashboardOverviewResponse> getOverview(
+            @PathVariable Long sellerId,
+            @RequestParam(required = false) String mode,
+            @RequestParam(required = false) String date,
+            @RequestParam(required = false) String yearMonth,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to,
+            @RequestParam(required = false) String bucket,
+            @RequestParam(required = false) String timezone
+    ) {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                mode,
+                date,
+                yearMonth,
+                from,
+                to,
+                bucket,
+                timezone
+        );
+        return ApiResponse.success(sellerDashboardOverviewQueryService.getOverview(sellerId, query));
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/controller/query/InternalSellerDashboardQueryController.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/controller/query/InternalSellerDashboardQueryController.java
@@ -4,10 +4,12 @@ import com.example.analyticsdashboard.dto.query.SellerDashboardOverviewQuery;
 import com.example.analyticsdashboard.dto.response.SellerDashboardOverviewResponse;
 import com.example.analyticsdashboard.service.query.SellerDashboardOverviewQueryService;
 import com.example.api.response.ApiResponse;
+import com.example.contracts.http.HttpHeaderNames;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Internal", description = "셀러 대시보드 내부 조회 API")
 @RestController
-@RequestMapping("/internal/v1/analytics/sellers")
+@RequestMapping("/internal/v1/analytics")
 @RequiredArgsConstructor
 public class InternalSellerDashboardQueryController {
 
     private final SellerDashboardOverviewQueryService sellerDashboardOverviewQueryService;
 
     @Operation(summary = "셀러 대시보드 overview 조회 (내부)")
-    @GetMapping("/{sellerId}/dashboard/overview")
+    @GetMapping("/sellers/{sellerId}/dashboard/overview")
     public ApiResponse<SellerDashboardOverviewResponse> getOverview(
             @PathVariable Long sellerId,
             @RequestParam(required = false) String mode,
@@ -43,5 +45,30 @@ public class InternalSellerDashboardQueryController {
                 timezone
         );
         return ApiResponse.success(sellerDashboardOverviewQueryService.getOverview(sellerId, query));
+    }
+
+    @Operation(summary = "스토어 대시보드 overview 조회 (내부)")
+    @GetMapping("/stores/{storeId}/dashboard/overview")
+    public ApiResponse<SellerDashboardOverviewResponse> getOverviewByStore(
+            @PathVariable Long storeId,
+            @RequestHeader(value = HttpHeaderNames.USER_ID, required = false) Long sellerId,
+            @RequestParam(required = false) String mode,
+            @RequestParam(required = false) String date,
+            @RequestParam(required = false) String yearMonth,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to,
+            @RequestParam(required = false) String bucket,
+            @RequestParam(required = false) String timezone
+    ) {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                mode,
+                date,
+                yearMonth,
+                from,
+                to,
+                bucket,
+                timezone
+        );
+        return ApiResponse.success(sellerDashboardOverviewQueryService.getOverviewByStore(storeId, sellerId, query));
     }
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/DashboardQueryMode.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/DashboardQueryMode.java
@@ -1,0 +1,28 @@
+package com.example.analyticsdashboard.dto.query;
+
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+public enum DashboardQueryMode {
+
+    DAILY,
+    MONTHLY,
+    RANGE;
+
+    public static DashboardQueryMode from(String rawMode) {
+        if (!StringUtils.hasText(rawMode)) {
+            return DAILY;
+        }
+        try {
+            return DashboardQueryMode.valueOf(rawMode.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(
+                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
+                    "mode는 DAILY, MONTHLY, RANGE 중 하나여야 합니다."
+            );
+        }
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/DashboardSeriesBucket.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/DashboardSeriesBucket.java
@@ -1,0 +1,27 @@
+package com.example.analyticsdashboard.dto.query;
+
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+public enum DashboardSeriesBucket {
+
+    DAY,
+    MONTH;
+
+    public static DashboardSeriesBucket from(String rawBucket) {
+        if (!StringUtils.hasText(rawBucket)) {
+            return DAY;
+        }
+        try {
+            return DashboardSeriesBucket.valueOf(rawBucket.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(
+                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
+                    "bucket은 DAY, MONTH 중 하나여야 합니다."
+            );
+        }
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/SellerDashboardOverviewQuery.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/query/SellerDashboardOverviewQuery.java
@@ -1,0 +1,132 @@
+package com.example.analyticsdashboard.dto.query;
+
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+
+public record SellerDashboardOverviewQuery(
+        DashboardQueryMode mode,
+        LocalDate date,
+        YearMonth yearMonth,
+        LocalDate from,
+        LocalDate to,
+        DashboardSeriesBucket bucket,
+        ZoneId timezone
+) {
+
+    private static final ZoneId DEFAULT_TIMEZONE = ZoneId.of("Asia/Seoul");
+    private static final long MAX_RANGE_DAYS = 93L;
+
+    public static SellerDashboardOverviewQuery of(String mode,
+                                                  String date,
+                                                  String yearMonth,
+                                                  String from,
+                                                  String to,
+                                                  String bucket,
+                                                  String timezone) {
+        DashboardQueryMode parsedMode = DashboardQueryMode.from(mode);
+        ZoneId parsedTimezone = parseTimezone(timezone);
+
+        return switch (parsedMode) {
+            case DAILY -> buildDailyQuery(date, parsedTimezone);
+            case MONTHLY -> buildMonthlyQuery(yearMonth, parsedTimezone);
+            case RANGE -> buildRangeQuery(from, to, bucket, parsedTimezone);
+        };
+    }
+
+    private static SellerDashboardOverviewQuery buildDailyQuery(String date, ZoneId timezone) {
+        LocalDate parsedDate = parseDate(date, "date");
+        return new SellerDashboardOverviewQuery(
+                DashboardQueryMode.DAILY,
+                parsedDate,
+                null,
+                null,
+                null,
+                null,
+                timezone
+        );
+    }
+
+    private static SellerDashboardOverviewQuery buildMonthlyQuery(String yearMonth, ZoneId timezone) {
+        YearMonth parsedYearMonth = parseYearMonth(yearMonth, "yearMonth");
+        return new SellerDashboardOverviewQuery(
+                DashboardQueryMode.MONTHLY,
+                null,
+                parsedYearMonth,
+                null,
+                null,
+                null,
+                timezone
+        );
+    }
+
+    private static SellerDashboardOverviewQuery buildRangeQuery(String from,
+                                                                String to,
+                                                                String bucket,
+                                                                ZoneId timezone) {
+        LocalDate parsedFrom = parseDate(from, "from");
+        LocalDate parsedTo = parseDate(to, "to");
+
+        if (parsedFrom.isAfter(parsedTo)) {
+            throw invalid("from은 to보다 클 수 없습니다.");
+        }
+
+        long days = ChronoUnit.DAYS.between(parsedFrom, parsedTo) + 1;
+        if (days > MAX_RANGE_DAYS) {
+            throw invalid("RANGE 조회는 최대 93일까지만 허용됩니다.");
+        }
+
+        return new SellerDashboardOverviewQuery(
+                DashboardQueryMode.RANGE,
+                null,
+                null,
+                parsedFrom,
+                parsedTo,
+                DashboardSeriesBucket.from(bucket),
+                timezone
+        );
+    }
+
+    private static LocalDate parseDate(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw invalid(fieldName + "는 필수입니다.");
+        }
+        try {
+            return LocalDate.parse(value.trim());
+        } catch (DateTimeParseException e) {
+            throw invalid(fieldName + "는 yyyy-MM-dd 형식이어야 합니다.");
+        }
+    }
+
+    private static YearMonth parseYearMonth(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw invalid(fieldName + "는 필수입니다.");
+        }
+        try {
+            return YearMonth.parse(value.trim());
+        } catch (DateTimeParseException e) {
+            throw invalid(fieldName + "는 yyyy-MM 형식이어야 합니다.");
+        }
+    }
+
+    private static ZoneId parseTimezone(String value) {
+        if (!StringUtils.hasText(value)) {
+            return DEFAULT_TIMEZONE;
+        }
+        try {
+            return ZoneId.of(value.trim());
+        } catch (Exception e) {
+            throw invalid("timezone 값이 유효하지 않습니다.");
+        }
+    }
+
+    private static BusinessException invalid(String message) {
+        return new BusinessException(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER, message);
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/DashboardLagStatus.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/DashboardLagStatus.java
@@ -1,0 +1,7 @@
+package com.example.analyticsdashboard.dto.response;
+
+public enum DashboardLagStatus {
+
+    HEALTHY,
+    DEGRADED
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardItemKpiResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardItemKpiResponse.java
@@ -1,0 +1,21 @@
+package com.example.analyticsdashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellerDashboardItemKpiResponse {
+
+    private Long onSaleCount;
+    private Long soldOutCount;
+    private Long hiddenCount;
+
+    public static SellerDashboardItemKpiResponse empty() {
+        return SellerDashboardItemKpiResponse.builder()
+                .onSaleCount(0L)
+                .soldOutCount(0L)
+                .hiddenCount(0L)
+                .build();
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardOverviewResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardOverviewResponse.java
@@ -1,0 +1,26 @@
+package com.example.analyticsdashboard.dto.response;
+
+import com.example.analyticsdashboard.dto.query.DashboardQueryMode;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class SellerDashboardOverviewResponse {
+
+    private DashboardQueryMode mode;
+    private SellerDashboardQueryRangeResponse queryRange;
+    private Instant asOf;
+    private DashboardLagStatus lagStatus;
+    private boolean partial;
+    private SellerDashboardSalesKpiResponse sales;
+    private SellerDashboardItemKpiResponse item;
+    private SellerDashboardSearchKpiResponse search;
+    private List<SellerDashboardSeriesPointResponse> series;
+    private String apiVersion;
+    private Map<String, Object> extensions;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardQueryRangeResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardQueryRangeResponse.java
@@ -1,0 +1,14 @@
+package com.example.analyticsdashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellerDashboardQueryRangeResponse {
+
+    private String from;
+    private String to;
+    private String bucket;
+    private String timezone;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSalesKpiResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSalesKpiResponse.java
@@ -1,0 +1,25 @@
+package com.example.analyticsdashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellerDashboardSalesKpiResponse {
+
+    private Long grossSales;
+    private Long netSales;
+    private Long orderCount;
+    private Long cancelCount;
+    private Long refundCount;
+
+    public static SellerDashboardSalesKpiResponse empty() {
+        return SellerDashboardSalesKpiResponse.builder()
+                .grossSales(0L)
+                .netSales(0L)
+                .orderCount(0L)
+                .cancelCount(0L)
+                .refundCount(0L)
+                .build();
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSearchKpiResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSearchKpiResponse.java
@@ -1,0 +1,21 @@
+package com.example.analyticsdashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellerDashboardSearchKpiResponse {
+
+    private Long searchCount;
+    private Long clickCount;
+    private Double ctr;
+
+    public static SellerDashboardSearchKpiResponse empty() {
+        return SellerDashboardSearchKpiResponse.builder()
+                .searchCount(0L)
+                .clickCount(0L)
+                .ctr(0.0d)
+                .build();
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSeriesPointResponse.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/dto/response/SellerDashboardSeriesPointResponse.java
@@ -1,0 +1,14 @@
+package com.example.analyticsdashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SellerDashboardSeriesPointResponse {
+
+    private String bucketStart;
+    private Long grossSales;
+    private Long netSales;
+    private Long orderCount;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiDaily.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiDaily.java
@@ -22,10 +22,11 @@ import java.time.LocalDate;
         name = "analytics_agg_seller_kpi_daily",
         indexes = {
                 @Index(
-                        name = "uk_analytics_agg_seller_kpi_daily_business_seller",
-                        columnList = "business_date,seller_id",
+                        name = "uk_analytics_agg_seller_kpi_daily_business_store",
+                        columnList = "business_date,store_id",
                         unique = true
                 ),
+                @Index(name = "idx_analytics_agg_seller_kpi_daily_store", columnList = "store_id"),
                 @Index(name = "idx_analytics_agg_seller_kpi_daily_seller", columnList = "seller_id")
         }
 )
@@ -37,6 +38,9 @@ public class AnalyticsAggSellerKpiDaily extends BaseEntity {
 
     @Column(name = "business_date", nullable = false)
     private LocalDate businessDate;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -68,6 +72,7 @@ public class AnalyticsAggSellerKpiDaily extends BaseEntity {
     @Builder
     private AnalyticsAggSellerKpiDaily(
             LocalDate businessDate,
+            Long storeId,
             Long sellerId,
             Long orderCount,
             Long cancelCount,
@@ -79,6 +84,7 @@ public class AnalyticsAggSellerKpiDaily extends BaseEntity {
             Double ctr
     ) {
         this.businessDate = businessDate;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.orderCount = orderCount;
         this.cancelCount = cancelCount;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiDaily.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiDaily.java
@@ -1,0 +1,92 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_agg_seller_kpi_daily",
+        indexes = {
+                @Index(
+                        name = "uk_analytics_agg_seller_kpi_daily_business_seller",
+                        columnList = "business_date,seller_id",
+                        unique = true
+                ),
+                @Index(name = "idx_analytics_agg_seller_kpi_daily_seller", columnList = "seller_id")
+        }
+)
+public class AnalyticsAggSellerKpiDaily extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "business_date", nullable = false)
+    private LocalDate businessDate;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount;
+
+    @Column(name = "cancel_count", nullable = false)
+    private Long cancelCount;
+
+    @Column(name = "refund_count", nullable = false)
+    private Long refundCount;
+
+    @Column(name = "gross_sales", nullable = false)
+    private Long grossSales;
+
+    @Column(name = "net_sales", nullable = false)
+    private Long netSales;
+
+    @Column(name = "search_count", nullable = false)
+    private Long searchCount;
+
+    @Column(name = "click_count", nullable = false)
+    private Long clickCount;
+
+    @Column(name = "ctr", nullable = false)
+    private Double ctr;
+
+    @Builder
+    private AnalyticsAggSellerKpiDaily(
+            LocalDate businessDate,
+            Long sellerId,
+            Long orderCount,
+            Long cancelCount,
+            Long refundCount,
+            Long grossSales,
+            Long netSales,
+            Long searchCount,
+            Long clickCount,
+            Double ctr
+    ) {
+        this.businessDate = businessDate;
+        this.sellerId = sellerId;
+        this.orderCount = orderCount;
+        this.cancelCount = cancelCount;
+        this.refundCount = refundCount;
+        this.grossSales = grossSales;
+        this.netSales = netSales;
+        this.searchCount = searchCount;
+        this.clickCount = clickCount;
+        this.ctr = ctr;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMinute.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMinute.java
@@ -1,0 +1,92 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_agg_seller_kpi_minute",
+        indexes = {
+                @Index(
+                        name = "uk_analytics_agg_seller_kpi_minute_bucket_seller",
+                        columnList = "bucket_minute,seller_id",
+                        unique = true
+                ),
+                @Index(name = "idx_analytics_agg_seller_kpi_minute_seller", columnList = "seller_id")
+        }
+)
+public class AnalyticsAggSellerKpiMinute extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "bucket_minute", nullable = false)
+    private LocalDateTime bucketMinute;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount;
+
+    @Column(name = "cancel_count", nullable = false)
+    private Long cancelCount;
+
+    @Column(name = "refund_count", nullable = false)
+    private Long refundCount;
+
+    @Column(name = "gross_sales", nullable = false)
+    private Long grossSales;
+
+    @Column(name = "net_sales", nullable = false)
+    private Long netSales;
+
+    @Column(name = "search_count", nullable = false)
+    private Long searchCount;
+
+    @Column(name = "click_count", nullable = false)
+    private Long clickCount;
+
+    @Column(name = "ctr", nullable = false)
+    private Double ctr;
+
+    @Builder
+    private AnalyticsAggSellerKpiMinute(
+            LocalDateTime bucketMinute,
+            Long sellerId,
+            Long orderCount,
+            Long cancelCount,
+            Long refundCount,
+            Long grossSales,
+            Long netSales,
+            Long searchCount,
+            Long clickCount,
+            Double ctr
+    ) {
+        this.bucketMinute = bucketMinute;
+        this.sellerId = sellerId;
+        this.orderCount = orderCount;
+        this.cancelCount = cancelCount;
+        this.refundCount = refundCount;
+        this.grossSales = grossSales;
+        this.netSales = netSales;
+        this.searchCount = searchCount;
+        this.clickCount = clickCount;
+        this.ctr = ctr;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMinute.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMinute.java
@@ -22,10 +22,11 @@ import java.time.LocalDateTime;
         name = "analytics_agg_seller_kpi_minute",
         indexes = {
                 @Index(
-                        name = "uk_analytics_agg_seller_kpi_minute_bucket_seller",
-                        columnList = "bucket_minute,seller_id",
+                        name = "uk_analytics_agg_seller_kpi_minute_bucket_store",
+                        columnList = "bucket_minute,store_id",
                         unique = true
                 ),
+                @Index(name = "idx_analytics_agg_seller_kpi_minute_store", columnList = "store_id"),
                 @Index(name = "idx_analytics_agg_seller_kpi_minute_seller", columnList = "seller_id")
         }
 )
@@ -37,6 +38,9 @@ public class AnalyticsAggSellerKpiMinute extends BaseEntity {
 
     @Column(name = "bucket_minute", nullable = false)
     private LocalDateTime bucketMinute;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -68,6 +72,7 @@ public class AnalyticsAggSellerKpiMinute extends BaseEntity {
     @Builder
     private AnalyticsAggSellerKpiMinute(
             LocalDateTime bucketMinute,
+            Long storeId,
             Long sellerId,
             Long orderCount,
             Long cancelCount,
@@ -79,6 +84,7 @@ public class AnalyticsAggSellerKpiMinute extends BaseEntity {
             Double ctr
     ) {
         this.bucketMinute = bucketMinute;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.orderCount = orderCount;
         this.cancelCount = cancelCount;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMonthly.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMonthly.java
@@ -20,10 +20,11 @@ import lombok.NoArgsConstructor;
         name = "analytics_agg_seller_kpi_monthly",
         indexes = {
                 @Index(
-                        name = "uk_analytics_agg_seller_kpi_monthly_business_seller",
-                        columnList = "business_month,seller_id",
+                        name = "uk_analytics_agg_seller_kpi_monthly_business_store",
+                        columnList = "business_month,store_id",
                         unique = true
                 ),
+                @Index(name = "idx_analytics_agg_seller_kpi_monthly_store", columnList = "store_id"),
                 @Index(name = "idx_analytics_agg_seller_kpi_monthly_seller", columnList = "seller_id")
         }
 )
@@ -35,6 +36,9 @@ public class AnalyticsAggSellerKpiMonthly extends BaseEntity {
 
     @Column(name = "business_month", nullable = false, length = 7)
     private String businessMonth;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -66,6 +70,7 @@ public class AnalyticsAggSellerKpiMonthly extends BaseEntity {
     @Builder
     private AnalyticsAggSellerKpiMonthly(
             String businessMonth,
+            Long storeId,
             Long sellerId,
             Long orderCount,
             Long cancelCount,
@@ -77,6 +82,7 @@ public class AnalyticsAggSellerKpiMonthly extends BaseEntity {
             Double ctr
     ) {
         this.businessMonth = businessMonth;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.orderCount = orderCount;
         this.cancelCount = cancelCount;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMonthly.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsAggSellerKpiMonthly.java
@@ -1,0 +1,90 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_agg_seller_kpi_monthly",
+        indexes = {
+                @Index(
+                        name = "uk_analytics_agg_seller_kpi_monthly_business_seller",
+                        columnList = "business_month,seller_id",
+                        unique = true
+                ),
+                @Index(name = "idx_analytics_agg_seller_kpi_monthly_seller", columnList = "seller_id")
+        }
+)
+public class AnalyticsAggSellerKpiMonthly extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "business_month", nullable = false, length = 7)
+    private String businessMonth;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount;
+
+    @Column(name = "cancel_count", nullable = false)
+    private Long cancelCount;
+
+    @Column(name = "refund_count", nullable = false)
+    private Long refundCount;
+
+    @Column(name = "gross_sales", nullable = false)
+    private Long grossSales;
+
+    @Column(name = "net_sales", nullable = false)
+    private Long netSales;
+
+    @Column(name = "search_count", nullable = false)
+    private Long searchCount;
+
+    @Column(name = "click_count", nullable = false)
+    private Long clickCount;
+
+    @Column(name = "ctr", nullable = false)
+    private Double ctr;
+
+    @Builder
+    private AnalyticsAggSellerKpiMonthly(
+            String businessMonth,
+            Long sellerId,
+            Long orderCount,
+            Long cancelCount,
+            Long refundCount,
+            Long grossSales,
+            Long netSales,
+            Long searchCount,
+            Long clickCount,
+            Double ctr
+    ) {
+        this.businessMonth = businessMonth;
+        this.sellerId = sellerId;
+        this.orderCount = orderCount;
+        this.cancelCount = cancelCount;
+        this.refundCount = refundCount;
+        this.grossSales = grossSales;
+        this.netSales = netSales;
+        this.searchCount = searchCount;
+        this.clickCount = clickCount;
+        this.ctr = ctr;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
@@ -73,12 +73,14 @@ public class AnalyticsDimItemSnapshot extends BaseEntity {
     }
 
     public void updateSnapshot(Long storeId,
+                               Long sellerId,
                                String itemType,
                                String itemStatus,
                                Long price,
                                Long stockQuantity,
                                LocalDateTime snapshotAt) {
         this.storeId = storeId;
+        this.sellerId = sellerId;
         this.itemType = itemType;
         this.itemStatus = itemStatus;
         this.price = price;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "analytics_dim_item_snapshot",
         indexes = {
+                @Index(name = "idx_analytics_dim_item_snapshot_store", columnList = "store_id"),
                 @Index(name = "idx_analytics_dim_item_snapshot_seller", columnList = "seller_id"),
                 @Index(name = "idx_analytics_dim_item_snapshot_status", columnList = "item_status")
         }
@@ -28,6 +29,9 @@ public class AnalyticsDimItemSnapshot extends BaseEntity {
     @Id
     @Column(name = "item_id")
     private Long itemId;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -50,6 +54,7 @@ public class AnalyticsDimItemSnapshot extends BaseEntity {
     @Builder
     private AnalyticsDimItemSnapshot(
             Long itemId,
+            Long storeId,
             Long sellerId,
             String itemType,
             String itemStatus,
@@ -58,6 +63,7 @@ public class AnalyticsDimItemSnapshot extends BaseEntity {
             LocalDateTime snapshotAt
     ) {
         this.itemId = itemId;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.itemType = itemType;
         this.itemStatus = itemStatus;
@@ -66,11 +72,13 @@ public class AnalyticsDimItemSnapshot extends BaseEntity {
         this.snapshotAt = snapshotAt;
     }
 
-    public void updateSnapshot(String itemType,
+    public void updateSnapshot(Long storeId,
+                               String itemType,
                                String itemStatus,
                                Long price,
                                Long stockQuantity,
                                LocalDateTime snapshotAt) {
+        this.storeId = storeId;
         this.itemType = itemType;
         this.itemStatus = itemStatus;
         this.price = price;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsDimItemSnapshot.java
@@ -1,0 +1,80 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_dim_item_snapshot",
+        indexes = {
+                @Index(name = "idx_analytics_dim_item_snapshot_seller", columnList = "seller_id"),
+                @Index(name = "idx_analytics_dim_item_snapshot_status", columnList = "item_status")
+        }
+)
+public class AnalyticsDimItemSnapshot extends BaseEntity {
+
+    @Id
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "item_type", nullable = false, length = 30)
+    private String itemType;
+
+    @Column(name = "item_status", nullable = false, length = 30)
+    private String itemStatus;
+
+    @Column(name = "price")
+    private Long price;
+
+    @Column(name = "stock_quantity")
+    private Long stockQuantity;
+
+    @Column(name = "snapshot_at", nullable = false)
+    private LocalDateTime snapshotAt;
+
+    @Builder
+    private AnalyticsDimItemSnapshot(
+            Long itemId,
+            Long sellerId,
+            String itemType,
+            String itemStatus,
+            Long price,
+            Long stockQuantity,
+            LocalDateTime snapshotAt
+    ) {
+        this.itemId = itemId;
+        this.sellerId = sellerId;
+        this.itemType = itemType;
+        this.itemStatus = itemStatus;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.snapshotAt = snapshotAt;
+    }
+
+    public void updateSnapshot(String itemType,
+                               String itemStatus,
+                               Long price,
+                               Long stockQuantity,
+                               LocalDateTime snapshotAt) {
+        this.itemType = itemType;
+        this.itemStatus = itemStatus;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.snapshotAt = snapshotAt;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSalesEvent.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSalesEvent.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
         name = "analytics_raw_sales_event",
         indexes = {
                 @Index(name = "idx_analytics_raw_sales_event_event_id", columnList = "event_id", unique = true),
+                @Index(name = "idx_analytics_raw_sales_event_store_occurred", columnList = "store_id,occurred_at"),
                 @Index(name = "idx_analytics_raw_sales_event_seller_occurred", columnList = "seller_id,occurred_at")
         }
 )
@@ -36,6 +37,9 @@ public class AnalyticsRawSalesEvent extends BaseEntity {
 
     @Column(name = "event_type", nullable = false, length = 40)
     private String eventType;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
@@ -68,6 +72,7 @@ public class AnalyticsRawSalesEvent extends BaseEntity {
     private AnalyticsRawSalesEvent(
             String eventId,
             String eventType,
+            Long storeId,
             Long sellerId,
             Long itemId,
             Long orderId,
@@ -80,6 +85,7 @@ public class AnalyticsRawSalesEvent extends BaseEntity {
     ) {
         this.eventId = eventId;
         this.eventType = eventType;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.itemId = itemId;
         this.orderId = orderId;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSalesEvent.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSalesEvent.java
@@ -1,0 +1,93 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_raw_sales_event",
+        indexes = {
+                @Index(name = "idx_analytics_raw_sales_event_event_id", columnList = "event_id", unique = true),
+                @Index(name = "idx_analytics_raw_sales_event_seller_occurred", columnList = "seller_id,occurred_at")
+        }
+)
+public class AnalyticsRawSalesEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 120)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 40)
+    private String eventType;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @Column(name = "purchase_id")
+    private Long purchaseId;
+
+    @Column(name = "quantity")
+    private Integer quantity;
+
+    @Column(name = "gross_amount")
+    private Long grossAmount;
+
+    @Column(name = "net_amount")
+    private Long netAmount;
+
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+
+    @Column(name = "ingested_at", nullable = false)
+    private LocalDateTime ingestedAt;
+
+    @Builder
+    private AnalyticsRawSalesEvent(
+            String eventId,
+            String eventType,
+            Long sellerId,
+            Long itemId,
+            Long orderId,
+            Long purchaseId,
+            Integer quantity,
+            Long grossAmount,
+            Long netAmount,
+            LocalDateTime occurredAt,
+            LocalDateTime ingestedAt
+    ) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.sellerId = sellerId;
+        this.itemId = itemId;
+        this.orderId = orderId;
+        this.purchaseId = purchaseId;
+        this.quantity = quantity;
+        this.grossAmount = grossAmount;
+        this.netAmount = netAmount;
+        this.occurredAt = occurredAt;
+        this.ingestedAt = ingestedAt;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSearchEvent.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSearchEvent.java
@@ -1,0 +1,79 @@
+package com.example.analyticsdashboard.entity;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "analytics_raw_search_event",
+        indexes = {
+                @Index(name = "idx_analytics_raw_search_event_event_id", columnList = "event_id", unique = true),
+                @Index(name = "idx_analytics_raw_search_event_seller_occurred", columnList = "seller_id,occurred_at"),
+                @Index(name = "idx_analytics_raw_search_event_item_occurred", columnList = "item_id,occurred_at")
+        }
+)
+public class AnalyticsRawSearchEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 120)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 40)
+    private String eventType;
+
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "query_hash", length = 128)
+    private String queryHash;
+
+    @Column(name = "session_id", length = 120)
+    private String sessionId;
+
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+
+    @Column(name = "ingested_at", nullable = false)
+    private LocalDateTime ingestedAt;
+
+    @Builder
+    private AnalyticsRawSearchEvent(
+            String eventId,
+            String eventType,
+            Long sellerId,
+            Long itemId,
+            String queryHash,
+            String sessionId,
+            LocalDateTime occurredAt,
+            LocalDateTime ingestedAt
+    ) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.sellerId = sellerId;
+        this.itemId = itemId;
+        this.queryHash = queryHash;
+        this.sessionId = sessionId;
+        this.occurredAt = occurredAt;
+        this.ingestedAt = ingestedAt;
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSearchEvent.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/entity/AnalyticsRawSearchEvent.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
         name = "analytics_raw_search_event",
         indexes = {
                 @Index(name = "idx_analytics_raw_search_event_event_id", columnList = "event_id", unique = true),
+                @Index(name = "idx_analytics_raw_search_event_store_occurred", columnList = "store_id,occurred_at"),
                 @Index(name = "idx_analytics_raw_search_event_seller_occurred", columnList = "seller_id,occurred_at"),
                 @Index(name = "idx_analytics_raw_search_event_item_occurred", columnList = "item_id,occurred_at")
         }
@@ -37,6 +38,9 @@ public class AnalyticsRawSearchEvent extends BaseEntity {
 
     @Column(name = "event_type", nullable = false, length = 40)
     private String eventType;
+
+    @Column(name = "store_id")
+    private Long storeId;
 
     @Column(name = "seller_id")
     private Long sellerId;
@@ -60,6 +64,7 @@ public class AnalyticsRawSearchEvent extends BaseEntity {
     private AnalyticsRawSearchEvent(
             String eventId,
             String eventType,
+            Long storeId,
             Long sellerId,
             Long itemId,
             String queryHash,
@@ -69,6 +74,7 @@ public class AnalyticsRawSearchEvent extends BaseEntity {
     ) {
         this.eventId = eventId;
         this.eventType = eventType;
+        this.storeId = storeId;
         this.sellerId = sellerId;
         this.itemId = itemId;
         this.queryHash = queryHash;

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/exception/AnalyticsDashboardErrorCode.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/exception/AnalyticsDashboardErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.analyticsdashboard.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AnalyticsDashboardErrorCode implements DomainErrorCode {
+
+    INVALID_DASHBOARD_QUERY_PARAMETER("ANALYTICS-001", "대시보드 조회 파라미터가 유효하지 않습니다", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiDailyRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiDailyRepository.java
@@ -1,0 +1,19 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsAggSellerKpiDaily;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface AnalyticsAggSellerKpiDailyRepository extends JpaRepository<AnalyticsAggSellerKpiDaily, Long> {
+
+    Optional<AnalyticsAggSellerKpiDaily> findBySellerIdAndBusinessDate(Long sellerId, LocalDate businessDate);
+
+    List<AnalyticsAggSellerKpiDaily> findBySellerIdAndBusinessDateBetweenOrderByBusinessDateAsc(
+            Long sellerId,
+            LocalDate from,
+            LocalDate to
+    );
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiDailyRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiDailyRepository.java
@@ -9,6 +9,14 @@ import java.util.Optional;
 
 public interface AnalyticsAggSellerKpiDailyRepository extends JpaRepository<AnalyticsAggSellerKpiDaily, Long> {
 
+    Optional<AnalyticsAggSellerKpiDaily> findByStoreIdAndBusinessDate(Long storeId, LocalDate businessDate);
+
+    List<AnalyticsAggSellerKpiDaily> findByStoreIdAndBusinessDateBetweenOrderByBusinessDateAsc(
+            Long storeId,
+            LocalDate from,
+            LocalDate to
+    );
+
     Optional<AnalyticsAggSellerKpiDaily> findBySellerIdAndBusinessDate(Long sellerId, LocalDate businessDate);
 
     List<AnalyticsAggSellerKpiDaily> findBySellerIdAndBusinessDateBetweenOrderByBusinessDateAsc(

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMinuteRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMinuteRepository.java
@@ -3,5 +3,17 @@ package com.example.analyticsdashboard.repository;
 import com.example.analyticsdashboard.entity.AnalyticsAggSellerKpiMinute;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 public interface AnalyticsAggSellerKpiMinuteRepository extends JpaRepository<AnalyticsAggSellerKpiMinute, Long> {
+
+    Optional<AnalyticsAggSellerKpiMinute> findByStoreIdAndBucketMinute(Long storeId, LocalDateTime bucketMinute);
+
+    List<AnalyticsAggSellerKpiMinute> findByStoreIdAndBucketMinuteBetweenOrderByBucketMinuteAsc(
+            Long storeId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMinuteRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMinuteRepository.java
@@ -1,0 +1,7 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsAggSellerKpiMinute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalyticsAggSellerKpiMinuteRepository extends JpaRepository<AnalyticsAggSellerKpiMinute, Long> {
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMonthlyRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMonthlyRepository.java
@@ -8,6 +8,14 @@ import java.util.Optional;
 
 public interface AnalyticsAggSellerKpiMonthlyRepository extends JpaRepository<AnalyticsAggSellerKpiMonthly, Long> {
 
+    Optional<AnalyticsAggSellerKpiMonthly> findByStoreIdAndBusinessMonth(Long storeId, String businessMonth);
+
+    List<AnalyticsAggSellerKpiMonthly> findByStoreIdAndBusinessMonthBetweenOrderByBusinessMonthAsc(
+            Long storeId,
+            String fromMonth,
+            String toMonth
+    );
+
     Optional<AnalyticsAggSellerKpiMonthly> findBySellerIdAndBusinessMonth(Long sellerId, String businessMonth);
 
     List<AnalyticsAggSellerKpiMonthly> findBySellerIdAndBusinessMonthBetweenOrderByBusinessMonthAsc(

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMonthlyRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsAggSellerKpiMonthlyRepository.java
@@ -1,0 +1,18 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsAggSellerKpiMonthly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AnalyticsAggSellerKpiMonthlyRepository extends JpaRepository<AnalyticsAggSellerKpiMonthly, Long> {
+
+    Optional<AnalyticsAggSellerKpiMonthly> findBySellerIdAndBusinessMonth(Long sellerId, String businessMonth);
+
+    List<AnalyticsAggSellerKpiMonthly> findBySellerIdAndBusinessMonthBetweenOrderByBusinessMonthAsc(
+            Long sellerId,
+            String fromMonth,
+            String toMonth
+    );
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
@@ -1,0 +1,11 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsDimItemSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnalyticsDimItemSnapshotRepository extends JpaRepository<AnalyticsDimItemSnapshot, Long> {
+
+    List<AnalyticsDimItemSnapshot> findBySellerId(Long sellerId);
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 
 public interface AnalyticsDimItemSnapshotRepository extends JpaRepository<AnalyticsDimItemSnapshot, Long> {
 
+    List<AnalyticsDimItemSnapshot> findByStoreId(Long storeId);
+
     List<AnalyticsDimItemSnapshot> findBySellerId(Long sellerId);
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
@@ -1,0 +1,11 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnalyticsRawSalesEventRepository extends JpaRepository<AnalyticsRawSalesEvent, Long> {
+
+    Optional<AnalyticsRawSalesEvent> findByEventId(String eventId);
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
@@ -11,6 +11,8 @@ public interface AnalyticsRawSalesEventRepository extends JpaRepository<Analytic
 
     Optional<AnalyticsRawSalesEvent> findByEventId(String eventId);
 
+    Optional<AnalyticsRawSalesEvent> findTopByPurchaseIdOrderByOccurredAtDesc(Long purchaseId);
+
     List<AnalyticsRawSalesEvent> findByStoreIdAndOccurredAtBetween(
             Long storeId,
             LocalDateTime from,

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
@@ -3,9 +3,17 @@ package com.example.analyticsdashboard.repository;
 import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AnalyticsRawSalesEventRepository extends JpaRepository<AnalyticsRawSalesEvent, Long> {
 
     Optional<AnalyticsRawSalesEvent> findByEventId(String eventId);
+
+    List<AnalyticsRawSalesEvent> findByStoreIdAndOccurredAtBetween(
+            Long storeId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
@@ -1,0 +1,11 @@
+package com.example.analyticsdashboard.repository;
+
+import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnalyticsRawSearchEventRepository extends JpaRepository<AnalyticsRawSearchEvent, Long> {
+
+    Optional<AnalyticsRawSearchEvent> findByEventId(String eventId);
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
@@ -3,9 +3,17 @@ package com.example.analyticsdashboard.repository;
 import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AnalyticsRawSearchEventRepository extends JpaRepository<AnalyticsRawSearchEvent, Long> {
 
     Optional<AnalyticsRawSearchEvent> findByEventId(String eventId);
+
+    List<AnalyticsRawSearchEvent> findByStoreIdAndOccurredAtBetween(
+            Long storeId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/ingest/AnalyticsEventIngestService.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/ingest/AnalyticsEventIngestService.java
@@ -1,0 +1,302 @@
+package com.example.analyticsdashboard.service.ingest;
+
+import com.example.analyticsdashboard.consumer.AnalyticsItemEventMessage;
+import com.example.analyticsdashboard.consumer.AnalyticsSalesEventMessage;
+import com.example.analyticsdashboard.consumer.AnalyticsSearchEventMessage;
+import com.example.analyticsdashboard.entity.AnalyticsDimItemSnapshot;
+import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
+import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
+import com.example.analyticsdashboard.repository.AnalyticsDimItemSnapshotRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSalesEventRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSearchEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsEventIngestService {
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+    private static final String ITEM_STATUS_DELETED = "DELETED";
+    private static final String ITEM_TYPE_UNKNOWN = "UNKNOWN";
+
+    private final AnalyticsDimItemSnapshotRepository dimItemSnapshotRepository;
+    private final AnalyticsRawSalesEventRepository rawSalesEventRepository;
+    private final AnalyticsRawSearchEventRepository rawSearchEventRepository;
+
+    @Transactional
+    public void ingestItemEvent(AnalyticsItemEventMessage event) {
+        if (event == null || event.getItemId() == null) {
+            return;
+        }
+
+        String eventType = normalize(event.getEventType());
+        switch (eventType) {
+            case "ITEM_CREATED" -> handleItemCreated(event);
+            case "ITEM_UPDATED" -> handleItemUpdated(event);
+            case "ITEM_STATUS_CHANGED" -> handleItemStatusChanged(event);
+            case "ITEM_DELETED" -> handleItemDeleted(event);
+            default -> log.debug("[AnalyticsIngest] skip unsupported item eventType={}", event.getEventType());
+        }
+    }
+
+    @Transactional
+    public void ingestSalesEvent(AnalyticsSalesEventMessage event) {
+        if (event == null || event.getEventId() == null || event.getEventType() == null) {
+            return;
+        }
+
+        String eventType = normalize(event.getEventType());
+        Ownership ownership = resolveOwnership(event);
+        if (!ownership.resolved()) {
+            log.warn("[AnalyticsIngest] sales ownership unresolved. eventId={}, eventType={}, purchaseId={}, itemId={}",
+                    event.getEventId(),
+                    eventType,
+                    event.getPurchaseId(),
+                    event.getItemId());
+            return;
+        }
+
+        Long signedNetAmount = resolveSignedNetAmount(event, eventType, ownership.referenceTotalAmount());
+        Long grossAmount = "PURCHASE_CREATED".equals(eventType) ? nullToZero(event.getTotalAmount()) : 0L;
+
+        AnalyticsRawSalesEvent rawEvent = AnalyticsRawSalesEvent.builder()
+                .eventId(event.getEventId())
+                .eventType(eventType)
+                .storeId(ownership.storeId())
+                .sellerId(ownership.sellerId())
+                .itemId(ownership.itemId())
+                .orderId(event.getOrderId())
+                .purchaseId(event.getPurchaseId())
+                .quantity(event.getQuantity())
+                .grossAmount(grossAmount)
+                .netAmount(signedNetAmount)
+                .occurredAt(parseOccurredAt(event.getOccurredAt()))
+                .ingestedAt(LocalDateTime.now())
+                .build();
+        rawSalesEventRepository.save(rawEvent);
+    }
+
+    @Transactional
+    public void ingestSearchEvent(AnalyticsSearchEventMessage event) {
+        if (event == null || event.getEventId() == null || event.getEventType() == null) {
+            return;
+        }
+
+        Long resolvedItemId = event.getItemId();
+        Long resolvedStoreId = event.getStoreId();
+        Long resolvedSellerId = event.getSellerId();
+
+        if ((resolvedStoreId == null || resolvedSellerId == null) && resolvedItemId != null) {
+            Optional<AnalyticsDimItemSnapshot> snapshot = dimItemSnapshotRepository.findById(resolvedItemId);
+            if (snapshot.isPresent()) {
+                AnalyticsDimItemSnapshot itemSnapshot = snapshot.get();
+                if (resolvedStoreId == null) {
+                    resolvedStoreId = itemSnapshot.getStoreId();
+                }
+                if (resolvedSellerId == null) {
+                    resolvedSellerId = itemSnapshot.getSellerId();
+                }
+            }
+        }
+
+        AnalyticsRawSearchEvent rawEvent = AnalyticsRawSearchEvent.builder()
+                .eventId(event.getEventId())
+                .eventType(normalize(event.getEventType()))
+                .storeId(resolvedStoreId)
+                .sellerId(resolvedSellerId)
+                .itemId(resolvedItemId)
+                .queryHash(event.getQueryHash())
+                .sessionId(event.getSessionId())
+                .occurredAt(parseOccurredAt(event.getOccurredAt()))
+                .ingestedAt(LocalDateTime.now())
+                .build();
+        rawSearchEventRepository.save(rawEvent);
+    }
+
+    private void handleItemCreated(AnalyticsItemEventMessage event) {
+        Long storeId = event.getStoreId();
+        Long sellerId = event.getSellerId();
+        if (storeId == null || sellerId == null) {
+            log.warn("[AnalyticsIngest] skip ITEM_CREATED due to missing ownership. itemId={}, storeId={}, sellerId={}",
+                    event.getItemId(),
+                    storeId,
+                    sellerId);
+            return;
+        }
+
+        Optional<AnalyticsDimItemSnapshot> snapshot = dimItemSnapshotRepository.findById(event.getItemId());
+        if (snapshot.isPresent()) {
+            AnalyticsDimItemSnapshot existing = snapshot.get();
+            existing.updateSnapshot(
+                    storeId,
+                    sellerId,
+                    defaultIfBlank(event.getItemType(), ITEM_TYPE_UNKNOWN),
+                    resolveItemStatus(event),
+                    event.getPrice(),
+                    existing.getStockQuantity(),
+                    LocalDateTime.now()
+            );
+            dimItemSnapshotRepository.save(existing);
+            return;
+        }
+
+        dimItemSnapshotRepository.save(
+                AnalyticsDimItemSnapshot.builder()
+                        .itemId(event.getItemId())
+                        .storeId(storeId)
+                        .sellerId(sellerId)
+                        .itemType(defaultIfBlank(event.getItemType(), ITEM_TYPE_UNKNOWN))
+                        .itemStatus(resolveItemStatus(event))
+                        .price(event.getPrice())
+                        .stockQuantity(null)
+                        .snapshotAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+
+    private void handleItemUpdated(AnalyticsItemEventMessage event) {
+        dimItemSnapshotRepository.findById(event.getItemId()).ifPresent(snapshot -> {
+            snapshot.updateSnapshot(
+                    snapshot.getStoreId(),
+                    snapshot.getSellerId(),
+                    defaultIfBlank(snapshot.getItemType(), ITEM_TYPE_UNKNOWN),
+                    defaultIfBlank(snapshot.getItemStatus(), "DRAFT"),
+                    event.getPrice() != null ? event.getPrice() : snapshot.getPrice(),
+                    snapshot.getStockQuantity(),
+                    LocalDateTime.now()
+            );
+            dimItemSnapshotRepository.save(snapshot);
+        });
+    }
+
+    private void handleItemStatusChanged(AnalyticsItemEventMessage event) {
+        dimItemSnapshotRepository.findById(event.getItemId()).ifPresent(snapshot -> {
+            snapshot.updateSnapshot(
+                    snapshot.getStoreId(),
+                    snapshot.getSellerId(),
+                    defaultIfBlank(snapshot.getItemType(), ITEM_TYPE_UNKNOWN),
+                    defaultIfBlank(event.getNewStatus(), defaultIfBlank(event.getStatus(), snapshot.getItemStatus())),
+                    snapshot.getPrice(),
+                    snapshot.getStockQuantity(),
+                    LocalDateTime.now()
+            );
+            dimItemSnapshotRepository.save(snapshot);
+        });
+    }
+
+    private void handleItemDeleted(AnalyticsItemEventMessage event) {
+        dimItemSnapshotRepository.findById(event.getItemId()).ifPresent(snapshot -> {
+            snapshot.updateSnapshot(
+                    snapshot.getStoreId(),
+                    snapshot.getSellerId(),
+                    defaultIfBlank(snapshot.getItemType(), ITEM_TYPE_UNKNOWN),
+                    ITEM_STATUS_DELETED,
+                    snapshot.getPrice(),
+                    snapshot.getStockQuantity(),
+                    LocalDateTime.now()
+            );
+            dimItemSnapshotRepository.save(snapshot);
+        });
+    }
+
+    private Ownership resolveOwnership(AnalyticsSalesEventMessage event) {
+        Long itemId = event.getItemId();
+        Long storeId = event.getStoreId();
+        Long sellerId = event.getSellerId();
+        Long referenceAmount = event.getTotalAmount();
+
+        if ((storeId == null || sellerId == null || itemId == null) && itemId != null) {
+            Optional<AnalyticsDimItemSnapshot> snapshot = dimItemSnapshotRepository.findById(itemId);
+            if (snapshot.isPresent()) {
+                AnalyticsDimItemSnapshot itemSnapshot = snapshot.get();
+                storeId = storeId == null ? itemSnapshot.getStoreId() : storeId;
+                sellerId = sellerId == null ? itemSnapshot.getSellerId() : sellerId;
+            }
+        }
+
+        if ((storeId == null || sellerId == null || itemId == null) && event.getPurchaseId() != null) {
+            Optional<AnalyticsRawSalesEvent> previous = rawSalesEventRepository
+                    .findTopByPurchaseIdOrderByOccurredAtDesc(event.getPurchaseId());
+            if (previous.isPresent()) {
+                AnalyticsRawSalesEvent raw = previous.get();
+                itemId = itemId == null ? raw.getItemId() : itemId;
+                storeId = storeId == null ? raw.getStoreId() : storeId;
+                sellerId = sellerId == null ? raw.getSellerId() : sellerId;
+                referenceAmount = referenceAmount == null ? raw.getGrossAmount() : referenceAmount;
+            }
+        }
+
+        return new Ownership(itemId, storeId, sellerId, referenceAmount);
+    }
+
+    private Long resolveSignedNetAmount(AnalyticsSalesEventMessage event, String eventType, Long fallbackAmount) {
+        Long amount = event.getTotalAmount() != null ? event.getTotalAmount() : fallbackAmount;
+        if (amount == null) {
+            return null;
+        }
+        long absolute = Math.abs(amount);
+        return "PURCHASE_CREATED".equals(eventType) ? absolute : -absolute;
+    }
+
+    private LocalDateTime parseOccurredAt(String rawOccurredAt) {
+        if (rawOccurredAt == null || rawOccurredAt.isBlank()) {
+            return LocalDateTime.now();
+        }
+        try {
+            return LocalDateTime.parse(rawOccurredAt);
+        } catch (DateTimeParseException ignored) {
+        }
+        try {
+            return OffsetDateTime.parse(rawOccurredAt).toLocalDateTime();
+        } catch (DateTimeParseException ignored) {
+        }
+        try {
+            return Instant.parse(rawOccurredAt).atZone(DEFAULT_ZONE).toLocalDateTime();
+        } catch (DateTimeParseException ignored) {
+        }
+        return LocalDateTime.now();
+    }
+
+    private String resolveItemStatus(AnalyticsItemEventMessage event) {
+        if (event.getStatus() != null && !event.getStatus().isBlank()) {
+            return event.getStatus();
+        }
+        if (event.getNewStatus() != null && !event.getNewStatus().isBlank()) {
+            return event.getNewStatus();
+        }
+        return "DRAFT";
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String defaultIfBlank(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value;
+    }
+
+    private Long nullToZero(Long value) {
+        return value == null ? 0L : value;
+    }
+
+    private record Ownership(Long itemId, Long storeId, Long sellerId, Long referenceTotalAmount) {
+        private boolean resolved() {
+            return itemId != null && storeId != null && sellerId != null;
+        }
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
@@ -10,24 +10,39 @@ import com.example.analyticsdashboard.dto.response.SellerDashboardQueryRangeResp
 import com.example.analyticsdashboard.dto.response.SellerDashboardSalesKpiResponse;
 import com.example.analyticsdashboard.dto.response.SellerDashboardSearchKpiResponse;
 import com.example.analyticsdashboard.dto.response.SellerDashboardSeriesPointResponse;
+import com.example.analyticsdashboard.entity.AnalyticsDimItemSnapshot;
+import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
+import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
 import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.analyticsdashboard.repository.AnalyticsDimItemSnapshotRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSalesEventRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSearchEventRepository;
 import com.example.core.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SellerDashboardOverviewQueryService {
 
     private static final String API_VERSION = "v1";
+
+    private final AnalyticsRawSalesEventRepository rawSalesEventRepository;
+    private final AnalyticsRawSearchEventRepository rawSearchEventRepository;
+    private final AnalyticsDimItemSnapshotRepository dimItemSnapshotRepository;
 
     public SellerDashboardOverviewResponse getOverview(Long sellerId, SellerDashboardOverviewQuery query) {
         return getOverviewByStore(sellerId, sellerId, query);
@@ -43,8 +58,27 @@ public class SellerDashboardOverviewQueryService {
             );
         }
 
-        SellerDashboardQueryRangeResponse queryRange = toQueryRange(query);
-        List<SellerDashboardSeriesPointResponse> series = buildEmptySeries(query, queryRange);
+        QueryRangeContext queryRangeContext = resolveRange(query);
+        SellerDashboardQueryRangeResponse queryRange = toQueryRange(queryRangeContext, query.timezone().getId());
+
+        List<AnalyticsRawSalesEvent> rawSalesEvents = rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(
+                storeId,
+                queryRangeContext.fromDateTime(),
+                queryRangeContext.toDateTime()
+        );
+        List<AnalyticsRawSearchEvent> rawSearchEvents = rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(
+                storeId,
+                queryRangeContext.fromDateTime(),
+                queryRangeContext.toDateTime()
+        );
+        List<AnalyticsDimItemSnapshot> itemSnapshots = dimItemSnapshotRepository.findByStoreId(storeId);
+
+        SellerDashboardSalesKpiResponse sales = toSalesKpi(rawSalesEvents);
+        SellerDashboardSearchKpiResponse search = toSearchKpi(rawSearchEvents);
+        SellerDashboardItemKpiResponse item = toItemKpi(itemSnapshots);
+        List<SellerDashboardSeriesPointResponse> series = toSeries(rawSalesEvents, queryRangeContext);
+        Instant asOf = resolveAsOf(rawSalesEvents, rawSearchEvents);
+
         Map<String, Object> extensions = new LinkedHashMap<>();
         extensions.put("funding", null);
         extensions.put("hotDeal", null);
@@ -54,86 +88,221 @@ public class SellerDashboardOverviewQueryService {
         return SellerDashboardOverviewResponse.builder()
                 .mode(query.mode())
                 .queryRange(queryRange)
-                .asOf(Instant.now())
+                .asOf(asOf)
                 .lagStatus(DashboardLagStatus.HEALTHY)
                 .partial(false)
-                .sales(SellerDashboardSalesKpiResponse.empty())
-                .item(SellerDashboardItemKpiResponse.empty())
-                .search(SellerDashboardSearchKpiResponse.empty())
+                .sales(sales)
+                .item(item)
+                .search(search)
                 .series(series)
                 .apiVersion(API_VERSION)
                 .extensions(extensions)
                 .build();
     }
 
-    private SellerDashboardQueryRangeResponse toQueryRange(SellerDashboardOverviewQuery query) {
-        return switch (query.mode()) {
-            case DAILY -> SellerDashboardQueryRangeResponse.builder()
-                    .from(query.date().toString())
-                    .to(query.date().toString())
-                    .bucket(DashboardSeriesBucket.DAY.name())
-                    .timezone(query.timezone().getId())
-                    .build();
-            case MONTHLY -> {
-                LocalDate firstDay = query.yearMonth().atDay(1);
-                LocalDate lastDay = query.yearMonth().atEndOfMonth();
-                yield SellerDashboardQueryRangeResponse.builder()
-                        .from(firstDay.toString())
-                        .to(lastDay.toString())
-                        .bucket(DashboardSeriesBucket.MONTH.name())
-                        .timezone(query.timezone().getId())
-                        .build();
-            }
-            case RANGE -> SellerDashboardQueryRangeResponse.builder()
-                    .from(query.from().toString())
-                    .to(query.to().toString())
-                    .bucket(query.bucket().name())
-                    .timezone(query.timezone().getId())
-                    .build();
-        };
+    private SellerDashboardQueryRangeResponse toQueryRange(QueryRangeContext queryRangeContext, String timezone) {
+        return SellerDashboardQueryRangeResponse.builder()
+                .from(queryRangeContext.fromDate().toString())
+                .to(queryRangeContext.toDate().toString())
+                .bucket(queryRangeContext.bucket().name())
+                .timezone(timezone)
+                .build();
     }
 
-    private List<SellerDashboardSeriesPointResponse> buildEmptySeries(SellerDashboardOverviewQuery query,
-                                                                      SellerDashboardQueryRangeResponse queryRange) {
+    private QueryRangeContext resolveRange(SellerDashboardOverviewQuery query) {
         if (query.mode() == DashboardQueryMode.DAILY) {
-            return List.of(emptyPoint(queryRange.getFrom()));
+            LocalDate date = query.date();
+            return new QueryRangeContext(
+                    date,
+                    date,
+                    date.atStartOfDay(),
+                    date.atTime(23, 59, 59),
+                    DashboardSeriesBucket.DAY
+            );
         }
         if (query.mode() == DashboardQueryMode.MONTHLY) {
-            return List.of(emptyPoint(query.yearMonth().toString()));
+            LocalDate from = query.yearMonth().atDay(1);
+            LocalDate to = query.yearMonth().atEndOfMonth();
+            return new QueryRangeContext(
+                    from,
+                    to,
+                    from.atStartOfDay(),
+                    to.atTime(23, 59, 59),
+                    DashboardSeriesBucket.MONTH
+            );
         }
-        if (query.bucket() == DashboardSeriesBucket.MONTH) {
-            return buildMonthlySeries(query.from(), query.to());
-        }
-        return buildDailySeries(query.from(), query.to());
+        return new QueryRangeContext(
+                query.from(),
+                query.to(),
+                query.from().atStartOfDay(),
+                query.to().atTime(23, 59, 59),
+                query.bucket()
+        );
     }
 
-    private List<SellerDashboardSeriesPointResponse> buildDailySeries(LocalDate from, LocalDate to) {
+    private SellerDashboardSalesKpiResponse toSalesKpi(List<AnalyticsRawSalesEvent> rawSalesEvents) {
+        long grossSales = 0L;
+        long netSales = 0L;
+        long orderCount = 0L;
+        long cancelCount = 0L;
+        long refundCount = 0L;
+
+        for (AnalyticsRawSalesEvent event : rawSalesEvents) {
+            grossSales += nullSafeLong(event.getGrossAmount());
+            netSales += nullSafeLong(event.getNetAmount());
+
+            String eventType = normalize(event.getEventType());
+            if ("PURCHASE_CREATED".equals(eventType)) {
+                orderCount++;
+            } else if ("PURCHASE_CANCELLED".equals(eventType)) {
+                cancelCount++;
+            } else if (eventType.contains("REFUND")) {
+                refundCount++;
+            }
+        }
+
+        return SellerDashboardSalesKpiResponse.builder()
+                .grossSales(grossSales)
+                .netSales(netSales)
+                .orderCount(orderCount)
+                .cancelCount(cancelCount)
+                .refundCount(refundCount)
+                .build();
+    }
+
+    private SellerDashboardSearchKpiResponse toSearchKpi(List<AnalyticsRawSearchEvent> rawSearchEvents) {
+        long searchCount = 0L;
+        long clickCount = 0L;
+
+        for (AnalyticsRawSearchEvent event : rawSearchEvents) {
+            String eventType = normalize(event.getEventType());
+            if ("SEARCH_EXECUTED".equals(eventType)) {
+                searchCount++;
+            } else if ("SEARCH_ITEM_CLICKED".equals(eventType)) {
+                clickCount++;
+            }
+        }
+
+        double ctr = searchCount == 0 ? 0.0d : (double) clickCount / (double) searchCount;
+        return SellerDashboardSearchKpiResponse.builder()
+                .searchCount(searchCount)
+                .clickCount(clickCount)
+                .ctr(ctr)
+                .build();
+    }
+
+    private SellerDashboardItemKpiResponse toItemKpi(List<AnalyticsDimItemSnapshot> itemSnapshots) {
+        long onSaleCount = 0L;
+        long soldOutCount = 0L;
+        long hiddenCount = 0L;
+
+        for (AnalyticsDimItemSnapshot snapshot : itemSnapshots) {
+            String status = normalize(snapshot.getItemStatus());
+            if ("ON_SALE".equals(status)) {
+                onSaleCount++;
+            } else if ("SOLD_OUT".equals(status)) {
+                soldOutCount++;
+            } else if ("HIDDEN".equals(status)) {
+                hiddenCount++;
+            }
+        }
+
+        return SellerDashboardItemKpiResponse.builder()
+                .onSaleCount(onSaleCount)
+                .soldOutCount(soldOutCount)
+                .hiddenCount(hiddenCount)
+                .build();
+    }
+
+    private List<SellerDashboardSeriesPointResponse> toSeries(List<AnalyticsRawSalesEvent> rawSalesEvents,
+                                                              QueryRangeContext queryRangeContext) {
+        Map<String, BucketSalesAggregate> aggregateMap = aggregateByBucket(rawSalesEvents, queryRangeContext.bucket());
+        List<String> buckets = buildBucketTimeline(queryRangeContext.fromDate(), queryRangeContext.toDate(), queryRangeContext.bucket());
         List<SellerDashboardSeriesPointResponse> series = new ArrayList<>();
+        for (String bucket : buckets) {
+            BucketSalesAggregate aggregate = aggregateMap.getOrDefault(bucket, BucketSalesAggregate.empty());
+            series.add(SellerDashboardSeriesPointResponse.builder()
+                    .bucketStart(bucket)
+                    .grossSales(aggregate.grossSales())
+                    .netSales(aggregate.netSales())
+                    .orderCount(aggregate.orderCount())
+                    .build());
+        }
+        return List.copyOf(series);
+    }
+
+    private Map<String, BucketSalesAggregate> aggregateByBucket(List<AnalyticsRawSalesEvent> rawSalesEvents,
+                                                                DashboardSeriesBucket bucket) {
+        Map<String, BucketSalesAggregate> aggregates = new HashMap<>();
+        for (AnalyticsRawSalesEvent event : rawSalesEvents) {
+            if (event.getOccurredAt() == null) {
+                continue;
+            }
+            String bucketKey = bucket == DashboardSeriesBucket.MONTH
+                    ? YearMonth.from(event.getOccurredAt()).toString()
+                    : event.getOccurredAt().toLocalDate().toString();
+
+            BucketSalesAggregate current = aggregates.getOrDefault(bucketKey, BucketSalesAggregate.empty());
+            long grossSales = current.grossSales() + nullSafeLong(event.getGrossAmount());
+            long netSales = current.netSales() + nullSafeLong(event.getNetAmount());
+            long orderCount = current.orderCount() + ("PURCHASE_CREATED".equals(normalize(event.getEventType())) ? 1L : 0L);
+            aggregates.put(bucketKey, new BucketSalesAggregate(grossSales, netSales, orderCount));
+        }
+        return aggregates;
+    }
+
+    private List<String> buildBucketTimeline(LocalDate from, LocalDate to, DashboardSeriesBucket bucket) {
+        List<String> buckets = new ArrayList<>();
+        if (bucket == DashboardSeriesBucket.MONTH) {
+            YearMonth cursor = YearMonth.from(from);
+            YearMonth end = YearMonth.from(to);
+            while (!cursor.isAfter(end)) {
+                buckets.add(cursor.toString());
+                cursor = cursor.plusMonths(1);
+            }
+            return List.copyOf(buckets);
+        }
+
         LocalDate cursor = from;
         while (!cursor.isAfter(to)) {
-            series.add(emptyPoint(cursor.toString()));
+            buckets.add(cursor.toString());
             cursor = cursor.plusDays(1);
         }
-        return List.copyOf(series);
+        return List.copyOf(buckets);
     }
 
-    private List<SellerDashboardSeriesPointResponse> buildMonthlySeries(LocalDate from, LocalDate to) {
-        List<SellerDashboardSeriesPointResponse> series = new ArrayList<>();
-        YearMonth cursor = YearMonth.from(from);
-        YearMonth end = YearMonth.from(to);
-        while (!cursor.isAfter(end)) {
-            series.add(emptyPoint(cursor.toString()));
-            cursor = cursor.plusMonths(1);
+    private Instant resolveAsOf(List<AnalyticsRawSalesEvent> salesEvents,
+                                List<AnalyticsRawSearchEvent> searchEvents) {
+        LocalDateTime latest = Stream.concat(
+                        salesEvents.stream().map(AnalyticsRawSalesEvent::getIngestedAt),
+                        searchEvents.stream().map(AnalyticsRawSearchEvent::getIngestedAt)
+                )
+                .filter(value -> value != null)
+                .max(LocalDateTime::compareTo)
+                .orElse(LocalDateTime.now());
+        return latest.atZone(java.time.ZoneId.of("Asia/Seoul")).toInstant();
+    }
+
+    private long nullSafeLong(Long value) {
+        return value == null ? 0L : value;
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toUpperCase(java.util.Locale.ROOT);
+    }
+
+    private record QueryRangeContext(
+            LocalDate fromDate,
+            LocalDate toDate,
+            LocalDateTime fromDateTime,
+            LocalDateTime toDateTime,
+            DashboardSeriesBucket bucket
+    ) {
+    }
+
+    private record BucketSalesAggregate(long grossSales, long netSales, long orderCount) {
+        private static BucketSalesAggregate empty() {
+            return new BucketSalesAggregate(0L, 0L, 0L);
         }
-        return List.copyOf(series);
-    }
-
-    private SellerDashboardSeriesPointResponse emptyPoint(String bucketStart) {
-        return SellerDashboardSeriesPointResponse.builder()
-                .bucketStart(bucketStart)
-                .grossSales(0L)
-                .netSales(0L)
-                .orderCount(0L)
-                .build();
     }
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
@@ -1,0 +1,133 @@
+package com.example.analyticsdashboard.service.query;
+
+import com.example.analyticsdashboard.dto.query.DashboardQueryMode;
+import com.example.analyticsdashboard.dto.query.DashboardSeriesBucket;
+import com.example.analyticsdashboard.dto.query.SellerDashboardOverviewQuery;
+import com.example.analyticsdashboard.dto.response.DashboardLagStatus;
+import com.example.analyticsdashboard.dto.response.SellerDashboardItemKpiResponse;
+import com.example.analyticsdashboard.dto.response.SellerDashboardOverviewResponse;
+import com.example.analyticsdashboard.dto.response.SellerDashboardQueryRangeResponse;
+import com.example.analyticsdashboard.dto.response.SellerDashboardSalesKpiResponse;
+import com.example.analyticsdashboard.dto.response.SellerDashboardSearchKpiResponse;
+import com.example.analyticsdashboard.dto.response.SellerDashboardSeriesPointResponse;
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class SellerDashboardOverviewQueryService {
+
+    private static final String API_VERSION = "v1";
+
+    public SellerDashboardOverviewResponse getOverview(Long sellerId, SellerDashboardOverviewQuery query) {
+        if (sellerId == null || sellerId <= 0) {
+            throw new BusinessException(
+                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
+                    "sellerId는 1 이상이어야 합니다."
+            );
+        }
+
+        SellerDashboardQueryRangeResponse queryRange = toQueryRange(query);
+        List<SellerDashboardSeriesPointResponse> series = buildEmptySeries(query, queryRange);
+        Map<String, Object> extensions = new LinkedHashMap<>();
+        extensions.put("funding", null);
+        extensions.put("hotDeal", null);
+        extensions.put("store", null);
+        extensions.put("review", null);
+
+        return SellerDashboardOverviewResponse.builder()
+                .mode(query.mode())
+                .queryRange(queryRange)
+                .asOf(Instant.now())
+                .lagStatus(DashboardLagStatus.HEALTHY)
+                .partial(false)
+                .sales(SellerDashboardSalesKpiResponse.empty())
+                .item(SellerDashboardItemKpiResponse.empty())
+                .search(SellerDashboardSearchKpiResponse.empty())
+                .series(series)
+                .apiVersion(API_VERSION)
+                .extensions(extensions)
+                .build();
+    }
+
+    private SellerDashboardQueryRangeResponse toQueryRange(SellerDashboardOverviewQuery query) {
+        return switch (query.mode()) {
+            case DAILY -> SellerDashboardQueryRangeResponse.builder()
+                    .from(query.date().toString())
+                    .to(query.date().toString())
+                    .bucket(DashboardSeriesBucket.DAY.name())
+                    .timezone(query.timezone().getId())
+                    .build();
+            case MONTHLY -> {
+                LocalDate firstDay = query.yearMonth().atDay(1);
+                LocalDate lastDay = query.yearMonth().atEndOfMonth();
+                yield SellerDashboardQueryRangeResponse.builder()
+                        .from(firstDay.toString())
+                        .to(lastDay.toString())
+                        .bucket(DashboardSeriesBucket.MONTH.name())
+                        .timezone(query.timezone().getId())
+                        .build();
+            }
+            case RANGE -> SellerDashboardQueryRangeResponse.builder()
+                    .from(query.from().toString())
+                    .to(query.to().toString())
+                    .bucket(query.bucket().name())
+                    .timezone(query.timezone().getId())
+                    .build();
+        };
+    }
+
+    private List<SellerDashboardSeriesPointResponse> buildEmptySeries(SellerDashboardOverviewQuery query,
+                                                                      SellerDashboardQueryRangeResponse queryRange) {
+        if (query.mode() == DashboardQueryMode.DAILY) {
+            return List.of(emptyPoint(queryRange.getFrom()));
+        }
+        if (query.mode() == DashboardQueryMode.MONTHLY) {
+            return List.of(emptyPoint(query.yearMonth().toString()));
+        }
+        if (query.bucket() == DashboardSeriesBucket.MONTH) {
+            return buildMonthlySeries(query.from(), query.to());
+        }
+        return buildDailySeries(query.from(), query.to());
+    }
+
+    private List<SellerDashboardSeriesPointResponse> buildDailySeries(LocalDate from, LocalDate to) {
+        List<SellerDashboardSeriesPointResponse> series = new ArrayList<>();
+        LocalDate cursor = from;
+        while (!cursor.isAfter(to)) {
+            series.add(emptyPoint(cursor.toString()));
+            cursor = cursor.plusDays(1);
+        }
+        return List.copyOf(series);
+    }
+
+    private List<SellerDashboardSeriesPointResponse> buildMonthlySeries(LocalDate from, LocalDate to) {
+        List<SellerDashboardSeriesPointResponse> series = new ArrayList<>();
+        YearMonth cursor = YearMonth.from(from);
+        YearMonth end = YearMonth.from(to);
+        while (!cursor.isAfter(end)) {
+            series.add(emptyPoint(cursor.toString()));
+            cursor = cursor.plusMonths(1);
+        }
+        return List.copyOf(series);
+    }
+
+    private SellerDashboardSeriesPointResponse emptyPoint(String bucketStart) {
+        return SellerDashboardSeriesPointResponse.builder()
+                .bucketStart(bucketStart)
+                .grossSales(0L)
+                .netSales(0L)
+                .orderCount(0L)
+                .build();
+    }
+}

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
@@ -30,10 +30,16 @@ public class SellerDashboardOverviewQueryService {
     private static final String API_VERSION = "v1";
 
     public SellerDashboardOverviewResponse getOverview(Long sellerId, SellerDashboardOverviewQuery query) {
-        if (sellerId == null || sellerId <= 0) {
+        return getOverviewByStore(sellerId, sellerId, query);
+    }
+
+    public SellerDashboardOverviewResponse getOverviewByStore(Long storeId,
+                                                              Long sellerId,
+                                                              SellerDashboardOverviewQuery query) {
+        if (storeId == null || storeId <= 0) {
             throw new BusinessException(
                     AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
-                    "sellerId는 1 이상이어야 합니다."
+                    "storeId는 1 이상이어야 합니다."
             );
         }
 

--- a/servers/services/analytics-dashboard/src/main/resources/application.yml
+++ b/servers/services/analytics-dashboard/src/main/resources/application.yml
@@ -1,0 +1,90 @@
+server:
+  port: ${SERVER_PORT:8095}
+
+spring:
+  application:
+    name: analytics-dashboard-service
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+  # ─── DataSource ───────────────────────────────
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/analytics_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  # ─── JPA ──────────────────────────────────────
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 100
+    show-sql: ${JPA_SHOW_SQL:false}
+    open-in-view: false
+
+  # ─── Redis ────────────────────────────────────
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── Kafka ────────────────────────────────────
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+    consumer:
+      group-id: analytics-dashboard-service-group
+      auto-offset-reset: earliest
+
+app:
+  security:
+    context:
+      signing-key: ${APP_SECURITY_CONTEXT_SIGNING_KEY:}
+      max-age-millis: ${APP_SECURITY_CONTEXT_MAX_AGE_MILLIS:300000}
+
+  gateway-security:
+    enabled: ${APP_GATEWAY_SECURITY_ENABLED:true}
+    gateway-auth-enabled: ${APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED:true}
+    internal-auth-header: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
+    internal-auth-token: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}
+    user-id-header: ${APP_GATEWAY_SECURITY_USER_ID_HEADER:X-User-Id}
+    required-paths:
+      - /internal/v1/analytics/**
+    excluded-paths:
+      - /actuator/**
+      - /v3/api-docs/**
+      - /swagger-ui/**
+
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:12}
+
+  service:
+    product-url: ${PRODUCT_SERVICE_URL:http://localhost:8084}
+    stock-url: ${STOCK_SERVICE_URL:http://localhost:8085}
+    sales-url: ${SALES_SERVICE_URL:http://localhost:8087}
+    search-url: ${SEARCH_SERVICE_URL:http://localhost:8088}
+
+  openapi:
+    enabled: ${OPENAPI_ENABLED:true}
+    title: "Analytics Dashboard Service API"
+    version: "1.0.0"
+    description: |
+      셀러 운영 대시보드 분석/조회 서비스
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info,metrics,prometheus}
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    com.example: ${LOG_LEVEL:INFO}
+    org.springframework.kafka: INFO

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/AnalyticsDashboardApplicationContextTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/AnalyticsDashboardApplicationContextTest.java
@@ -1,0 +1,14 @@
+package com.example.analyticsdashboard;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AnalyticsDashboardApplicationContextTest {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventConsumerTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsItemEventConsumerTest.java
@@ -1,0 +1,74 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import com.example.config.kafka.IdempotentConsumerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsItemEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private AnalyticsEventIngestService analyticsEventIngestService;
+
+    @InjectMocks
+    private AnalyticsItemEventConsumer consumer;
+
+    @Test
+    void consume_validEvent_executesIngest() {
+        stubIdempotentExecution();
+        String message = """
+                {
+                  "eventId": "evt-item-1",
+                  "eventType": "ITEM_CREATED",
+                  "itemId": 101,
+                  "storeId": 201,
+                  "sellerId": 301
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService).ingestItemEvent(any(AnalyticsItemEventMessage.class));
+    }
+
+    @Test
+    void consume_invalidEvent_skipsIdempotent() {
+        String message = """
+                {
+                  "eventType": "ITEM_CREATED",
+                  "itemId": 101
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService, never()).ingestItemEvent(any(AnalyticsItemEventMessage.class));
+    }
+
+    private void stubIdempotentExecution() {
+        when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventConsumerTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsSalesEventConsumerTest.java
@@ -1,0 +1,74 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import com.example.config.kafka.IdempotentConsumerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsSalesEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private AnalyticsEventIngestService analyticsEventIngestService;
+
+    @InjectMocks
+    private AnalyticsSalesEventConsumer consumer;
+
+    @Test
+    void consume_validEvent_executesIngest() {
+        stubIdempotentExecution();
+        String message = """
+                {
+                  "eventId": "evt-sales-1",
+                  "eventType": "PURCHASE_CREATED",
+                  "purchaseId": 10,
+                  "itemId": 20,
+                  "totalAmount": 3000
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService).ingestSalesEvent(any(AnalyticsSalesEventMessage.class));
+    }
+
+    @Test
+    void consume_invalidEvent_skipsIdempotent() {
+        String message = """
+                {
+                  "eventType": "PURCHASE_CREATED",
+                  "purchaseId": 10
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService, never()).ingestSalesEvent(any(AnalyticsSalesEventMessage.class));
+    }
+
+    private void stubIdempotentExecution() {
+        when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventConsumerTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/consumer/AnalyticsSearchEventConsumerTest.java
@@ -1,0 +1,72 @@
+package com.example.analyticsdashboard.consumer;
+
+import com.example.analyticsdashboard.service.ingest.AnalyticsEventIngestService;
+import com.example.config.kafka.IdempotentConsumerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsSearchEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private AnalyticsEventIngestService analyticsEventIngestService;
+
+    @InjectMocks
+    private AnalyticsSearchEventConsumer consumer;
+
+    @Test
+    void consume_validEvent_executesIngest() {
+        stubIdempotentExecution();
+        String message = """
+                {
+                  "eventId": "evt-search-1",
+                  "eventType": "SEARCH_EXECUTED",
+                  "itemId": 101,
+                  "queryHash": "abc123"
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService).ingestSearchEvent(any(AnalyticsSearchEventMessage.class));
+    }
+
+    @Test
+    void consume_invalidEvent_skipsIdempotent() {
+        String message = """
+                {
+                  "eventType": "SEARCH_EXECUTED"
+                }
+                """;
+
+        consumer.consume(message);
+
+        verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
+        verify(analyticsEventIngestService, never()).ingestSearchEvent(any(AnalyticsSearchEventMessage.class));
+    }
+
+    private void stubIdempotentExecution() {
+        when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/dto/query/SellerDashboardOverviewQueryTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/dto/query/SellerDashboardOverviewQueryTest.java
@@ -1,0 +1,143 @@
+package com.example.analyticsdashboard.dto.query;
+
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SellerDashboardOverviewQueryTest {
+
+    @Test
+    void of_dailyMode_parsesDateAndDefaultTimezone() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThat(query.mode()).isEqualTo(DashboardQueryMode.DAILY);
+        assertThat(query.date()).isEqualTo(LocalDate.of(2026, 2, 26));
+        assertThat(query.timezone()).isEqualTo(ZoneId.of("Asia/Seoul"));
+    }
+
+    @Test
+    void of_monthlyMode_parsesYearMonth() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "MONTHLY",
+                null,
+                "2026-02",
+                null,
+                null,
+                null,
+                "UTC"
+        );
+
+        assertThat(query.mode()).isEqualTo(DashboardQueryMode.MONTHLY);
+        assertThat(query.yearMonth()).isEqualTo(YearMonth.of(2026, 2));
+        assertThat(query.timezone()).isEqualTo(ZoneId.of("UTC"));
+    }
+
+    @Test
+    void of_rangeMode_usesDefaultBucketDay() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "RANGE",
+                null,
+                null,
+                "2026-02-01",
+                "2026-02-10",
+                null,
+                "Asia/Seoul"
+        );
+
+        assertThat(query.mode()).isEqualTo(DashboardQueryMode.RANGE);
+        assertThat(query.from()).isEqualTo(LocalDate.of(2026, 2, 1));
+        assertThat(query.to()).isEqualTo(LocalDate.of(2026, 2, 10));
+        assertThat(query.bucket()).isEqualTo(DashboardSeriesBucket.DAY);
+    }
+
+    @Test
+    void of_throwsWhenDailyDateMissing() {
+        assertThatThrownBy(() -> SellerDashboardOverviewQuery.of(
+                "DAILY",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
+
+    @Test
+    void of_throwsWhenRangeFromAfterTo() {
+        assertThatThrownBy(() -> SellerDashboardOverviewQuery.of(
+                "RANGE",
+                null,
+                null,
+                "2026-02-27",
+                "2026-02-26",
+                "DAY",
+                null
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
+
+    @Test
+    void of_throwsWhenRangeExceedsMaxDays() {
+        assertThatThrownBy(() -> SellerDashboardOverviewQuery.of(
+                "RANGE",
+                null,
+                null,
+                "2026-01-01",
+                "2026-04-10",
+                "DAY",
+                null
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
+
+    @Test
+    void of_throwsWhenTimezoneInvalid() {
+        assertThatThrownBy(() -> SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                "Asia/Unknown"
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/ingest/AnalyticsEventIngestServiceTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/ingest/AnalyticsEventIngestServiceTest.java
@@ -1,0 +1,145 @@
+package com.example.analyticsdashboard.service.ingest;
+
+import com.example.analyticsdashboard.consumer.AnalyticsItemEventMessage;
+import com.example.analyticsdashboard.consumer.AnalyticsSalesEventMessage;
+import com.example.analyticsdashboard.consumer.AnalyticsSearchEventMessage;
+import com.example.analyticsdashboard.entity.AnalyticsDimItemSnapshot;
+import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
+import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
+import com.example.analyticsdashboard.repository.AnalyticsDimItemSnapshotRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSalesEventRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSearchEventRepository;
+import com.example.core.util.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsEventIngestServiceTest {
+
+    @Mock
+    private AnalyticsDimItemSnapshotRepository dimItemSnapshotRepository;
+
+    @Mock
+    private AnalyticsRawSalesEventRepository rawSalesEventRepository;
+
+    @Mock
+    private AnalyticsRawSearchEventRepository rawSearchEventRepository;
+
+    @InjectMocks
+    private AnalyticsEventIngestService service;
+
+    @Test
+    void ingestItemEvent_itemCreated_savesSnapshot() {
+        when(dimItemSnapshotRepository.findById(101L)).thenReturn(Optional.empty());
+
+        AnalyticsItemEventMessage event = JsonUtils.fromJson("""
+                {
+                  "eventId": "evt-item-created",
+                  "eventType": "ITEM_CREATED",
+                  "itemId": 101,
+                  "storeId": 201,
+                  "sellerId": 301,
+                  "itemType": "GOODS",
+                  "status": "ON_SALE",
+                  "price": 15000
+                }
+                """, AnalyticsItemEventMessage.class);
+
+        service.ingestItemEvent(event);
+
+        ArgumentCaptor<AnalyticsDimItemSnapshot> captor = ArgumentCaptor.forClass(AnalyticsDimItemSnapshot.class);
+        verify(dimItemSnapshotRepository).save(captor.capture());
+        AnalyticsDimItemSnapshot saved = captor.getValue();
+        assertThat(saved.getItemId()).isEqualTo(101L);
+        assertThat(saved.getStoreId()).isEqualTo(201L);
+        assertThat(saved.getSellerId()).isEqualTo(301L);
+        assertThat(saved.getItemType()).isEqualTo("GOODS");
+        assertThat(saved.getItemStatus()).isEqualTo("ON_SALE");
+        assertThat(saved.getPrice()).isEqualTo(15000L);
+    }
+
+    @Test
+    void ingestSalesEvent_cancel_resolvesOwnershipFromPreviousRaw() {
+        AnalyticsRawSalesEvent previous = AnalyticsRawSalesEvent.builder()
+                .eventId("prev-created")
+                .eventType("PURCHASE_CREATED")
+                .storeId(11L)
+                .sellerId(22L)
+                .itemId(33L)
+                .purchaseId(99L)
+                .grossAmount(10000L)
+                .netAmount(10000L)
+                .occurredAt(LocalDateTime.now().minusMinutes(1))
+                .ingestedAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+        when(rawSalesEventRepository.findTopByPurchaseIdOrderByOccurredAtDesc(99L))
+                .thenReturn(Optional.of(previous));
+
+        AnalyticsSalesEventMessage event = JsonUtils.fromJson("""
+                {
+                  "eventId": "evt-cancel",
+                  "eventType": "PURCHASE_CANCELLED",
+                  "purchaseId": 99
+                }
+                """, AnalyticsSalesEventMessage.class);
+
+        service.ingestSalesEvent(event);
+
+        ArgumentCaptor<AnalyticsRawSalesEvent> captor = ArgumentCaptor.forClass(AnalyticsRawSalesEvent.class);
+        verify(rawSalesEventRepository).save(captor.capture());
+        AnalyticsRawSalesEvent saved = captor.getValue();
+        assertThat(saved.getStoreId()).isEqualTo(11L);
+        assertThat(saved.getSellerId()).isEqualTo(22L);
+        assertThat(saved.getItemId()).isEqualTo(33L);
+        assertThat(saved.getNetAmount()).isEqualTo(-10000L);
+    }
+
+    @Test
+    void ingestSearchEvent_resolvesOwnershipByItemSnapshot() {
+        AnalyticsDimItemSnapshot snapshot = AnalyticsDimItemSnapshot.builder()
+                .itemId(333L)
+                .storeId(444L)
+                .sellerId(555L)
+                .itemType("GOODS")
+                .itemStatus("ON_SALE")
+                .price(1000L)
+                .stockQuantity(10L)
+                .snapshotAt(LocalDateTime.now())
+                .build();
+        when(dimItemSnapshotRepository.findById(333L)).thenReturn(Optional.of(snapshot));
+        when(rawSearchEventRepository.save(any(AnalyticsRawSearchEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        AnalyticsSearchEventMessage event = JsonUtils.fromJson("""
+                {
+                  "eventId": "evt-search",
+                  "eventType": "SEARCH_EXECUTED",
+                  "itemId": 333,
+                  "queryHash": "hash-value",
+                  "sessionId": "sess-1"
+                }
+                """, AnalyticsSearchEventMessage.class);
+
+        service.ingestSearchEvent(event);
+
+        ArgumentCaptor<AnalyticsRawSearchEvent> captor = ArgumentCaptor.forClass(AnalyticsRawSearchEvent.class);
+        verify(rawSearchEventRepository).save(captor.capture());
+        AnalyticsRawSearchEvent saved = captor.getValue();
+        assertThat(saved.getStoreId()).isEqualTo(444L);
+        assertThat(saved.getSellerId()).isEqualTo(555L);
+        assertThat(saved.getItemId()).isEqualTo(333L);
+        assertThat(saved.getQueryHash()).isEqualTo("hash-value");
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
@@ -74,4 +74,25 @@ class SellerDashboardOverviewQueryServiceTest {
                             .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
                 });
     }
+
+    @Test
+    void getOverviewByStore_throwsWhenStoreIdInvalid() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> service.getOverviewByStore(-1L, 100L, query))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
 }

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.analyticsdashboard.service.query;
+
+import com.example.analyticsdashboard.dto.query.SellerDashboardOverviewQuery;
+import com.example.analyticsdashboard.dto.response.SellerDashboardOverviewResponse;
+import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.core.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SellerDashboardOverviewQueryServiceTest {
+
+    private final SellerDashboardOverviewQueryService service = new SellerDashboardOverviewQueryService();
+
+    @Test
+    void getOverview_daily_returnsSingleSeriesAndDayRange() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                "Asia/Seoul"
+        );
+
+        SellerDashboardOverviewResponse response = service.getOverview(100L, query);
+
+        assertThat(response.getMode().name()).isEqualTo("DAILY");
+        assertThat(response.getQueryRange().getFrom()).isEqualTo("2026-02-26");
+        assertThat(response.getQueryRange().getTo()).isEqualTo("2026-02-26");
+        assertThat(response.getSeries()).hasSize(1);
+        assertThat(response.getSeries().get(0).getBucketStart()).isEqualTo("2026-02-26");
+    }
+
+    @Test
+    void getOverview_rangeDay_returnsSeriesForEachDate() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "RANGE",
+                null,
+                null,
+                "2026-02-01",
+                "2026-02-03",
+                "DAY",
+                "UTC"
+        );
+
+        SellerDashboardOverviewResponse response = service.getOverview(10L, query);
+
+        assertThat(response.getQueryRange().getBucket()).isEqualTo("DAY");
+        assertThat(response.getSeries()).hasSize(3);
+        assertThat(response.getSeries().get(0).getBucketStart()).isEqualTo("2026-02-01");
+        assertThat(response.getSeries().get(2).getBucketStart()).isEqualTo("2026-02-03");
+    }
+
+    @Test
+    void getOverview_throwsWhenSellerIdInvalid() {
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> service.getOverview(0L, query))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
+                });
+    }
+}

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
@@ -2,19 +2,46 @@ package com.example.analyticsdashboard.service.query;
 
 import com.example.analyticsdashboard.dto.query.SellerDashboardOverviewQuery;
 import com.example.analyticsdashboard.dto.response.SellerDashboardOverviewResponse;
+import com.example.analyticsdashboard.entity.AnalyticsRawSalesEvent;
+import com.example.analyticsdashboard.entity.AnalyticsRawSearchEvent;
 import com.example.analyticsdashboard.exception.AnalyticsDashboardErrorCode;
+import com.example.analyticsdashboard.repository.AnalyticsDimItemSnapshotRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSalesEventRepository;
+import com.example.analyticsdashboard.repository.AnalyticsRawSearchEventRepository;
 import com.example.core.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class SellerDashboardOverviewQueryServiceTest {
 
-    private final SellerDashboardOverviewQueryService service = new SellerDashboardOverviewQueryService();
+    @Mock
+    private AnalyticsRawSalesEventRepository rawSalesEventRepository;
+
+    @Mock
+    private AnalyticsRawSearchEventRepository rawSearchEventRepository;
+
+    @Mock
+    private AnalyticsDimItemSnapshotRepository dimItemSnapshotRepository;
+
+    @InjectMocks
+    private SellerDashboardOverviewQueryService service;
 
     @Test
     void getOverview_daily_returnsSingleSeriesAndDayRange() {
+        stubEmptyRepos();
         SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
                 "DAILY",
                 "2026-02-26",
@@ -36,6 +63,7 @@ class SellerDashboardOverviewQueryServiceTest {
 
     @Test
     void getOverview_rangeDay_returnsSeriesForEachDate() {
+        stubEmptyRepos();
         SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
                 "RANGE",
                 null,
@@ -52,6 +80,75 @@ class SellerDashboardOverviewQueryServiceTest {
         assertThat(response.getSeries()).hasSize(3);
         assertThat(response.getSeries().get(0).getBucketStart()).isEqualTo("2026-02-01");
         assertThat(response.getSeries().get(2).getBucketStart()).isEqualTo("2026-02-03");
+    }
+
+    @Test
+    void getOverview_calculatesSalesAndSearchKpiFromRawEvents() {
+        LocalDateTime now = LocalDateTime.now();
+        AnalyticsRawSalesEvent created = AnalyticsRawSalesEvent.builder()
+                .eventId("sales-1")
+                .eventType("PURCHASE_CREATED")
+                .storeId(10L)
+                .sellerId(20L)
+                .itemId(30L)
+                .grossAmount(10000L)
+                .netAmount(10000L)
+                .occurredAt(now.minusHours(2))
+                .ingestedAt(now.minusHours(2))
+                .build();
+        AnalyticsRawSalesEvent cancelled = AnalyticsRawSalesEvent.builder()
+                .eventId("sales-2")
+                .eventType("PURCHASE_CANCELLED")
+                .storeId(10L)
+                .sellerId(20L)
+                .itemId(30L)
+                .grossAmount(0L)
+                .netAmount(-2000L)
+                .occurredAt(now.minusHours(1))
+                .ingestedAt(now.minusHours(1))
+                .build();
+        when(rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of(created, cancelled));
+
+        AnalyticsRawSearchEvent searchExecuted = AnalyticsRawSearchEvent.builder()
+                .eventId("search-1")
+                .eventType("SEARCH_EXECUTED")
+                .storeId(10L)
+                .sellerId(20L)
+                .occurredAt(now.minusMinutes(40))
+                .ingestedAt(now.minusMinutes(40))
+                .build();
+        AnalyticsRawSearchEvent clicked = AnalyticsRawSearchEvent.builder()
+                .eventId("search-2")
+                .eventType("SEARCH_ITEM_CLICKED")
+                .storeId(10L)
+                .sellerId(20L)
+                .occurredAt(now.minusMinutes(30))
+                .ingestedAt(now.minusMinutes(30))
+                .build();
+        when(rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of(searchExecuted, clicked));
+        when(dimItemSnapshotRepository.findByStoreId(anyLong())).thenReturn(List.of());
+
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                "Asia/Seoul"
+        );
+
+        SellerDashboardOverviewResponse response = service.getOverviewByStore(10L, 20L, query);
+
+        assertThat(response.getSales().getGrossSales()).isEqualTo(10000L);
+        assertThat(response.getSales().getNetSales()).isEqualTo(8000L);
+        assertThat(response.getSales().getOrderCount()).isEqualTo(1L);
+        assertThat(response.getSales().getCancelCount()).isEqualTo(1L);
+        assertThat(response.getSearch().getSearchCount()).isEqualTo(1L);
+        assertThat(response.getSearch().getClickCount()).isEqualTo(1L);
+        assertThat(response.getSearch().getCtr()).isEqualTo(1.0d);
     }
 
     @Test
@@ -94,5 +191,13 @@ class SellerDashboardOverviewQueryServiceTest {
                     assertThat(businessException.getErrorCode())
                             .isEqualTo(AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER);
                 });
+    }
+
+    private void stubEmptyRepos() {
+        when(rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of());
+        when(rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of());
+        when(dimItemSnapshotRepository.findByStoreId(anyLong())).thenReturn(List.of());
     }
 }

--- a/servers/services/analytics-dashboard/src/test/resources/application-test.yml
+++ b/servers/services/analytics-dashboard/src/test/resources/application-test.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:analytics-dashboard-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  kafka:
+    bootstrap-servers: localhost:9092
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+app:
+  gateway-security:
+    enabled: false
+  outbox:
+    enabled: false
+  openapi:
+    enabled: false

--- a/servers/services/search/src/main/java/com/example/search/SearchApplication.java
+++ b/servers/services/search/src/main/java/com/example/search/SearchApplication.java
@@ -2,9 +2,11 @@ package com.example.search;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.example")
+@EnableAsync
 @EnableScheduling
 public class SearchApplication {
 

--- a/servers/services/search/src/main/java/com/example/search/event/SearchExecutedEvent.java
+++ b/servers/services/search/src/main/java/com/example/search/event/SearchExecutedEvent.java
@@ -1,0 +1,51 @@
+package com.example.search.event;
+
+import com.example.event.DomainEvent;
+import com.example.search.util.SearchLogMasker;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class SearchExecutedEvent extends DomainEvent {
+
+    private static final String TOPIC = "search-events";
+    private static final String EVENT_TYPE = "SEARCH_EXECUTED";
+
+    private final Long itemId;
+    private final Long storeId;
+    private final Long sellerId;
+    private final String queryHash;
+    private final String sessionId;
+
+    public SearchExecutedEvent(String query,
+                               String sessionId,
+                               Long itemId,
+                               Long storeId,
+                               Long sellerId) {
+        super(TOPIC);
+        this.itemId = itemId;
+        this.storeId = storeId;
+        this.sellerId = sellerId;
+        this.queryHash = SearchLogMasker.keywordHash(query);
+        this.sessionId = sessionId;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return EVENT_TYPE;
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("occurredAt", getOccurredAt().toString());
+        payload.put("itemId", itemId);
+        payload.put("storeId", storeId);
+        payload.put("sellerId", sellerId);
+        payload.put("queryHash", queryHash);
+        payload.put("sessionId", sessionId);
+        return payload;
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/query/SearchAnalyticsEventPublisher.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/SearchAnalyticsEventPublisher.java
@@ -1,0 +1,94 @@
+package com.example.search.service.query;
+
+import com.example.contracts.http.HttpHeaderNames;
+import com.example.core.pagination.CursorResponse;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.search.dto.search.request.SearchRequest;
+import com.example.search.dto.search.response.SearchItemResponse;
+import com.example.search.event.SearchExecutedEvent;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SearchAnalyticsEventPublisher {
+
+    private final ObjectProvider<EventPublisher> eventPublisherProvider;
+
+    public void publishSearchExecuted(SearchRequest request, CursorResponse<SearchItemResponse> result) {
+        EventPublisher eventPublisher = eventPublisherProvider.getIfAvailable();
+        if (eventPublisher == null) {
+            return;
+        }
+
+        HttpServletRequest httpRequest = currentHttpRequest();
+        String sessionId = resolveSessionId(httpRequest);
+        Long sellerId = parseLongHeader(httpRequest, HttpHeaderNames.USER_ID);
+        Long storeId = parseLongHeader(httpRequest, HttpHeaderNames.STORE_ID);
+        Long itemId = resolveFirstItemId(result);
+
+        SearchExecutedEvent event = new SearchExecutedEvent(
+                request.getQ(),
+                sessionId,
+                itemId,
+                storeId,
+                sellerId
+        );
+
+        String aggregateId = itemId != null ? String.valueOf(itemId) : event.getEventId();
+        try {
+            eventPublisher.publish(event, EventMetadata.of("SearchQuery", aggregateId));
+        } catch (Exception e) {
+            log.warn("Search analytics event publish failed. aggregateId={}", aggregateId, e);
+        }
+    }
+
+    private Long resolveFirstItemId(CursorResponse<SearchItemResponse> result) {
+        if (result == null || result.getItems() == null || result.getItems().isEmpty()) {
+            return null;
+        }
+        return result.getItems().get(0).getItemId();
+    }
+
+    private HttpServletRequest currentHttpRequest() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attributes)) {
+            return null;
+        }
+        return attributes.getRequest();
+    }
+
+    private String resolveSessionId(HttpServletRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        String sessionId = request.getHeader(HttpHeaderNames.SESSION_ID);
+        if (!StringUtils.hasText(sessionId)) {
+            sessionId = request.getRequestedSessionId();
+        }
+        return StringUtils.hasText(sessionId) ? sessionId.trim() : null;
+    }
+
+    private Long parseLongHeader(HttpServletRequest request, String headerName) {
+        if (request == null) {
+            return null;
+        }
+        String value = request.getHeader(headerName);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
+++ b/servers/services/search/src/main/java/com/example/search/service/query/SearchQueryService.java
@@ -51,6 +51,7 @@ public class SearchQueryService {
     private final PopularSearchService popularSearchService;
     private final SearchResultCacheService searchResultCacheService;
     private final SearchMetricsService searchMetricsService;
+    private final SearchAnalyticsEventPublisher searchAnalyticsEventPublisher;
 
     public CursorResponse<SearchItemResponse> search(SearchRequest request) {
         long startNanos = System.nanoTime();
@@ -64,6 +65,7 @@ public class SearchQueryService {
             try {
                 CursorResponse<SearchItemResponse> cachedResult = parseSearchResponse(cachedJson, size);
                 recordKeyword(request.getQ());
+                publishSearchExecutedEvent(request, cachedResult);
                 searchMetricsService.recordSearchLatency(Duration.ofNanos(System.nanoTime() - startNanos), true, false);
                 return cachedResult;
             } catch (RuntimeException e) {
@@ -92,6 +94,7 @@ public class SearchQueryService {
             CursorResponse<SearchItemResponse> result = parseSearchResponse(json, size);
             searchResultCacheService.put(request, json);
             recordKeyword(request.getQ());
+            publishSearchExecutedEvent(request, result);
             searchMetricsService.recordSearchLatency(Duration.ofNanos(System.nanoTime() - startNanos), true, false);
             return result;
         } catch (IOException e) {
@@ -114,6 +117,13 @@ public class SearchQueryService {
         }
         autocompleteService.recordKeyword(keyword);
         popularSearchService.recordKeyword(keyword);
+    }
+
+    private void publishSearchExecutedEvent(SearchRequest request, CursorResponse<SearchItemResponse> result) {
+        if (!StringUtils.hasText(request.getQ())) {
+            return;
+        }
+        searchAnalyticsEventPublisher.publishSearchExecuted(request, result);
     }
 
     private Map<String, Object> buildQuery(SearchRequest request) {

--- a/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
+++ b/servers/services/search/src/test/java/com/example/search/service/query/SearchQueryServiceTest.java
@@ -49,6 +49,9 @@ class SearchQueryServiceTest {
     @Mock
     private SearchMetricsService searchMetricsService;
 
+    @Mock
+    private SearchAnalyticsEventPublisher searchAnalyticsEventPublisher;
+
     private SearchQueryService searchQueryService;
 
     @BeforeEach
@@ -59,7 +62,8 @@ class SearchQueryServiceTest {
                 autocompleteService,
                 popularSearchService,
                 searchResultCacheService,
-                searchMetricsService
+                searchMetricsService,
+                searchAnalyticsEventPublisher
         );
     }
 
@@ -116,6 +120,7 @@ class SearchQueryServiceTest {
         verify(searchResultCacheService).put(any(SearchRequest.class), anyString());
         verify(autocompleteService).recordKeyword("아이폰");
         verify(popularSearchService).recordKeyword("아이폰");
+        verify(searchAnalyticsEventPublisher).publishSearchExecuted(any(SearchRequest.class), any(CursorResponse.class));
 
         ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
         verify(restClient).performRequest(captor.capture());
@@ -172,6 +177,7 @@ class SearchQueryServiceTest {
         verify(searchResultCacheService, never()).put(any(SearchRequest.class), anyString());
         verify(autocompleteService).recordKeyword("아이폰");
         verify(popularSearchService).recordKeyword("아이폰");
+        verify(searchAnalyticsEventPublisher).publishSearchExecuted(any(SearchRequest.class), any(CursorResponse.class));
     }
 
     @Test
@@ -309,6 +315,7 @@ class SearchQueryServiceTest {
         verify(restClient).performRequest(any(Request.class));
         verify(autocompleteService, never()).recordKeyword(anyString());
         verify(popularSearchService, never()).recordKeyword(anyString());
+        verify(searchAnalyticsEventPublisher, never()).publishSearchExecuted(any(SearchRequest.class), any(CursorResponse.class));
 
         ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
         verify(restClient).performRequest(captor.capture());

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ include("servers:services:hot-deal")
 include("servers:services:media-api")
 include("servers:services:media-worker")
 include("servers:services:user-123")
+include("servers:services:analytics-dashboard")
 
 // 테스트 서버
 include("servers:test:test-server")


### PR DESCRIPTION
## 개요
셀러 운영 대시보드 Epic(#757) 범위의 MVP/확장 구현을 마무리하고, 운영 환경 시나리오(비즈니스 API + 장애/복구 + 인증/세션 + 발행체인)까지 한 번에 검증 가능한 E2E 스위트를 보강했습니다.

### 관련 이슈
- Closes #757
- Closes #758
- Closes #759
- Closes #760
- Closes #761
- Closes #762
- Closes #763
- Closes #764
- Closes #765
- Closes #766
- Closes #767
- Closes #768
- Closes #769
- Closes #770

### 작업 / 변경 내용
- `analytics-dashboard` MVP 구축 및 조회 모드(DAILY/MONTHLY/RANGE) 쿼리/응답 보강
- Gateway BFF 대시보드 응답 확장(`apiVersion`, `extensions`) 및 store/review 범위 null placeholder 정책 반영
- Search 조회 경로에서 search analytics 이벤트 발행 연동 및 테스트 보강
- 운영형 E2E 스위트 추가/보강
  - `funding_hotdeal_business_e2e.sh`
  - `search_consumer_dlq_retry_e2e.sh`
  - `outbox_broker_recovery_e2e.sh`
  - `gateway_seller_dashboard_e2e_verify.sh`
  - `full_stack_publish_chain_e2e.sh`
  - `full_commerce_scope_e2e.sh` (통합 오케스트레이터)
- 통합 오케스트레이터 안정화
  - 시나리오 간 포트 점유 프로세스 정리
  - Postgres 재기동/헬스 대기로 누적 커넥션 이슈 방지

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

추가 확인
- [x] `./gradlew :servers:services:search:test :servers:services:analytics-dashboard:test`
- [x] `bash docker/scripts/full_commerce_scope_e2e.sh` (summary: passes=8, failures=0)

### 참고사항
- PR 범위는 Epic 브랜치 누적 커밋 + 본 커밋(`f9462e3`)을 포함합니다.
- Store/Review는 현 범위에서 미연동(null placeholder) 정책으로 유지하고, 추후 범위 편입 시 별도 구현 예정입니다.
