### PR TITLE
[TASK] analytics-dashboard seller/store 조회 경계 분리

### DIFF
--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsDimItemSnapshotRepository.java
@@ -10,4 +10,6 @@ public interface AnalyticsDimItemSnapshotRepository extends JpaRepository<Analyt
     List<AnalyticsDimItemSnapshot> findByStoreId(Long storeId);
 
     List<AnalyticsDimItemSnapshot> findBySellerId(Long sellerId);
+
+    List<AnalyticsDimItemSnapshot> findByStoreIdAndSellerId(Long storeId, Long sellerId);
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSalesEventRepository.java
@@ -18,4 +18,17 @@ public interface AnalyticsRawSalesEventRepository extends JpaRepository<Analytic
             LocalDateTime from,
             LocalDateTime to
     );
+
+    List<AnalyticsRawSalesEvent> findBySellerIdAndOccurredAtBetween(
+            Long sellerId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
+
+    List<AnalyticsRawSalesEvent> findByStoreIdAndSellerIdAndOccurredAtBetween(
+            Long storeId,
+            Long sellerId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/repository/AnalyticsRawSearchEventRepository.java
@@ -16,4 +16,17 @@ public interface AnalyticsRawSearchEventRepository extends JpaRepository<Analyti
             LocalDateTime from,
             LocalDateTime to
     );
+
+    List<AnalyticsRawSearchEvent> findBySellerIdAndOccurredAtBetween(
+            Long sellerId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
+
+    List<AnalyticsRawSearchEvent> findByStoreIdAndSellerIdAndOccurredAtBetween(
+            Long storeId,
+            Long sellerId,
+            LocalDateTime from,
+            LocalDateTime to
+    );
 }

--- a/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
+++ b/servers/services/analytics-dashboard/src/main/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryService.java
@@ -47,34 +47,71 @@ public class SellerDashboardOverviewQueryService {
     private final AnalyticsDimItemSnapshotRepository dimItemSnapshotRepository;
 
     public SellerDashboardOverviewResponse getOverview(Long sellerId, SellerDashboardOverviewQuery query) {
-        return getOverviewByStore(sellerId, sellerId, query);
+        validateSellerId(sellerId);
+
+        QueryRangeContext queryRangeContext = resolveRange(query);
+        List<AnalyticsRawSalesEvent> rawSalesEvents = rawSalesEventRepository.findBySellerIdAndOccurredAtBetween(
+                sellerId,
+                queryRangeContext.fromDateTime(),
+                queryRangeContext.toDateTime()
+        );
+        List<AnalyticsRawSearchEvent> rawSearchEvents = rawSearchEventRepository.findBySellerIdAndOccurredAtBetween(
+                sellerId,
+                queryRangeContext.fromDateTime(),
+                queryRangeContext.toDateTime()
+        );
+        List<AnalyticsDimItemSnapshot> itemSnapshots = dimItemSnapshotRepository.findBySellerId(sellerId);
+
+        return buildOverviewResponse(query, queryRangeContext, rawSalesEvents, rawSearchEvents, itemSnapshots);
     }
 
     public SellerDashboardOverviewResponse getOverviewByStore(Long storeId,
                                                               Long sellerId,
                                                               SellerDashboardOverviewQuery query) {
-        if (storeId == null || storeId <= 0) {
-            throw new BusinessException(
-                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
-                    "storeId는 1 이상이어야 합니다."
-            );
-        }
+        validateStoreId(storeId);
 
         QueryRangeContext queryRangeContext = resolveRange(query);
+        List<AnalyticsRawSalesEvent> rawSalesEvents;
+        List<AnalyticsRawSearchEvent> rawSearchEvents;
+        List<AnalyticsDimItemSnapshot> itemSnapshots;
+
+        if (hasPositiveId(sellerId)) {
+            rawSalesEvents = rawSalesEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(
+                    storeId,
+                    sellerId,
+                    queryRangeContext.fromDateTime(),
+                    queryRangeContext.toDateTime()
+            );
+            rawSearchEvents = rawSearchEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(
+                    storeId,
+                    sellerId,
+                    queryRangeContext.fromDateTime(),
+                    queryRangeContext.toDateTime()
+            );
+            itemSnapshots = dimItemSnapshotRepository.findByStoreIdAndSellerId(storeId, sellerId);
+        } else {
+            rawSalesEvents = rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(
+                    storeId,
+                    queryRangeContext.fromDateTime(),
+                    queryRangeContext.toDateTime()
+            );
+            rawSearchEvents = rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(
+                    storeId,
+                    queryRangeContext.fromDateTime(),
+                    queryRangeContext.toDateTime()
+            );
+            itemSnapshots = dimItemSnapshotRepository.findByStoreId(storeId);
+        }
+
+        return buildOverviewResponse(query, queryRangeContext, rawSalesEvents, rawSearchEvents, itemSnapshots);
+    }
+
+    private SellerDashboardOverviewResponse buildOverviewResponse(SellerDashboardOverviewQuery query,
+                                                                  QueryRangeContext queryRangeContext,
+                                                                  List<AnalyticsRawSalesEvent> rawSalesEvents,
+                                                                  List<AnalyticsRawSearchEvent> rawSearchEvents,
+                                                                  List<AnalyticsDimItemSnapshot> itemSnapshots) {
         SellerDashboardQueryRangeResponse queryRange = toQueryRange(queryRangeContext, query.timezone().getId());
-
-        List<AnalyticsRawSalesEvent> rawSalesEvents = rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(
-                storeId,
-                queryRangeContext.fromDateTime(),
-                queryRangeContext.toDateTime()
-        );
-        List<AnalyticsRawSearchEvent> rawSearchEvents = rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(
-                storeId,
-                queryRangeContext.fromDateTime(),
-                queryRangeContext.toDateTime()
-        );
-        List<AnalyticsDimItemSnapshot> itemSnapshots = dimItemSnapshotRepository.findByStoreId(storeId);
-
         SellerDashboardSalesKpiResponse sales = toSalesKpi(rawSalesEvents);
         SellerDashboardSearchKpiResponse search = toSearchKpi(rawSearchEvents);
         SellerDashboardItemKpiResponse item = toItemKpi(itemSnapshots);
@@ -100,6 +137,28 @@ public class SellerDashboardOverviewQueryService {
                 .apiVersion(API_VERSION)
                 .extensions(extensions)
                 .build();
+    }
+
+    private void validateStoreId(Long storeId) {
+        if (!hasPositiveId(storeId)) {
+            throw new BusinessException(
+                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
+                    "storeId는 1 이상이어야 합니다."
+            );
+        }
+    }
+
+    private void validateSellerId(Long sellerId) {
+        if (!hasPositiveId(sellerId)) {
+            throw new BusinessException(
+                    AnalyticsDashboardErrorCode.INVALID_DASHBOARD_QUERY_PARAMETER,
+                    "sellerId는 1 이상이어야 합니다."
+            );
+        }
+    }
+
+    private boolean hasPositiveId(Long value) {
+        return value != null && value > 0;
     }
 
     private SellerDashboardQueryRangeResponse toQueryRange(QueryRangeContext queryRangeContext, String timezone) {

--- a/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
+++ b/servers/services/analytics-dashboard/src/test/java/com/example/analyticsdashboard/service/query/SellerDashboardOverviewQueryServiceTest.java
@@ -22,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -107,7 +110,7 @@ class SellerDashboardOverviewQueryServiceTest {
                 .occurredAt(now.minusHours(1))
                 .ingestedAt(now.minusHours(1))
                 .build();
-        when(rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+        when(rawSalesEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(anyLong(), anyLong(), any(), any()))
                 .thenReturn(List.of(created, cancelled));
 
         AnalyticsRawSearchEvent searchExecuted = AnalyticsRawSearchEvent.builder()
@@ -126,9 +129,9 @@ class SellerDashboardOverviewQueryServiceTest {
                 .occurredAt(now.minusMinutes(30))
                 .ingestedAt(now.minusMinutes(30))
                 .build();
-        when(rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+        when(rawSearchEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(anyLong(), anyLong(), any(), any()))
                 .thenReturn(List.of(searchExecuted, clicked));
-        when(dimItemSnapshotRepository.findByStoreId(anyLong())).thenReturn(List.of());
+        when(dimItemSnapshotRepository.findByStoreIdAndSellerId(anyLong(), anyLong())).thenReturn(List.of());
 
         SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
                 "DAILY",
@@ -149,6 +152,47 @@ class SellerDashboardOverviewQueryServiceTest {
         assertThat(response.getSearch().getSearchCount()).isEqualTo(1L);
         assertThat(response.getSearch().getClickCount()).isEqualTo(1L);
         assertThat(response.getSearch().getCtr()).isEqualTo(1.0d);
+    }
+
+    @Test
+    void getOverview_bySeller_usesSellerRepositories() {
+        stubEmptyRepos();
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        service.getOverview(100L, query);
+
+        verify(rawSalesEventRepository).findBySellerIdAndOccurredAtBetween(anyLong(), any(), any());
+        verify(rawSearchEventRepository).findBySellerIdAndOccurredAtBetween(anyLong(), any(), any());
+        verify(dimItemSnapshotRepository).findBySellerId(anyLong());
+        verify(rawSalesEventRepository, never()).findByStoreIdAndOccurredAtBetween(anyLong(), any(), any());
+    }
+
+    @Test
+    void getOverviewByStore_withoutSellerFilter_usesStoreRepositories() {
+        stubEmptyRepos();
+        SellerDashboardOverviewQuery query = SellerDashboardOverviewQuery.of(
+                "DAILY",
+                "2026-02-26",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        service.getOverviewByStore(10L, null, query);
+
+        verify(rawSalesEventRepository).findByStoreIdAndOccurredAtBetween(anyLong(), any(), any());
+        verify(rawSearchEventRepository).findByStoreIdAndOccurredAtBetween(anyLong(), any(), any());
+        verify(dimItemSnapshotRepository).findByStoreId(anyLong());
     }
 
     @Test
@@ -194,10 +238,20 @@ class SellerDashboardOverviewQueryServiceTest {
     }
 
     private void stubEmptyRepos() {
-        when(rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+        lenient().when(rawSalesEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
                 .thenReturn(List.of());
-        when(rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+        lenient().when(rawSalesEventRepository.findBySellerIdAndOccurredAtBetween(anyLong(), any(), any()))
                 .thenReturn(List.of());
-        when(dimItemSnapshotRepository.findByStoreId(anyLong())).thenReturn(List.of());
+        lenient().when(rawSalesEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(anyLong(), anyLong(), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(rawSearchEventRepository.findByStoreIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(rawSearchEventRepository.findBySellerIdAndOccurredAtBetween(anyLong(), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(rawSearchEventRepository.findByStoreIdAndSellerIdAndOccurredAtBetween(anyLong(), anyLong(), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(dimItemSnapshotRepository.findByStoreId(anyLong())).thenReturn(List.of());
+        lenient().when(dimItemSnapshotRepository.findBySellerId(anyLong())).thenReturn(List.of());
+        lenient().when(dimItemSnapshotRepository.findByStoreIdAndSellerId(anyLong(), anyLong())).thenReturn(List.of());
     }
 }


### PR DESCRIPTION
## Summary
- separate seller and store dashboard query paths in analytics-dashboard
- make `/sellers/{sellerId}` use seller-based repositories
- keep `/stores/{storeId}` as store-based query and apply optional store+seller filter when header sellerId exists
- add/adjust repository methods and query service tests

## Why
- sellerId(가게 주인)와 storeId(가게) 경계를 명확히 분리하기 위함
- store 서버 부재 환경에서도 이벤트에 포함된 seller/store 식별자로 조회 정합성을 확보하기 위함

## Test
- `./gradlew :servers:services:analytics-dashboard:test`

Related #780
Closes #781
