### PR TITLE
feat(#790): queue enter 멱등 처리 및 토큰 재사용

### DIFF
--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
@@ -32,26 +32,31 @@ public class QueueService {
     public QueueEnterResponse enter(Long hotDealId, Long userId) {
         String queueKey = QUEUE_KEY_PREFIX + hotDealId;
         String memberKey = userId.toString();
+        String token = resolveOrIssueToken(hotDealId, userId);
 
-        // 이미 대기열에 있는지 확인
+        // 이미 대기열에 있으면 멱등 응답 (재진입으로 순번이 뒤로 밀리지 않음)
         Long existingRank = redisTemplate.opsForZSet().rank(queueKey, memberKey);
         if (existingRank != null) {
-            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+            long position = existingRank + 1;
+            return QueueEnterResponse.builder()
+                    .token(token)
+                    .position(position)
+                    .estimatedWaitSeconds(position * ESTIMATED_PROCESS_SECONDS_PER_USER)
+                    .build();
         }
 
-        // 이미 입장 허용된 사용자인지 확인
+        // 이미 입장 허용된 사용자도 멱등 응답
         if (isAdmitted(hotDealId, userId)) {
-            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+            return QueueEnterResponse.builder()
+                    .token(token)
+                    .position(0L)
+                    .estimatedWaitSeconds(0L)
+                    .build();
         }
 
         // ZADD (score = timestamp)
         double score = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(queueKey, memberKey, score);
-
-        // 토큰 생성
-        String token = UUID.randomUUID().toString();
-        String tokenKey = TOKEN_KEY_PREFIX + hotDealId + ":" + userId;
-        redisTemplate.opsForValue().set(tokenKey, token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
 
         Long position = redisTemplate.opsForZSet().rank(queueKey, memberKey);
         long pos = position != null ? position + 1 : 1;
@@ -112,6 +117,18 @@ public class QueueService {
     public boolean isAdmitted(Long hotDealId, Long userId) {
         String admittedKey = ADMITTED_KEY_PREFIX + hotDealId + ":" + userId;
         return Boolean.TRUE.equals(redisTemplate.hasKey(admittedKey));
+    }
+
+    private String resolveOrIssueToken(Long hotDealId, Long userId) {
+        String tokenKey = TOKEN_KEY_PREFIX + hotDealId + ":" + userId;
+        Object stored = redisTemplate.opsForValue().get(tokenKey);
+        if (stored instanceof String storedToken && StringUtils.hasText(storedToken)) {
+            return storedToken;
+        }
+
+        String issued = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(tokenKey, issued, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+        return issued;
     }
 
     /**

--- a/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueServiceTest.java
+++ b/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueServiceTest.java
@@ -1,0 +1,128 @@
+package com.example.hotdeal.service;
+
+import com.example.hotdeal.dto.QueueEnterResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, Object> zSetOperations;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private QueueService queueService;
+
+    @BeforeEach
+    void setUp() {
+        queueService = new QueueService(redisTemplate);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void enter_whenAlreadyQueued_returnsExistingPositionAndToken() {
+        Long hotDealId = 100L;
+        Long userId = 11L;
+        String queueKey = "hotdeal:queue:100";
+        String tokenKey = "hotdeal:token:100:11";
+
+        when(valueOperations.get(tokenKey)).thenReturn("existing-token");
+        when(zSetOperations.rank(queueKey, "11")).thenReturn(4L);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getToken()).isEqualTo("existing-token");
+        assertThat(response.getPosition()).isEqualTo(5L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(10L);
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+        verify(redisTemplate, never()).hasKey(anyString());
+    }
+
+    @Test
+    void enter_whenAlreadyAdmitted_returnsImmediateResponse() {
+        Long hotDealId = 101L;
+        Long userId = 12L;
+        String queueKey = "hotdeal:queue:101";
+        String tokenKey = "hotdeal:token:101:12";
+        String admittedKey = "hotdeal:admitted:101:12";
+
+        when(valueOperations.get(tokenKey)).thenReturn("admitted-token");
+        when(zSetOperations.rank(queueKey, "12")).thenReturn(null);
+        when(redisTemplate.hasKey(admittedKey)).thenReturn(true);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getToken()).isEqualTo("admitted-token");
+        assertThat(response.getPosition()).isEqualTo(0L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(0L);
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+    }
+
+    @Test
+    void enter_whenNewUser_addsQueueAndIssuesToken() {
+        Long hotDealId = 102L;
+        Long userId = 13L;
+        String queueKey = "hotdeal:queue:102";
+        String tokenKey = "hotdeal:token:102:13";
+        String admittedKey = "hotdeal:admitted:102:13";
+
+        when(valueOperations.get(tokenKey)).thenReturn(null);
+        when(zSetOperations.rank(queueKey, "13")).thenReturn(null, 0L);
+        when(redisTemplate.hasKey(admittedKey)).thenReturn(false);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getPosition()).isEqualTo(1L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(2L);
+        assertThat(response.getToken()).isNotBlank();
+        verify(zSetOperations).add(eq(queueKey), eq("13"), anyDouble());
+        verify(valueOperations).set(eq(tokenKey), anyString(), eq(30L), eq(TimeUnit.MINUTES));
+    }
+
+    @Test
+    void enter_whenQueuedButTokenExpired_reissuesTokenWithoutRequeue() {
+        Long hotDealId = 103L;
+        Long userId = 14L;
+        String queueKey = "hotdeal:queue:103";
+        String tokenKey = "hotdeal:token:103:14";
+
+        when(valueOperations.get(tokenKey)).thenReturn(null);
+        when(zSetOperations.rank(queueKey, "14")).thenReturn(2L);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getPosition()).isEqualTo(3L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(6L);
+        assertThat(response.getToken()).isNotBlank();
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(eq(tokenKey), tokenCaptor.capture(), anyLong(), eq(TimeUnit.MINUTES));
+        assertThat(tokenCaptor.getValue()).isNotBlank();
+    }
+}


### PR DESCRIPTION
## 개요
핫딜 대기열 진입 API를 재진입 친화적으로 바꿔, 새로고침/재요청 시 순번이 뒤로 밀리지 않도록 멱등 동작을 적용했습니다.

### 관련 이슈
- Closes #790

### 작업 / 변경 내용
- `QueueService.enter()`를 예외(`QUEUE_ALREADY_ENTERED`) 기반에서 멱등 응답 기반으로 변경
- 동일 `hotDealId + userId` 재진입 시 기존 순번/토큰 재사용
- 토큰이 만료된 재진입 케이스는 새 토큰 재발급 후 기존 순번 유지
- 이미 입장 허용된 사용자 재진입은 `position=0`, `estimatedWaitSeconds=0` 응답
- `QueueServiceTest` 신규 추가(4건)

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인 (`./gradlew :servers:services:hot-deal:test`)
- [ ] 스키마/마이그레이션 변경 시 팀원 공유 (해당 없음)

### 참고사항
- 이번 PR은 `task/790 -> epic/788` 통합용입니다.
- epic 통합 후 `epic -> develop` 최종 PR에서 전체 검증/정리를 진행하면 됩니다.
