### PR TITLE
[TASK] notification: auth 이메일 인증 이벤트 소비 및 메일 발송 구현

### DIFF
--- a/servers/services/notification/src/main/java/com/example/notification/consumer/AuthEmailConfirmEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/AuthEmailConfirmEventMessage.java
@@ -1,0 +1,14 @@
+package com.example.notification.consumer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthEmailConfirmEventMessage {
+
+    private String eventId;
+    private String eventType;
+    private String email;
+    private String verificationCode;
+}

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/AuthEmailEventConsumer.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/AuthEmailEventConsumer.java
@@ -1,0 +1,71 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonUtils;
+import com.example.notification.service.email.AuthEmailEventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthEmailEventConsumer {
+
+    private static final String AUTH_EVENT = "AUTH_EVENT";
+    private static final String EMAIL_CONFIRM_EVENT_TYPE = "EMAIL_CONFIRM_EVENT";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final AuthEmailEventService authEmailEventService;
+
+    @KafkaListener(topics = "auth-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consumeAuth(String message) {
+        AuthEmailConfirmEventMessage event = JsonUtils.fromJson(message, AuthEmailConfirmEventMessage.class);
+        if (!hasRequiredEnvelope(event)) {
+            return;
+        }
+
+        idempotentConsumerService.executeIdempotent(event.getEventId(), AUTH_EVENT, () -> {
+            if (!EMAIL_CONFIRM_EVENT_TYPE.equals(normalizeEventType(event.getEventType()))) {
+                log.debug("Ignore auth event type: {}", event.getEventType());
+                return null;
+            }
+            if (!hasRequiredPayload(event)) {
+                log.warn("Skip EMAIL_CONFIRM_EVENT due to missing payload. eventId={}", event.getEventId());
+                return null;
+            }
+
+            authEmailEventService.sendEmailConfirm(event.getEventId(), event.getEmail(), event.getVerificationCode());
+            return null;
+        });
+    }
+
+    private boolean hasRequiredEnvelope(AuthEmailConfirmEventMessage event) {
+        if (event == null) {
+            log.warn("Skip invalid auth event. payload is null");
+            return false;
+        }
+        if (event.getEventId() == null || event.getEventType() == null) {
+            log.warn("Skip invalid auth event. eventId={}, eventType={}", event.getEventId(), event.getEventType());
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasRequiredPayload(AuthEmailConfirmEventMessage event) {
+        return hasText(event.getEmail()) && hasText(event.getVerificationCode());
+    }
+
+    private String normalizeEventType(String eventType) {
+        return eventType == null ? "" : eventType.toUpperCase(Locale.ROOT);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/servers/services/notification/src/main/java/com/example/notification/service/email/AuthEmailEventService.java
+++ b/servers/services/notification/src/main/java/com/example/notification/service/email/AuthEmailEventService.java
@@ -1,0 +1,73 @@
+package com.example.notification.service.email;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthEmailEventService {
+
+    private static final String EMAIL_CONFIRM_SUBJECT = "[돈오아] 이메일 인증 코드 안내";
+    private static final String EMAIL_CONFIRM_TEXT_TEMPLATE = """
+            안녕하세요, 돈오아입니다.
+
+            요청하신 이메일 인증 코드를 안내드립니다.
+
+            인증 코드: %s
+
+            보안을 위해 본 코드는 일정 시간 후 만료됩니다.
+            코드 요청을 하지 않으셨다면 본 메일을 무시해 주세요.
+            """;
+    private static final String EMAIL_CONFIRM_HTML_TEMPLATE = """
+            <!doctype html>
+            <html lang="ko">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>돈오아 이메일 인증</title>
+            </head>
+            <body style="margin:0; padding:24px; background:#f2f6f9; font-family:'Segoe UI','Noto Sans KR',sans-serif; color:#102a43;">
+              <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="max-width:640px; margin:0 auto; border-collapse:collapse;">
+                <tr>
+                  <td style="padding:28px; border-radius:18px; background:linear-gradient(135deg,#0a7ea4 0%%,#127fbf 55%%,#2f9d9c 100%%); color:#ffffff;">
+                    <div style="font-size:13px; letter-spacing:0.08em; opacity:0.9;">DONOA</div>
+                    <h1 style="margin:10px 0 0 0; font-size:28px; line-height:1.25;">이메일 인증 코드</h1>
+                    <p style="margin:12px 0 0 0; font-size:14px; line-height:1.6; opacity:0.95;">안전한 계정 사용을 위해 아래 코드를 입력해 주세요.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:26px 24px; border-radius:0 0 18px 18px; background:#ffffff;">
+                    <p style="margin:0 0 12px 0; font-size:15px; line-height:1.7;">안녕하세요, 돈오아입니다.<br />요청하신 인증 코드를 발급해 드렸습니다.</p>
+                    <div style="margin:18px 0; padding:18px; border:1px solid #d9e2ec; border-radius:14px; background:#f7fafc; text-align:center;">
+                      <div style="font-size:12px; color:#486581; margin-bottom:8px;">인증 코드</div>
+                      <div style="font-size:30px; letter-spacing:0.24em; font-weight:700; color:#102a43;">%s</div>
+                    </div>
+                    <p style="margin:0; font-size:13px; line-height:1.7; color:#627d98;">보안을 위해 본 코드는 일정 시간 후 만료됩니다. 코드 요청을 하지 않으셨다면 본 메일을 무시해 주세요.</p>
+                  </td>
+                </tr>
+              </table>
+            </body>
+            </html>
+            """;
+
+    private final EmailSender emailSender;
+
+    public void sendEmailConfirm(String eventId, String to, String verificationCode) {
+        EmailSendResult result = emailSender.send(EmailSendCommand.builder()
+                .to(to)
+                .subject(EMAIL_CONFIRM_SUBJECT)
+                .textBody(EMAIL_CONFIRM_TEXT_TEMPLATE.formatted(verificationCode))
+                .htmlBody(EMAIL_CONFIRM_HTML_TEMPLATE.formatted(verificationCode))
+                .build());
+
+        if (result.isSuccess()) {
+            log.info("EMAIL_CONFIRM_EVENT mail sent. eventId={}, provider={}", eventId, result.getProvider());
+            return;
+        }
+
+        String reason = result.getErrorMessage() == null ? "unknown" : result.getErrorMessage();
+        throw new IllegalStateException("EMAIL_CONFIRM_EVENT mail send failed: " + reason);
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/consumer/AuthEmailEventConsumerTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/consumer/AuthEmailEventConsumerTest.java
@@ -1,0 +1,106 @@
+package com.example.notification.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.notification.service.email.AuthEmailEventService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthEmailEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private AuthEmailEventService authEmailEventService;
+
+    @InjectMocks
+    private AuthEmailEventConsumer authEmailEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(idempotentConsumerService.executeIdempotent(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<Object> supplier = invocation.getArgument(2);
+                    return Optional.ofNullable(supplier.get());
+                });
+    }
+
+    @Test
+    void consumeAuth_sendsEmailWhenEmailConfirmEvent() {
+        String message = """
+                {
+                  "eventId": "evt-auth-1",
+                  "eventType": "EMAIL_CONFIRM_EVENT",
+                  "email": "user@example.com",
+                  "verificationCode": "ABC123"
+                }
+                """;
+
+        authEmailEventConsumer.consumeAuth(message);
+
+        verify(authEmailEventService).sendEmailConfirm("evt-auth-1", "user@example.com", "ABC123");
+    }
+
+    @Test
+    void consumeAuth_ignoresUnknownAuthEventType() {
+        String message = """
+                {
+                  "eventId": "evt-auth-2",
+                  "eventType": "USER_CREATED",
+                  "email": "user@example.com",
+                  "verificationCode": "ABC123"
+                }
+                """;
+
+        authEmailEventConsumer.consumeAuth(message);
+
+        verify(authEmailEventService, never()).sendEmailConfirm(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void consumeAuth_skipsWhenEnvelopeInvalid() {
+        String message = """
+                {
+                  "eventType": "EMAIL_CONFIRM_EVENT",
+                  "email": "user@example.com",
+                  "verificationCode": "ABC123"
+                }
+                """;
+
+        authEmailEventConsumer.consumeAuth(message);
+
+        verify(idempotentConsumerService, never()).executeIdempotent(anyString(), anyString(), any());
+        verify(authEmailEventService, never()).sendEmailConfirm(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void consumeAuth_skipsWhenPayloadMissing() {
+        String message = """
+                {
+                  "eventId": "evt-auth-3",
+                  "eventType": "EMAIL_CONFIRM_EVENT",
+                  "email": "user@example.com"
+                }
+                """;
+
+        authEmailEventConsumer.consumeAuth(message);
+
+        verify(authEmailEventService, never()).sendEmailConfirm(anyString(), anyString(), anyString());
+    }
+}

--- a/servers/services/notification/src/test/java/com/example/notification/service/email/AuthEmailEventServiceTest.java
+++ b/servers/services/notification/src/test/java/com/example/notification/service/email/AuthEmailEventServiceTest.java
@@ -1,0 +1,49 @@
+package com.example.notification.service.email;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthEmailEventServiceTest {
+
+    @Mock
+    private EmailSender emailSender;
+
+    @InjectMocks
+    private AuthEmailEventService authEmailEventService;
+
+    @Test
+    void sendEmailConfirm_sendsMailWhenProviderSuccess() {
+        when(emailSender.send(any())).thenReturn(EmailSendResult.success("SMTP", "msg-1"));
+
+        authEmailEventService.sendEmailConfirm("evt-auth-1", "user@example.com", "ABC123");
+
+        ArgumentCaptor<EmailSendCommand> captor = ArgumentCaptor.forClass(EmailSendCommand.class);
+        verify(emailSender).send(captor.capture());
+        EmailSendCommand command = captor.getValue();
+        assertThat(command.getTo()).isEqualTo("user@example.com");
+        assertThat(command.getSubject()).contains("이메일 인증 코드 안내");
+        assertThat(command.getTextBody()).contains("ABC123");
+        assertThat(command.getHtmlBody()).contains("돈오아");
+        assertThat(command.getHtmlBody()).contains("ABC123");
+    }
+
+    @Test
+    void sendEmailConfirm_throwsWhenProviderFailed() {
+        when(emailSender.send(any())).thenReturn(EmailSendResult.failure("SMTP", "smtp unavailable"));
+
+        assertThatThrownBy(() -> authEmailEventService.sendEmailConfirm("evt-auth-2", "user@example.com", "XYZ999"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("mail send failed");
+    }
+}


### PR DESCRIPTION
## Summary
- add `auth-events` consumer in notification service for `EMAIL_CONFIRM_EVENT`
- add idempotent handling + payload validation before send
- add dedicated email service that sends branded 돈오아 verification mail (text + html)
- add unit tests for consumer and service

## Details
- new consumer: `AuthEmailEventConsumer`
  - listens to `auth-events`
  - ignores non-`EMAIL_CONFIRM_EVENT`
  - skips invalid envelope/payload
  - delegates to email service
- new dto: `AuthEmailConfirmEventMessage`
- new service: `AuthEmailEventService`
  - subject: `[돈오아] 이메일 인증 코드 안내`
  - sends both plain text and HTML body
  - throws on provider failure to allow retry path

## Test
- `./gradlew :servers:services:notification:test`

Closes #778
