### PR TITLE
feat(#788): hotdeal queue realtime UX hardening

### DIFF
--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/config/QueueSseRedisConfig.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/config/QueueSseRedisConfig.java
@@ -1,0 +1,30 @@
+package com.example.hotdeal.config;
+
+import com.example.hotdeal.service.QueueSseRedisSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class QueueSseRedisConfig {
+
+    @Bean
+    public ChannelTopic queueSseTopic(
+            @Value("${hotdeal.queue.sse.topic:hotdeal-queue-sse-events}") String topicName) {
+        return new ChannelTopic(topicName);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer queueSseMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            ChannelTopic queueSseTopic,
+            QueueSseRedisSubscriber queueSseRedisSubscriber) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(queueSseRedisSubscriber, queueSseTopic);
+        return container;
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealCommandController.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/HotDealCommandController.java
@@ -3,13 +3,15 @@ package com.example.hotdeal.controller;
 import com.example.api.response.ApiResponse;
 import com.example.hotdeal.controller.api.HotDealCommandApi;
 import com.example.hotdeal.dto.*;
-import com.example.hotdeal.entity.HotDeal;
 import com.example.hotdeal.service.HotDealCommandService;
 import com.example.hotdeal.service.HotDealPurchaseService;
+import com.example.hotdeal.service.QueueSseEventPublisher;
+import com.example.hotdeal.service.QueueSseService;
 import com.example.hotdeal.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/hot-deals")
@@ -19,6 +21,8 @@ public class HotDealCommandController implements HotDealCommandApi {
     private final HotDealCommandService hotDealCommandService;
     private final HotDealPurchaseService hotDealPurchaseService;
     private final QueueService queueService;
+    private final QueueSseService queueSseService;
+    private final QueueSseEventPublisher queueSseEventPublisher;
 
     @Override
     public ApiResponse<HotDealDetailResponse> createHotDeal(CreateHotDealRequest request, Long userId) {
@@ -33,11 +37,19 @@ public class HotDealCommandController implements HotDealCommandApi {
 
     @Override
     public ApiResponse<QueueEnterResponse> enterQueue(Long hotDealId, Long userId) {
-        return ApiResponse.success(queueService.enter(hotDealId, userId));
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+        boolean canPurchase = response.getPosition() != null && response.getPosition() == 0L;
+        queueSseEventPublisher.publishQueueStatus(hotDealId, userId, response.getPosition(), canPurchase);
+        return ApiResponse.success(response);
     }
 
     @Override
     public ApiResponse<QueueStatusResponse> getQueueStatus(Long hotDealId, Long userId) {
         return ApiResponse.success(queueService.getStatus(hotDealId, userId));
+    }
+
+    @Override
+    public SseEmitter streamQueue(Long hotDealId, Long userId) {
+        return queueSseService.subscribe(hotDealId, userId);
     }
 }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealCommandApi.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/controller/api/HotDealCommandApi.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Hot-Deal Command", description = "핫딜 구매/대기열 API")
 public interface HotDealCommandApi {
@@ -33,6 +35,12 @@ public interface HotDealCommandApi {
     @Operation(summary = "대기열 상태 조회")
     @GetMapping("/{hotDealId}/queue")
     ApiResponse<QueueStatusResponse> getQueueStatus(
+            @PathVariable Long hotDealId,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
+
+    @Operation(summary = "대기열 실시간 스트림(SSE)")
+    @GetMapping(value = "/{hotDealId}/queue/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    SseEmitter streamQueue(
             @PathVariable Long hotDealId,
             @Parameter(hidden = true) @RequestHeader(value = "X-User-Id") Long userId);
 }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueSseFanoutEvent.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueSseFanoutEvent.java
@@ -1,0 +1,18 @@
+package com.example.hotdeal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueueSseFanoutEvent {
+
+    private Long hotDealId;
+    private Long userId;
+    private Long position;
+    private boolean canPurchase;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueStreamEventResponse.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/dto/QueueStreamEventResponse.java
@@ -1,0 +1,14 @@
+package com.example.hotdeal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueStreamEventResponse {
+
+    private Long hotDealId;
+    private Long position;
+    private boolean canPurchase;
+    private String serverTime;
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/scheduler/QueueAdmissionScheduler.java
@@ -2,6 +2,7 @@ package com.example.hotdeal.scheduler;
 
 import com.example.hotdeal.entity.HotDealStatus;
 import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.service.QueueSseEventPublisher;
 import com.example.hotdeal.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,12 +10,15 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class QueueAdmissionScheduler {
 
     private final QueueService queueService;
+    private final QueueSseEventPublisher queueSseEventPublisher;
     private final HotDealRepository hotDealRepository;
 
     private static final int ADMIT_COUNT = 10;
@@ -28,7 +32,8 @@ public class QueueAdmissionScheduler {
         hotDealRepository.findByStatus(HotDealStatus.ACTIVE)
                 .forEach(hotDeal -> {
                     try {
-                        queueService.admitUsers(hotDeal.getId(), ADMIT_COUNT);
+                        Set<Long> admittedUsers = queueService.admitUsers(hotDeal.getId(), ADMIT_COUNT);
+                        queueSseEventPublisher.publishAdmittedUsers(hotDeal.getId(), admittedUsers);
                     } catch (Exception e) {
                         log.error("Queue admission failed: hotDealId={}", hotDeal.getId(), e);
                     }

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
@@ -32,26 +32,31 @@ public class QueueService {
     public QueueEnterResponse enter(Long hotDealId, Long userId) {
         String queueKey = QUEUE_KEY_PREFIX + hotDealId;
         String memberKey = userId.toString();
+        String token = resolveOrIssueToken(hotDealId, userId);
 
-        // 이미 대기열에 있는지 확인
+        // 이미 대기열에 있으면 멱등 응답 (재진입으로 순번이 뒤로 밀리지 않음)
         Long existingRank = redisTemplate.opsForZSet().rank(queueKey, memberKey);
         if (existingRank != null) {
-            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+            long position = existingRank + 1;
+            return QueueEnterResponse.builder()
+                    .token(token)
+                    .position(position)
+                    .estimatedWaitSeconds(position * ESTIMATED_PROCESS_SECONDS_PER_USER)
+                    .build();
         }
 
-        // 이미 입장 허용된 사용자인지 확인
+        // 이미 입장 허용된 사용자도 멱등 응답
         if (isAdmitted(hotDealId, userId)) {
-            throw new BusinessException(HotDealErrorCode.QUEUE_ALREADY_ENTERED);
+            return QueueEnterResponse.builder()
+                    .token(token)
+                    .position(0L)
+                    .estimatedWaitSeconds(0L)
+                    .build();
         }
 
         // ZADD (score = timestamp)
         double score = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(queueKey, memberKey, score);
-
-        // 토큰 생성
-        String token = UUID.randomUUID().toString();
-        String tokenKey = TOKEN_KEY_PREFIX + hotDealId + ":" + userId;
-        redisTemplate.opsForValue().set(tokenKey, token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
 
         Long position = redisTemplate.opsForZSet().rank(queueKey, memberKey);
         long pos = position != null ? position + 1 : 1;
@@ -112,6 +117,18 @@ public class QueueService {
     public boolean isAdmitted(Long hotDealId, Long userId) {
         String admittedKey = ADMITTED_KEY_PREFIX + hotDealId + ":" + userId;
         return Boolean.TRUE.equals(redisTemplate.hasKey(admittedKey));
+    }
+
+    private String resolveOrIssueToken(Long hotDealId, Long userId) {
+        String tokenKey = TOKEN_KEY_PREFIX + hotDealId + ":" + userId;
+        Object stored = redisTemplate.opsForValue().get(tokenKey);
+        if (stored instanceof String storedToken && StringUtils.hasText(storedToken)) {
+            return storedToken;
+        }
+
+        String issued = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(tokenKey, issued, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+        return issued;
     }
 
     /**

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueService.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -94,24 +95,32 @@ public class QueueService {
     /**
      * 상위 N명 입장 허용 (스케줄러에서 호출)
      */
-    public void admitUsers(Long hotDealId, int count) {
+    public Set<Long> admitUsers(Long hotDealId, int count) {
         String queueKey = QUEUE_KEY_PREFIX + hotDealId;
 
         Set<ZSetOperations.TypedTuple<Object>> topUsers =
                 redisTemplate.opsForZSet().popMin(queueKey, count);
 
         if (topUsers == null || topUsers.isEmpty()) {
-            return;
+            return Set.of();
         }
 
+        Set<Long> admittedUserIds = new HashSet<>();
         for (ZSetOperations.TypedTuple<Object> user : topUsers) {
             Object value = user.getValue();
             if (value != null) {
                 String admittedKey = ADMITTED_KEY_PREFIX + hotDealId + ":" + value;
                 redisTemplate.opsForValue().set(admittedKey, "true", ADMITTED_TTL_MINUTES, TimeUnit.MINUTES);
                 log.debug("User admitted: hotDealId={}, userId={}", hotDealId, value);
+                try {
+                    admittedUserIds.add(Long.parseLong(String.valueOf(value)));
+                } catch (NumberFormatException e) {
+                    log.warn("Failed to parse admitted user id. hotDealId={}, rawUserId={}", hotDealId, value);
+                }
             }
         }
+
+        return admittedUserIds;
     }
 
     public boolean isAdmitted(Long hotDealId, Long userId) {

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseEventPublisher.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseEventPublisher.java
@@ -1,0 +1,59 @@
+package com.example.hotdeal.service;
+
+import com.example.hotdeal.dto.QueueSseFanoutEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueSseEventPublisher {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final QueueSseService queueSseService;
+
+    @Value("${hotdeal.queue.sse.topic:hotdeal-queue-sse-events}")
+    private String topic;
+
+    public void publishQueueStatus(Long hotDealId, Long userId, Long position, boolean canPurchase) {
+        if (hotDealId == null || userId == null) {
+            return;
+        }
+        publish(QueueSseFanoutEvent.builder()
+                .hotDealId(hotDealId)
+                .userId(userId)
+                .position(position)
+                .canPurchase(canPurchase)
+                .build());
+    }
+
+    public void publishAdmittedUsers(Long hotDealId, Set<Long> admittedUserIds) {
+        if (hotDealId == null || admittedUserIds == null || admittedUserIds.isEmpty()) {
+            return;
+        }
+        admittedUserIds.forEach(userId -> publishQueueStatus(hotDealId, userId, 0L, true));
+    }
+
+    private void publish(QueueSseFanoutEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            stringRedisTemplate.convertAndSend(topic, payload);
+        } catch (Exception e) {
+            log.warn("Queue SSE redis publish failed. fallback local publish. topic={}, hotDealId={}, userId={}",
+                    topic, event.getHotDealId(), event.getUserId(), e);
+            queueSseService.publishQueueStatus(
+                    event.getHotDealId(),
+                    event.getUserId(),
+                    event.getPosition(),
+                    event.isCanPurchase()
+            );
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseRedisSubscriber.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseRedisSubscriber.java
@@ -1,0 +1,36 @@
+package com.example.hotdeal.service;
+
+import com.example.hotdeal.dto.QueueSseFanoutEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueSseRedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final QueueSseService queueSseService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String payload = new String(message.getBody(), StandardCharsets.UTF_8);
+            QueueSseFanoutEvent event = objectMapper.readValue(payload, QueueSseFanoutEvent.class);
+            queueSseService.publishQueueStatus(
+                    event.getHotDealId(),
+                    event.getUserId(),
+                    event.getPosition(),
+                    event.isCanPurchase()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to consume hot-deal queue SSE redis message", e);
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseService.java
+++ b/servers/services/hot-deal/src/main/java/com/example/hotdeal/service/QueueSseService.java
@@ -1,0 +1,157 @@
+package com.example.hotdeal.service;
+
+import com.example.core.exception.BusinessException;
+import com.example.hotdeal.dto.QueueStatusResponse;
+import com.example.hotdeal.dto.QueueStreamEventResponse;
+import com.example.hotdeal.exception.HotDealErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueSseService {
+
+    private static final String EVENT_CONNECTED = "queue-connected";
+    private static final String EVENT_POSITION = "queue-position";
+    private static final String EVENT_ADMITTED = "queue-admitted";
+    private static final String EVENT_HEARTBEAT = "heartbeat";
+
+    private final QueueService queueService;
+    private final Map<String, QueueSession> sessions = new ConcurrentHashMap<>();
+
+    @Value("${hotdeal.queue.sse.timeout-ms:600000}")
+    private long emitterTimeoutMillis;
+
+    public SseEmitter subscribe(Long hotDealId, Long userId) {
+        SseEmitter emitter = new SseEmitter(emitterTimeoutMillis);
+        QueueSession session = new QueueSession(hotDealId, userId, emitter);
+        String sessionKey = sessionKey(hotDealId, userId);
+
+        QueueSession previous = sessions.put(sessionKey, session);
+        if (previous != null) {
+            previous.emitter.complete();
+        }
+
+        emitter.onCompletion(() -> sessions.remove(sessionKey, session));
+        emitter.onTimeout(() -> {
+            sessions.remove(sessionKey, session);
+            emitter.complete();
+        });
+        emitter.onError(error -> {
+            sessions.remove(sessionKey, session);
+            emitter.completeWithError(error);
+        });
+
+        sendEvent(session, EVENT_CONNECTED, null, false);
+        publishLatestStatus(session);
+        return emitter;
+    }
+
+    public void publishQueueStatus(Long hotDealId, Long userId, Long position, boolean canPurchase) {
+        QueueSession session = sessions.get(sessionKey(hotDealId, userId));
+        if (session == null) {
+            return;
+        }
+        String eventName = canPurchase ? EVENT_ADMITTED : EVENT_POSITION;
+        sendEvent(session, eventName, position, canPurchase);
+    }
+
+    @Scheduled(fixedDelayString = "${hotdeal.queue.sse.heartbeat-interval-ms:5000}")
+    public void heartbeat() {
+        sessions.values().forEach(this::refreshAndHeartbeat);
+    }
+
+    private void refreshAndHeartbeat(QueueSession session) {
+        try {
+            QueueStatusResponse status = queueService.getStatus(session.hotDealId, session.userId);
+            if (isStateChanged(session, status.getPosition(), status.isCanPurchase())) {
+                String eventName = status.isCanPurchase() ? EVENT_ADMITTED : EVENT_POSITION;
+                sendEvent(session, eventName, status.getPosition(), status.isCanPurchase());
+            }
+            sendEvent(session, EVENT_HEARTBEAT, status.getPosition(), status.isCanPurchase());
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == HotDealErrorCode.QUEUE_TOKEN_INVALID) {
+                sendEvent(session, EVENT_HEARTBEAT, null, false);
+                return;
+            }
+            unregister(session, e);
+        } catch (Exception e) {
+            unregister(session, e);
+        }
+    }
+
+    private void publishLatestStatus(QueueSession session) {
+        try {
+            QueueStatusResponse status = queueService.getStatus(session.hotDealId, session.userId);
+            String eventName = status.isCanPurchase() ? EVENT_ADMITTED : EVENT_POSITION;
+            sendEvent(session, eventName, status.getPosition(), status.isCanPurchase());
+        } catch (BusinessException e) {
+            if (e.getErrorCode() != HotDealErrorCode.QUEUE_TOKEN_INVALID) {
+                unregister(session, e);
+            }
+        } catch (Exception e) {
+            unregister(session, e);
+        }
+    }
+
+    private boolean isStateChanged(QueueSession session, Long position, boolean canPurchase) {
+        return !Objects.equals(session.lastPosition, position)
+                || !Objects.equals(session.lastCanPurchase, canPurchase);
+    }
+
+    private void sendEvent(QueueSession session, String eventName, Long position, boolean canPurchase) {
+        QueueStreamEventResponse payload = QueueStreamEventResponse.builder()
+                .hotDealId(session.hotDealId)
+                .position(position)
+                .canPurchase(canPurchase)
+                .serverTime(Instant.now().toString())
+                .build();
+
+        try {
+            session.emitter.send(SseEmitter.event()
+                    .name(eventName)
+                    .data(payload));
+            session.lastPosition = position;
+            session.lastCanPurchase = canPurchase;
+        } catch (IOException e) {
+            unregister(session, e);
+        }
+    }
+
+    private void unregister(QueueSession session, Exception e) {
+        String sessionKey = sessionKey(session.hotDealId, session.userId);
+        sessions.remove(sessionKey, session);
+        session.emitter.completeWithError(e);
+        log.debug("Queue SSE session removed. hotDealId={}, userId={}, reason={}",
+                session.hotDealId, session.userId, e.toString());
+    }
+
+    private String sessionKey(Long hotDealId, Long userId) {
+        return hotDealId + ":" + userId;
+    }
+
+    private static final class QueueSession {
+        private final Long hotDealId;
+        private final Long userId;
+        private final SseEmitter emitter;
+        private volatile Long lastPosition;
+        private volatile Boolean lastCanPurchase;
+
+        private QueueSession(Long hotDealId, Long userId, SseEmitter emitter) {
+            this.hotDealId = hotDealId;
+            this.userId = userId;
+            this.emitter = emitter;
+        }
+    }
+}

--- a/servers/services/hot-deal/src/main/resources/application.yml
+++ b/servers/services/hot-deal/src/main/resources/application.yml
@@ -91,3 +91,10 @@ logging:
   level:
     com.example: ${LOG_LEVEL:INFO}
     org.springframework.kafka: INFO
+
+hotdeal:
+  queue:
+    sse:
+      timeout-ms: ${HOTDEAL_QUEUE_SSE_TIMEOUT_MS:600000}
+      heartbeat-interval-ms: ${HOTDEAL_QUEUE_SSE_HEARTBEAT_INTERVAL_MS:5000}
+      topic: ${HOTDEAL_QUEUE_SSE_TOPIC:hotdeal-queue-sse-events}

--- a/servers/services/hot-deal/src/test/java/com/example/hotdeal/scheduler/QueueAdmissionSchedulerTest.java
+++ b/servers/services/hot-deal/src/test/java/com/example/hotdeal/scheduler/QueueAdmissionSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.example.hotdeal.scheduler;
+
+import com.example.hotdeal.entity.HotDeal;
+import com.example.hotdeal.entity.HotDealStatus;
+import com.example.hotdeal.repository.HotDealRepository;
+import com.example.hotdeal.service.QueueService;
+import com.example.hotdeal.service.QueueSseEventPublisher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueAdmissionSchedulerTest {
+
+    @Mock
+    private QueueService queueService;
+
+    @Mock
+    private QueueSseEventPublisher queueSseEventPublisher;
+
+    @Mock
+    private HotDealRepository hotDealRepository;
+
+    @InjectMocks
+    private QueueAdmissionScheduler queueAdmissionScheduler;
+
+    @Test
+    void admitUsers_publishesAdmittedUsersPerActiveDeal() {
+        HotDeal first = mock(HotDeal.class);
+        HotDeal second = mock(HotDeal.class);
+        when(first.getId()).thenReturn(10L);
+        when(second.getId()).thenReturn(20L);
+        when(hotDealRepository.findByStatus(HotDealStatus.ACTIVE)).thenReturn(List.of(first, second));
+        when(queueService.admitUsers(10L, 10)).thenReturn(Set.of(1L, 2L));
+        when(queueService.admitUsers(20L, 10)).thenReturn(Set.of());
+
+        queueAdmissionScheduler.admitUsers();
+
+        verify(queueSseEventPublisher).publishAdmittedUsers(10L, Set.of(1L, 2L));
+        verify(queueSseEventPublisher).publishAdmittedUsers(20L, Set.of());
+    }
+}

--- a/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueServiceTest.java
+++ b/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueServiceTest.java
@@ -1,0 +1,128 @@
+package com.example.hotdeal.service;
+
+import com.example.hotdeal.dto.QueueEnterResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, Object> zSetOperations;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private QueueService queueService;
+
+    @BeforeEach
+    void setUp() {
+        queueService = new QueueService(redisTemplate);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void enter_whenAlreadyQueued_returnsExistingPositionAndToken() {
+        Long hotDealId = 100L;
+        Long userId = 11L;
+        String queueKey = "hotdeal:queue:100";
+        String tokenKey = "hotdeal:token:100:11";
+
+        when(valueOperations.get(tokenKey)).thenReturn("existing-token");
+        when(zSetOperations.rank(queueKey, "11")).thenReturn(4L);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getToken()).isEqualTo("existing-token");
+        assertThat(response.getPosition()).isEqualTo(5L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(10L);
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+        verify(redisTemplate, never()).hasKey(anyString());
+    }
+
+    @Test
+    void enter_whenAlreadyAdmitted_returnsImmediateResponse() {
+        Long hotDealId = 101L;
+        Long userId = 12L;
+        String queueKey = "hotdeal:queue:101";
+        String tokenKey = "hotdeal:token:101:12";
+        String admittedKey = "hotdeal:admitted:101:12";
+
+        when(valueOperations.get(tokenKey)).thenReturn("admitted-token");
+        when(zSetOperations.rank(queueKey, "12")).thenReturn(null);
+        when(redisTemplate.hasKey(admittedKey)).thenReturn(true);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getToken()).isEqualTo("admitted-token");
+        assertThat(response.getPosition()).isEqualTo(0L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(0L);
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+    }
+
+    @Test
+    void enter_whenNewUser_addsQueueAndIssuesToken() {
+        Long hotDealId = 102L;
+        Long userId = 13L;
+        String queueKey = "hotdeal:queue:102";
+        String tokenKey = "hotdeal:token:102:13";
+        String admittedKey = "hotdeal:admitted:102:13";
+
+        when(valueOperations.get(tokenKey)).thenReturn(null);
+        when(zSetOperations.rank(queueKey, "13")).thenReturn(null, 0L);
+        when(redisTemplate.hasKey(admittedKey)).thenReturn(false);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getPosition()).isEqualTo(1L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(2L);
+        assertThat(response.getToken()).isNotBlank();
+        verify(zSetOperations).add(eq(queueKey), eq("13"), anyDouble());
+        verify(valueOperations).set(eq(tokenKey), anyString(), eq(30L), eq(TimeUnit.MINUTES));
+    }
+
+    @Test
+    void enter_whenQueuedButTokenExpired_reissuesTokenWithoutRequeue() {
+        Long hotDealId = 103L;
+        Long userId = 14L;
+        String queueKey = "hotdeal:queue:103";
+        String tokenKey = "hotdeal:token:103:14";
+
+        when(valueOperations.get(tokenKey)).thenReturn(null);
+        when(zSetOperations.rank(queueKey, "14")).thenReturn(2L);
+
+        QueueEnterResponse response = queueService.enter(hotDealId, userId);
+
+        assertThat(response.getPosition()).isEqualTo(3L);
+        assertThat(response.getEstimatedWaitSeconds()).isEqualTo(6L);
+        assertThat(response.getToken()).isNotBlank();
+        verify(zSetOperations, never()).add(anyString(), any(), anyDouble());
+
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(eq(tokenKey), tokenCaptor.capture(), anyLong(), eq(TimeUnit.MINUTES));
+        assertThat(tokenCaptor.getValue()).isNotBlank();
+    }
+}

--- a/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueSseEventPublisherTest.java
+++ b/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueSseEventPublisherTest.java
@@ -1,0 +1,57 @@
+package com.example.hotdeal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueSseEventPublisherTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private QueueSseService queueSseService;
+
+    @InjectMocks
+    private QueueSseEventPublisher queueSseEventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(queueSseEventPublisher, "topic", "hotdeal-queue-sse-events");
+    }
+
+    @Test
+    void publishQueueStatus_publishesRedisMessage() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"ok\":true}");
+
+        queueSseEventPublisher.publishQueueStatus(100L, 77L, 3L, false);
+
+        verify(stringRedisTemplate).convertAndSend("hotdeal-queue-sse-events", "{\"ok\":true}");
+        verify(queueSseService, never()).publishQueueStatus(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    void publishQueueStatus_fallsBackToLocalPublishWhenRedisFails() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenThrow(new RuntimeException("redis-down"));
+
+        queueSseEventPublisher.publishQueueStatus(100L, 77L, 3L, false);
+
+        verify(queueSseService).publishQueueStatus(100L, 77L, 3L, false);
+    }
+}

--- a/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueSseRedisSubscriberTest.java
+++ b/servers/services/hot-deal/src/test/java/com/example/hotdeal/service/QueueSseRedisSubscriberTest.java
@@ -1,0 +1,51 @@
+package com.example.hotdeal.service;
+
+import com.example.hotdeal.dto.QueueSseFanoutEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueueSseRedisSubscriberTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private QueueSseService queueSseService;
+
+    @InjectMocks
+    private QueueSseRedisSubscriber queueSseRedisSubscriber;
+
+    @Test
+    void onMessage_forwardsFanoutEventToLocalSseService() throws Exception {
+        String json = "{\"hotDealId\":100,\"userId\":77,\"position\":2,\"canPurchase\":false}";
+        Message message = new DefaultMessage(
+                json.getBytes(StandardCharsets.UTF_8),
+                "hotdeal-queue-sse-events".getBytes(StandardCharsets.UTF_8)
+        );
+        QueueSseFanoutEvent event = QueueSseFanoutEvent.builder()
+                .hotDealId(100L)
+                .userId(77L)
+                .position(2L)
+                .canPurchase(false)
+                .build();
+        when(objectMapper.readValue(anyString(), eq(QueueSseFanoutEvent.class))).thenReturn(event);
+
+        queueSseRedisSubscriber.onMessage(message, null);
+
+        verify(queueSseService).publishQueueStatus(100L, 77L, 2L, false);
+    }
+}


### PR DESCRIPTION
## 개요
- HotDeal 대기열 UX 실시간화(epic #788) 최종 통합 PR입니다.
- idempotent queue enter + queue token 재사용/검증 + SSE Redis Pub/Sub fan-out을 반영했습니다.
- 오토스케일링 환경에서 인스턴스 간 SSE 전달 누락 문제를 fan-out 구조로 보완했습니다.

### 관련 이슈
- Closes #788
- Related: #790, #791

### 작업 / 변경 내용
- Queue 진입 멱등 처리: 재진입 시 순번 유지, 토큰 재발급/재사용 정책 정리
- Queue admission 이후 SSE 이벤트를 Redis Pub/Sub로 fan-out
- Redis publish 실패 시 local publish fallback 적용
- Queue stream 응답 이벤트 타입/DTO 정리
- admission scheduler -> publish 경로 통합
- Redis subscriber/listener config 추가 및 테스트 보강

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [x] 관련 테스트 작성 또는 확인
- [x] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 검증 커맨드: `./gradlew :servers:services:hot-deal:test`
- 결과: `BUILD SUCCESSFUL`
- 범위: `servers/services/hot-deal` (결제/주문 도메인 변경 없음)
