### PR TITLE
feat(order): Order 핵심 API 구현 (Internal + Public)

### DIFF
--- a/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
@@ -1,0 +1,18 @@
+package com.example.order.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.request.CreateOrderRequest;
+import com.example.order.dto.response.CreateOrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Internal Order Command", description = "내부 서비스 간 주문 생성 API")
+public interface InternalOrderCommandApi {
+
+    @Operation(summary = "주문 생성 (내부)", description = "Sales 서비스에서 호출하여 주문을 생성합니다")
+    @PostMapping
+    ApiResponse<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
@@ -1,0 +1,16 @@
+package com.example.order.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.response.OrderDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Internal Order Query", description = "내부 서비스 간 주문 조회 API")
+public interface InternalOrderQueryApi {
+
+    @Operation(summary = "주문 상세 조회 (내부)")
+    @GetMapping("/{orderId}")
+    ApiResponse<OrderDetailResponse> findById(@PathVariable Long orderId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/query/OrderQueryApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/query/OrderQueryApi.java
@@ -1,0 +1,31 @@
+package com.example.order.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Order Query", description = "주문 조회 API")
+public interface OrderQueryApi {
+
+    @Operation(summary = "내 주문 목록 조회")
+    @GetMapping
+    ApiResponse<CursorResponse<OrderListResponse>> findMyOrders(
+            @Parameter(hidden = true) @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    );
+
+    @Operation(summary = "주문 상세 조회")
+    @GetMapping("/{orderId}")
+    ApiResponse<OrderDetailResponse> findById(@PathVariable Long orderId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
@@ -1,0 +1,23 @@
+package com.example.order.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.command.InternalOrderCommandApi;
+import com.example.order.dto.request.CreateOrderRequest;
+import com.example.order.dto.response.CreateOrderResponse;
+import com.example.order.service.command.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/orders")
+@RequiredArgsConstructor
+public class InternalOrderCommandController implements InternalOrderCommandApi {
+
+    private final OrderCommandService orderCommandService;
+
+    @Override
+    public ApiResponse<CreateOrderResponse> createOrder(CreateOrderRequest request) {
+        return ApiResponse.success(orderCommandService.createOrder(request));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
@@ -1,0 +1,22 @@
+package com.example.order.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.query.InternalOrderQueryApi;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.service.query.OrderQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/orders")
+@RequiredArgsConstructor
+public class InternalOrderQueryController implements InternalOrderQueryApi {
+
+    private final OrderQueryService orderQueryService;
+
+    @Override
+    public ApiResponse<OrderDetailResponse> findById(Long orderId) {
+        return ApiResponse.success(orderQueryService.findById(orderId));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/query/OrderQueryController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/query/OrderQueryController.java
@@ -1,0 +1,30 @@
+package com.example.order.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.core.pagination.CursorResponse;
+import com.example.order.controller.api.query.OrderQueryApi;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
+import com.example.order.service.query.OrderQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderQueryController implements OrderQueryApi {
+
+    private final OrderQueryService orderQueryService;
+
+    @Override
+    public ApiResponse<CursorResponse<OrderListResponse>> findMyOrders(
+            Long userId, String cursor, int size) {
+        return ApiResponse.success(orderQueryService.findByUserId(userId, cursor, size));
+    }
+
+    @Override
+    public ApiResponse<OrderDetailResponse> findById(Long orderId) {
+        return ApiResponse.success(orderQueryService.findById(orderId));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/request/CreateOrderRequest.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/request/CreateOrderRequest.java
@@ -1,0 +1,50 @@
+package com.example.order.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateOrderRequest {
+
+    @NotNull(message = "구매 ID는 필수입니다")
+    private Long purchaseId;
+
+    @NotNull(message = "사용자 ID는 필수입니다")
+    private Long userId;
+
+    @NotNull(message = "총 금액은 필수입니다")
+    @Min(value = 0, message = "총 금액은 0 이상이어야 합니다")
+    private Long totalAmount;
+
+    private Long reservationId;
+
+    @NotEmpty(message = "주문 항목은 최소 1개 이상이어야 합니다")
+    @Valid
+    private List<OrderItemRequest> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class OrderItemRequest {
+
+        @NotNull(message = "상품 ID는 필수입니다")
+        private Long itemId;
+
+        @NotNull(message = "상품명은 필수입니다")
+        private String itemName;
+
+        @NotNull(message = "수량은 필수입니다")
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+        private Integer quantity;
+
+        @NotNull(message = "단가는 필수입니다")
+        @Min(value = 0, message = "단가는 0 이상이어야 합니다")
+        private Long unitPrice;
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/CreateOrderResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/CreateOrderResponse.java
@@ -1,0 +1,33 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CreateOrderResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    @SnowflakeId
+    private Long purchaseId;
+
+    private String status;
+    private Long totalAmount;
+    private LocalDateTime createdAt;
+
+    public static CreateOrderResponse from(Order order) {
+        return CreateOrderResponse.builder()
+                .orderId(order.getId())
+                .purchaseId(order.getPurchaseId())
+                .status(order.getStatus().name())
+                .totalAmount(order.getTotalAmount())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/OrderDetailResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,80 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderDetailResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    @SnowflakeId
+    private Long userId;
+
+    @SnowflakeId
+    private Long purchaseId;
+
+    @SnowflakeId
+    private Long reservationId;
+
+    @SnowflakeId
+    private Long paymentId;
+
+    private Long totalAmount;
+    private String status;
+    private List<OrderItemResponse> items;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Getter
+    @Builder
+    public static class OrderItemResponse {
+
+        @SnowflakeId
+        private Long id;
+
+        @SnowflakeId
+        private Long itemId;
+
+        private String itemName;
+        private Integer quantity;
+        private Long unitPrice;
+        private Long subtotal;
+
+        public static OrderItemResponse from(OrderItem item) {
+            return OrderItemResponse.builder()
+                    .id(item.getId())
+                    .itemId(item.getItemId())
+                    .itemName(item.getItemName())
+                    .quantity(item.getQuantity())
+                    .unitPrice(item.getUnitPrice())
+                    .subtotal(item.getSubtotal())
+                    .build();
+        }
+    }
+
+    public static OrderDetailResponse from(Order order) {
+        return OrderDetailResponse.builder()
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .purchaseId(order.getPurchaseId())
+                .reservationId(order.getReservationId())
+                .paymentId(order.getPaymentId())
+                .totalAmount(order.getTotalAmount())
+                .status(order.getStatus().name())
+                .items(order.getOrderItems().stream()
+                        .map(OrderItemResponse::from)
+                        .toList())
+                .createdAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/OrderListResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/OrderListResponse.java
@@ -1,0 +1,35 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class OrderListResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    @SnowflakeId
+    private Long purchaseId;
+
+    private Long totalAmount;
+    private String status;
+    private int itemCount;
+    private LocalDateTime createdAt;
+
+    public static OrderListResponse from(Order order) {
+        return OrderListResponse.builder()
+                .orderId(order.getId())
+                .purchaseId(order.getPurchaseId())
+                .totalAmount(order.getTotalAmount())
+                .status(order.getStatus().name())
+                .itemCount(order.getOrderItems().size())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/event/OrderCreatedEvent.java
+++ b/servers/services/order/src/main/java/com/example/order/event/OrderCreatedEvent.java
@@ -1,0 +1,48 @@
+package com.example.order.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class OrderCreatedEvent extends DomainEvent {
+
+    private final Long orderId;
+    private final Long purchaseId;
+    private final Long userId;
+    private final Long totalAmount;
+    private final Long reservationId;
+    private final List<Map<String, Object>> items;
+
+    public OrderCreatedEvent(Long orderId, Long purchaseId, Long userId,
+                              Long totalAmount, Long reservationId,
+                              List<Map<String, Object>> items) {
+        super("order-events");
+        this.orderId = orderId;
+        this.purchaseId = purchaseId;
+        this.userId = userId;
+        this.totalAmount = totalAmount;
+        this.reservationId = reservationId;
+        this.items = items;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ORDER_CREATED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("orderId", orderId);
+        payload.put("purchaseId", purchaseId);
+        payload.put("userId", userId);
+        payload.put("totalAmount", totalAmount);
+        payload.put("reservationId", reservationId);
+        payload.put("items", items);
+        return payload;
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
@@ -1,0 +1,87 @@
+package com.example.order.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.request.CreateOrderRequest;
+import com.example.order.dto.response.CreateOrderResponse;
+import com.example.order.event.OrderCreatedEvent;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderCommandService {
+
+    private final OrderRepository orderRepository;
+    private final EventPublisher eventPublisher;
+
+    @Transactional
+    public CreateOrderResponse createOrder(CreateOrderRequest request) {
+        // 중복 주문 검증
+        orderRepository.findByPurchaseId(request.getPurchaseId())
+                .ifPresent(existing -> {
+                    throw new BusinessException(OrderErrorCode.ORDER_ALREADY_EXISTS);
+                });
+
+        // 주문 생성
+        Order order = Order.create(
+                request.getUserId(),
+                request.getPurchaseId(),
+                request.getTotalAmount(),
+                request.getReservationId()
+        );
+
+        // 주문 아이템 추가
+        for (CreateOrderRequest.OrderItemRequest itemReq : request.getItems()) {
+            OrderItem item = OrderItem.create(
+                    itemReq.getItemId(),
+                    itemReq.getItemName(),
+                    itemReq.getQuantity(),
+                    itemReq.getUnitPrice()
+            );
+            order.addItem(item);
+        }
+
+        orderRepository.save(order);
+
+        // 이벤트 페이로드에 아이템 정보 포함
+        List<Map<String, Object>> itemPayloads = request.getItems().stream()
+                .map(item -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("itemId", item.getItemId());
+                    map.put("itemName", item.getItemName());
+                    map.put("quantity", item.getQuantity());
+                    map.put("unitPrice", item.getUnitPrice());
+                    return map;
+                })
+                .toList();
+
+        // ORDER_CREATED 이벤트 발행
+        OrderCreatedEvent event = new OrderCreatedEvent(
+                order.getId(),
+                order.getPurchaseId(),
+                order.getUserId(),
+                order.getTotalAmount(),
+                order.getReservationId(),
+                itemPayloads
+        );
+        eventPublisher.publish(event, EventMetadata.of("Order", String.valueOf(order.getId())));
+
+        log.info("[Order] Created order: id={}, purchaseId={}, totalAmount={}",
+                order.getId(), order.getPurchaseId(), order.getTotalAmount());
+
+        return CreateOrderResponse.from(order);
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
@@ -1,0 +1,64 @@
+package com.example.order.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.core.pagination.CursorResponse;
+import com.example.core.pagination.CursorUtils;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryService {
+
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final OrderRepository orderRepository;
+
+    public OrderDetailResponse findById(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        return OrderDetailResponse.from(order);
+    }
+
+    public CursorResponse<OrderListResponse> findByUserId(Long userId, String cursor, Integer size) {
+        int normalizedSize = normalizeSize(size);
+        Long cursorId = cursor != null ? CursorUtils.decodeLong(cursor) : null;
+
+        List<Order> orders = orderRepository.findByUserIdWithCursor(
+                userId, cursorId, PageRequest.of(0, normalizedSize + 1)
+        );
+
+        boolean hasNext = orders.size() > normalizedSize;
+        List<Order> pageOrders = hasNext ? orders.subList(0, normalizedSize) : orders;
+
+        List<OrderListResponse> items = pageOrders.stream()
+                .map(OrderListResponse::from)
+                .toList();
+
+        String nextCursor = hasNext && !pageOrders.isEmpty()
+                ? CursorUtils.encode(pageOrders.get(pageOrders.size() - 1).getId())
+                : null;
+
+        long totalCount = orderRepository.countByUserId(userId);
+
+        return CursorResponse.of(items, nextCursor, totalCount);
+    }
+
+    private int normalizeSize(Integer size) {
+        if (size == null) {
+            return DEFAULT_SIZE;
+        }
+        return Math.max(1, Math.min(size, MAX_SIZE));
+    }
+}


### PR DESCRIPTION

## 관련 이슈
- Epic: #807
- Story: #809
- Depends on: #820

- Closes #816
- Closes #817
- Closes #818

## Test 계획
- [ ] `./gradlew :servers:services:order:compileJava` 빌드 성공 확인
- [ ] `POST /internal/v1/orders` curl 호출 → 주문 생성 + DB 저장 확인
- [ ] `GET /internal/v1/orders/{orderId}` 주문 상세 조회 확인
- [ ] `GET /api/v1/orders` 주문 목록 조회 (커서 페이지네이션) 확인
- [ ] outbox_messages 테이블에 ORDER_CREATED 이벤트 기록 확인

