### PR TITLE
feat(#823): auth 이벤트 기반 프로필 동기화 및 미디어 수명주기 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ HELP.md
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/gradle/wrapper/gradle-wrapper.jar
-
+./resume
 /docs
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ HELP.md
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/gradle/wrapper/gradle-wrapper.jar
-./resume
+resume/
 /docs
 ### STS ###
 .apt_generated

--- a/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaLinksSyncCommand.java
+++ b/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaLinksSyncCommand.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record MediaLinksSyncCommand(
-        String ownerType,
+        MediaOwnerType ownerType,
         Long ownerId,
         List<MediaUsageSet> sets
 ) {
@@ -16,7 +16,7 @@ public record MediaLinksSyncCommand(
     }
 
     public record MediaUsageSet(
-            String usageType,
+            MediaUsageType usageType,
             List<Long> mediaIds
     ) {
         public MediaUsageSet {

--- a/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaOwnerType.java
+++ b/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaOwnerType.java
@@ -1,0 +1,12 @@
+package com.example.clients.media.dto;
+
+public enum MediaOwnerType {
+    USER_PROFILE,
+    STORE,
+    ITEM,
+    POST,
+    CHAT_MESSAGE,
+    FUNDING,
+    HOT_DEAL,
+    COMMENT
+}

--- a/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaUsageType.java
+++ b/libs/clients/media-client/src/main/java/com/example/clients/media/dto/MediaUsageType.java
@@ -1,0 +1,6 @@
+package com.example.clients.media.dto;
+
+public enum MediaUsageType {
+    THUMBNAIL,
+    GALLERY
+}

--- a/libs/clients/media-client/src/main/java/com/example/clients/media/impl/MediaClientValidator.java
+++ b/libs/clients/media-client/src/main/java/com/example/clients/media/impl/MediaClientValidator.java
@@ -2,7 +2,6 @@ package com.example.clients.media.impl;
 
 import com.example.clients.media.dto.MediaLinksSyncCommand;
 import com.example.clients.media.exception.InvalidMediaReferenceException;
-import org.springframework.util.StringUtils;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -31,14 +30,14 @@ public class MediaClientValidator {
     }
 
     public MediaLinksSyncCommand normalizeSyncCommand(MediaLinksSyncCommand command) {
-        if (command == null || !StringUtils.hasText(command.ownerType()) || command.ownerId() == null || command.ownerId() <= 0) {
+        if (command == null || command.ownerType() == null || command.ownerId() == null || command.ownerId() <= 0) {
             throw new InvalidMediaReferenceException("syncLinks command is invalid");
         }
 
         List<MediaLinksSyncCommand.MediaUsageSet> normalizedSets = command.sets().stream()
                 .filter(Objects::nonNull)
                 .map(set -> {
-                    if (!StringUtils.hasText(set.usageType())) {
+                    if (set.usageType() == null) {
                         throw new InvalidMediaReferenceException("usageType is required");
                     }
                     return new MediaLinksSyncCommand.MediaUsageSet(

--- a/libs/clients/media-client/src/test/java/com/example/clients/media/impl/MediaClientValidatorTest.java
+++ b/libs/clients/media-client/src/test/java/com/example/clients/media/impl/MediaClientValidatorTest.java
@@ -1,6 +1,8 @@
 package com.example.clients.media.impl;
 
 import com.example.clients.media.dto.MediaLinksSyncCommand;
+import com.example.clients.media.dto.MediaOwnerType;
+import com.example.clients.media.dto.MediaUsageType;
 import com.example.clients.media.exception.InvalidMediaReferenceException;
 import org.junit.jupiter.api.Test;
 
@@ -37,9 +39,9 @@ class MediaClientValidatorTest {
     @Test
     void normalizeSyncCommand_normalizesSetMediaIds() {
         MediaLinksSyncCommand command = new MediaLinksSyncCommand(
-                "ITEM",
+                MediaOwnerType.ITEM,
                 100L,
-                List.of(new MediaLinksSyncCommand.MediaUsageSet("GALLERY", List.of(20L, 21L, 20L)))
+                List.of(new MediaLinksSyncCommand.MediaUsageSet(MediaUsageType.GALLERY, List.of(20L, 21L, 20L)))
         );
 
         MediaLinksSyncCommand normalized = validator.normalizeSyncCommand(command);

--- a/servers/services/auth/src/main/java/com/example/auth/event/UserCreatedEvent.java
+++ b/servers/services/auth/src/main/java/com/example/auth/event/UserCreatedEvent.java
@@ -2,17 +2,20 @@ package com.example.auth.event;
 
 import com.example.event.DomainEvent;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class UserCreatedEvent extends DomainEvent {
 
     private final Long userId;
     private final String email;
+    private final String nickname;
 
-    public UserCreatedEvent(Long userId, String email) {
+    public UserCreatedEvent(Long userId, String email, String nickname) {
         super("user-events");
         this.userId = userId;
         this.email = email;
+        this.nickname = nickname;
     }
 
     @Override
@@ -22,9 +25,10 @@ public class UserCreatedEvent extends DomainEvent {
 
     @Override
     public Map<String, Object> getPayload() {
-        return Map.of(
-                "userId", userId,
-                "email", email
-        );
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("userId", userId);
+        payload.put("email", email);
+        payload.put("nickname", nickname);
+        return payload;
     }
 }

--- a/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
+++ b/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
     private final String realm;
     private final String keycloakServerUrl;
     private final String directGrantClientId;
+    private final boolean syncProfileCreateOnSignup;
 
     public AuthService(UserRepository userRepository,
                        UserStatusHistoryRepository statusHistoryRepository,
@@ -53,7 +54,8 @@ public class AuthService {
                        EventPublisher eventPublisher,
                        @Value("${keycloak.admin.realm}") String realm,
                        @Value("${keycloak.admin.server-url}") String keycloakServerUrl,
-                       @Value("${keycloak.admin.direct-grant-client-id}") String directGrantClientId) {
+                       @Value("${keycloak.admin.direct-grant-client-id}") String directGrantClientId,
+                       @Value("${feature.sync-profile-create-on-signup:true}") boolean syncProfileCreateOnSignup) {
         this.userRepository = userRepository;
         this.statusHistoryRepository = statusHistoryRepository;
         this.keycloakAdminClient = keycloakAdminClient;
@@ -62,6 +64,7 @@ public class AuthService {
         this.realm = realm;
         this.keycloakServerUrl = keycloakServerUrl;
         this.directGrantClientId = directGrantClientId;
+        this.syncProfileCreateOnSignup = syncProfileCreateOnSignup;
     }
 
     // ─── 회원가입 ──────────────────────────────────────────────
@@ -89,12 +92,16 @@ public class AuthService {
                     user.getId(), null, UserStatus.ACTIVE, "회원가입", user.getId());
             statusHistoryRepository.save(history);
 
-            // 6. Profile Service 동기 호출
-            profileServiceClient.createProfile(user.getId(), user.getEmail(), request.nickname());
+            // 6. Profile Service 동기 호출 (feature flag)
+            if (syncProfileCreateOnSignup) {
+                profileServiceClient.createProfile(user.getId(), user.getEmail(), request.nickname());
+            } else {
+                log.info("Sync profile create disabled by feature flag. userId={}", user.getId());
+            }
 
             // 7. Outbox 이벤트 발행
             eventPublisher.publish(
-                    new UserCreatedEvent(user.getId(), user.getEmail()),
+                    new UserCreatedEvent(user.getId(), user.getEmail(), user.getNickname()),
                     EventMetadata.of("USER", String.valueOf(user.getId()))
             );
 

--- a/servers/services/auth/src/main/resources/application.yml
+++ b/servers/services/auth/src/main/resources/application.yml
@@ -47,6 +47,10 @@ profile:
   service:
     base-url: ${PROFILE_SERVICE_URL:http://localhost:8082}
 
+# ─── Feature Flags ───────────────────────────
+feature:
+  sync-profile-create-on-signup: ${FEATURE_SYNC_PROFILE_CREATE_ON_SIGNUP:true}
+
 # ─── App ───────────────────────────────────────
 app:
   snowflake:
@@ -89,4 +93,3 @@ logging:
   level:
     com.example: ${LOG_LEVEL:DEBUG}
     org.keycloak: ${KC_LOG_LEVEL:INFO}
-

--- a/servers/services/auth/src/test/java/com/example/auth/service/AuthServiceTest.java
+++ b/servers/services/auth/src/test/java/com/example/auth/service/AuthServiceTest.java
@@ -6,11 +6,13 @@ import com.example.auth.dto.request.WithdrawRequest;
 import com.example.auth.dto.response.SignupResponse;
 import com.example.auth.entity.User;
 import com.example.auth.entity.UserStatusHistory;
+import com.example.auth.event.UserCreatedEvent;
 import com.example.auth.exception.AuthErrorCode;
 import com.example.auth.repository.UserRepository;
 import com.example.auth.repository.UserStatusHistoryRepository;
 import com.example.core.exception.BusinessException;
 import com.example.core.exception.TechnicalException;
+import com.example.event.DomainEvent;
 import com.example.event.EventPublisher;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +25,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -65,7 +68,8 @@ class AuthServiceTest {
                 eventPublisher,
                 "don-moa",
                 "http://localhost:43217",
-                "don-moa-gateway"
+                "don-moa-gateway",
+                true
         );
     }
 
@@ -108,7 +112,60 @@ class AuthServiceTest {
             // then
             assertThat(response.email()).isEqualTo("test@example.com");
             verify(profileServiceClient).createProfile(any(), eq("test@example.com"), eq("테스터"));
-            verify(eventPublisher).publish(any(), any());
+            ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+            verify(eventPublisher).publish(eventCaptor.capture(), any());
+            assertThat(eventCaptor.getValue()).isInstanceOf(UserCreatedEvent.class);
+            assertThat(eventCaptor.getValue().getPayload())
+                    .containsEntry("userId", response.userId())
+                    .containsEntry("email", "test@example.com")
+                    .containsEntry("nickname", "테스터");
+        }
+
+        @Test
+        @DisplayName("성공 - 동기 profile 생성 feature flag OFF 시 이벤트만 발행")
+        void signup_success_whenSyncProfileCreateFlagOff() {
+            // given
+            AuthService asyncOnlyAuthService = new AuthService(
+                    userRepository,
+                    statusHistoryRepository,
+                    keycloakAdminClient,
+                    profileServiceClient,
+                    eventPublisher,
+                    "don-moa",
+                    "http://localhost:43217",
+                    "don-moa-gateway",
+                    false
+            );
+
+            SignupRequest request = new SignupRequest("flag-off@example.com", "password123", "플래그오프");
+            when(userRepository.existsByEmail("flag-off@example.com")).thenReturn(false);
+
+            RealmResource realmResource = mock(RealmResource.class);
+            UsersResource usersResource = mock(UsersResource.class);
+            UserResource userResource = mock(UserResource.class);
+            Response kcResponse = mock(Response.class);
+
+            when(keycloakAdminClient.realm("don-moa")).thenReturn(realmResource);
+            when(realmResource.users()).thenReturn(usersResource);
+            when(usersResource.create(any(UserRepresentation.class))).thenReturn(kcResponse);
+            when(kcResponse.getStatus()).thenReturn(201);
+            when(kcResponse.getHeaderString("Location"))
+                    .thenReturn("http://localhost/users/kc-user-id-flag-off");
+            when(usersResource.get(anyString())).thenReturn(userResource);
+            when(userResource.toRepresentation()).thenReturn(new UserRepresentation());
+
+            when(userRepository.save(any(User.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            when(statusHistoryRepository.save(any(UserStatusHistory.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            SignupResponse response = asyncOnlyAuthService.signup(request);
+
+            // then
+            assertThat(response.email()).isEqualTo("flag-off@example.com");
+            verify(profileServiceClient, never()).createProfile(any(), anyString(), anyString());
+            verify(eventPublisher).publish(any(DomainEvent.class), any());
         }
 
         @Test

--- a/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeProfile.java
+++ b/servers/services/media-api/src/main/java/com/example/media/entity/MediaDerivativeProfile.java
@@ -1,5 +1,6 @@
 package com.example.media.entity;
 
 public enum MediaDerivativeProfile {
-    THUMBNAIL_WEBP
+    THUMBNAIL_WEBP,
+    DISPLAY_WEBP
 }

--- a/servers/services/media-api/src/main/java/com/example/media/repository/MediaDerivativeRepository.java
+++ b/servers/services/media-api/src/main/java/com/example/media/repository/MediaDerivativeRepository.java
@@ -14,4 +14,10 @@ public interface MediaDerivativeRepository extends JpaRepository<MediaDerivative
             MediaDerivativeProfile derivativeProfile,
             MediaDerivativeStatus status
     );
+
+    List<MediaDerivative> findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+            List<Long> mediaIds,
+            List<MediaDerivativeProfile> derivativeProfiles,
+            MediaDerivativeStatus status
+    );
 }

--- a/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
+++ b/servers/services/media-api/src/main/java/com/example/media/service/query/MediaQueryService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -28,6 +29,9 @@ import java.util.stream.Collectors;
 public class MediaQueryService {
 
     private static final MediaDerivativeProfile THUMBNAIL_PROFILE = MediaDerivativeProfile.THUMBNAIL_WEBP;
+    private static final MediaDerivativeProfile DISPLAY_PROFILE = MediaDerivativeProfile.DISPLAY_WEBP;
+    private static final List<MediaDerivativeProfile> SERVING_DERIVATIVE_PROFILES =
+            List.of(THUMBNAIL_PROFILE, DISPLAY_PROFILE);
 
     private final MediaFileRepository mediaFileRepository;
     private final MediaLinkRepository mediaLinkRepository;
@@ -43,8 +47,9 @@ public class MediaQueryService {
         validateStatus(mediaFile);
 
         MediaLink link = mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(mediaId).orElse(null);
-        MediaDerivative derivative = findThumbnailDerivative(mediaId);
-        return toMediaUrlResponse(mediaFile, link, derivative);
+        Map<MediaDerivativeProfile, MediaDerivative> derivativeByProfile =
+                findLatestReadyDerivativesByMediaId(List.of(mediaId)).getOrDefault(mediaId, Map.of());
+        return toMediaUrlResponse(mediaFile, link, derivativeByProfile);
     }
 
     @Transactional(readOnly = true)
@@ -70,14 +75,8 @@ public class MediaQueryService {
                 .stream()
                 .collect(Collectors.toMap(MediaLink::getMediaId, Function.identity(), (left, right) -> left));
 
-        Map<Long, MediaDerivative> latestThumbnailDerivativeByMediaId = mediaDerivativeRepository
-                .findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
-                        uniqueIds,
-                        THUMBNAIL_PROFILE,
-                        MediaDerivativeStatus.READY
-                )
-                .stream()
-                .collect(Collectors.toMap(MediaDerivative::getMediaId, Function.identity(), (left, right) -> left));
+        Map<Long, Map<MediaDerivativeProfile, MediaDerivative>> derivativeByMediaAndProfile =
+                findLatestReadyDerivativesByMediaId(uniqueIds);
 
         return uniqueIds.stream()
                 .map(mediaFileMap::get)
@@ -86,7 +85,7 @@ public class MediaQueryService {
                 .map(mediaFile -> toMediaUrlResponse(
                         mediaFile,
                         latestLinkByMediaId.get(mediaFile.getId()),
-                        latestThumbnailDerivativeByMediaId.get(mediaFile.getId())
+                        derivativeByMediaAndProfile.getOrDefault(mediaFile.getId(), Map.of())
                 ))
                 .toList();
     }
@@ -113,21 +112,34 @@ public class MediaQueryService {
         }
     }
 
-    private MediaDerivative findThumbnailDerivative(Long mediaId) {
-        return mediaDerivativeRepository
-                .findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
-                        List.of(mediaId),
-                        THUMBNAIL_PROFILE,
+    private Map<Long, Map<MediaDerivativeProfile, MediaDerivative>> findLatestReadyDerivativesByMediaId(List<Long> mediaIds) {
+        if (mediaIds == null || mediaIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<MediaDerivative> readyDerivatives = mediaDerivativeRepository
+                .findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                        mediaIds,
+                        SERVING_DERIVATIVE_PROFILES,
                         MediaDerivativeStatus.READY
-                )
-                .stream()
-                .findFirst()
-                .orElse(null);
+                );
+
+        Map<Long, Map<MediaDerivativeProfile, MediaDerivative>> result = new LinkedHashMap<>();
+        for (MediaDerivative derivative : readyDerivatives) {
+            Map<MediaDerivativeProfile, MediaDerivative> derivativeByProfile = result.computeIfAbsent(
+                    derivative.getMediaId(),
+                    ignored -> new LinkedHashMap<>()
+            );
+            derivativeByProfile.putIfAbsent(derivative.getDerivativeProfile(), derivative);
+        }
+        return result;
     }
 
-    private MediaUrlResponse toMediaUrlResponse(MediaFile mediaFile, MediaLink link, MediaDerivative derivative) {
-        String resolvedObjectKey = resolveObjectKey(mediaFile, link, derivative);
-        MediaUsageType resolvedUsageType = resolveUsageType(link, derivative);
+    private MediaUrlResponse toMediaUrlResponse(MediaFile mediaFile,
+                                                MediaLink link,
+                                                Map<MediaDerivativeProfile, MediaDerivative> derivativeByProfile) {
+        String resolvedObjectKey = resolveObjectKey(mediaFile, link, derivativeByProfile);
+        MediaUsageType resolvedUsageType = resolveUsageType(link);
         MediaUrlPolicyService.MediaUrlContract urlContract = mediaUrlPolicyService.resolve(
                 resolvedObjectKey,
                 resolvedUsageType
@@ -144,21 +156,37 @@ public class MediaQueryService {
                 .build();
     }
 
-    private String resolveObjectKey(MediaFile mediaFile, MediaLink link, MediaDerivative derivative) {
-        if (derivative != null && shouldUseThumbnailDerivative(link)) {
-            return derivative.getObjectKey();
+    private String resolveObjectKey(MediaFile mediaFile,
+                                    MediaLink link,
+                                    Map<MediaDerivativeProfile, MediaDerivative> derivativeByProfile) {
+        MediaDerivative preferredDerivative = resolvePreferredDerivative(link, derivativeByProfile);
+        if (preferredDerivative != null) {
+            return preferredDerivative.getObjectKey();
         }
         return mediaFile.getObjectKey();
     }
 
-    private MediaUsageType resolveUsageType(MediaLink link, MediaDerivative derivative) {
+    private MediaUsageType resolveUsageType(MediaLink link) {
         if (link != null) {
             return link.getUsageType();
         }
         return null;
     }
 
-    private boolean shouldUseThumbnailDerivative(MediaLink link) {
-        return link != null && link.getUsageType() == MediaUsageType.THUMBNAIL;
+    private MediaDerivative resolvePreferredDerivative(MediaLink link,
+                                                       Map<MediaDerivativeProfile, MediaDerivative> derivativeByProfile) {
+        if (derivativeByProfile == null || derivativeByProfile.isEmpty()) {
+            return null;
+        }
+
+        MediaUsageType usageType = resolveUsageType(link);
+        if (usageType == MediaUsageType.THUMBNAIL) {
+            MediaDerivative thumbnail = derivativeByProfile.get(THUMBNAIL_PROFILE);
+            if (thumbnail != null) {
+                return thumbnail;
+            }
+        }
+
+        return derivativeByProfile.get(DISPLAY_PROFILE);
     }
 }

--- a/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
+++ b/servers/services/media-api/src/test/java/com/example/media/service/query/MediaQueryServiceTest.java
@@ -88,9 +88,9 @@ class MediaQueryServiceTest {
 
         when(mediaFileRepository.findById(101L)).thenReturn(Optional.of(mediaFile));
         when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(101L)).thenReturn(Optional.of(mediaLink));
-        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
                 List.of(101L),
-                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                List.of(MediaDerivativeProfile.THUMBNAIL_WEBP, MediaDerivativeProfile.DISPLAY_WEBP),
                 MediaDerivativeStatus.READY
         )).thenReturn(List.of());
 
@@ -127,9 +127,9 @@ class MediaQueryServiceTest {
 
         when(mediaFileRepository.findById(102L)).thenReturn(Optional.of(mediaFile));
         when(mediaLinkRepository.findTopByMediaIdOrderByCreatedAtDesc(102L)).thenReturn(Optional.empty());
-        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
                 List.of(102L),
-                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                List.of(MediaDerivativeProfile.THUMBNAIL_WEBP, MediaDerivativeProfile.DISPLAY_WEBP),
                 MediaDerivativeStatus.READY
         )).thenReturn(List.of());
 
@@ -206,9 +206,9 @@ class MediaQueryServiceTest {
                 .thenReturn(List.of(confirmed, pending));
         when(mediaLinkRepository.findByMediaIdInOrderByMediaIdAscCreatedAtDesc(List.of(201L, 202L, 999L)))
                 .thenReturn(List.of(link));
-        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
                 List.of(201L, 202L, 999L),
-                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                List.of(MediaDerivativeProfile.THUMBNAIL_WEBP, MediaDerivativeProfile.DISPLAY_WEBP),
                 MediaDerivativeStatus.READY
         )).thenReturn(List.of());
 
@@ -248,9 +248,9 @@ class MediaQueryServiceTest {
                 .thenReturn(List.of(confirmed));
         when(mediaLinkRepository.findByMediaIdInOrderByMediaIdAscCreatedAtDesc(List.of(301L)))
                 .thenReturn(List.of(link));
-        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
                 List.of(301L),
-                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                List.of(MediaDerivativeProfile.THUMBNAIL_WEBP, MediaDerivativeProfile.DISPLAY_WEBP),
                 MediaDerivativeStatus.READY
         )).thenReturn(List.of(derivative));
 
@@ -259,6 +259,56 @@ class MediaQueryServiceTest {
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getObjectKey()).isEqualTo(derivative.getObjectKey());
         assertThat(responses.get(0).getMediaUrl()).contains("/derived/");
+    }
+
+    @Test
+    void getMediaUrls_prefersDisplayDerivativeForNonThumbnailUsage() {
+        MediaFile confirmed = MediaFile.createPending(
+                100L,
+                "ready-display.jpg",
+                "team2-donmoa-media/raw/2026/01/01/ready-display.jpg",
+                "team2-donmoa-media-raw",
+                "image/jpeg",
+                1024L,
+                null,
+                null,
+                null,
+                null,
+                "upload-token-display",
+                LocalDateTime.now().plusMinutes(1)
+        );
+        ReflectionTestUtils.setField(confirmed, "id", 401L);
+        confirmed.confirm(1024L, "image/jpeg", "etag-display", LocalDateTime.now());
+
+        MediaLink link = MediaLink.create(401L, MediaOwnerType.ITEM, 888L, MediaUsageType.GALLERY, 0);
+        MediaDerivative displayDerivative = MediaDerivative.createReady(
+                401L,
+                MediaDerivativeProfile.DISPLAY_WEBP,
+                1L,
+                "team2-donmoa-media/derived/2026/01/01/ready-display_display_webp_v1.webp",
+                "https://cdn.example.com/team2-donmoa-media/derived/2026/01/01/ready-display_display_webp_v1.webp",
+                1280,
+                720,
+                "image/webp",
+                22345L
+        );
+        ReflectionTestUtils.setField(displayDerivative, "id", 9002L);
+
+        when(mediaFileRepository.findAllById(List.of(401L)))
+                .thenReturn(List.of(confirmed));
+        when(mediaLinkRepository.findByMediaIdInOrderByMediaIdAscCreatedAtDesc(List.of(401L)))
+                .thenReturn(List.of(link));
+        when(mediaDerivativeRepository.findByMediaIdInAndDerivativeProfileInAndStatusOrderByMediaIdAscMediaVersionDescCreatedAtDesc(
+                List.of(401L),
+                List.of(MediaDerivativeProfile.THUMBNAIL_WEBP, MediaDerivativeProfile.DISPLAY_WEBP),
+                MediaDerivativeStatus.READY
+        )).thenReturn(List.of(displayDerivative));
+
+        List<MediaUrlResponse> responses = mediaQueryService.getMediaUrls(List.of(401L), 100L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getObjectKey()).isEqualTo(displayDerivative.getObjectKey());
+        assertThat(responses.get(0).getUsageType()).isEqualTo("GALLERY");
     }
 
     private MediaDerivative createReadyDerivative(Long mediaId, String objectKey) {

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerCleanupProperties.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerCleanupProperties.java
@@ -1,0 +1,18 @@
+package com.example.mediaworker.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "media.worker.cleanup")
+public class MediaWorkerCleanupProperties {
+
+    private boolean enabled = true;
+    private int batchSize = 100;
+    private long fixedDelayMs = 60_000L;
+    private boolean deleteObjectEnabled = false;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerRawCleanupProperties.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/config/MediaWorkerRawCleanupProperties.java
@@ -1,0 +1,19 @@
+package com.example.mediaworker.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "media.worker.raw-cleanup")
+public class MediaWorkerRawCleanupProperties {
+
+    private boolean enabled = true;
+    private int batchSize = 100;
+    private long fixedDelayMs = 3_600_000L;
+    private long transitionGraceDays = 7L;
+    private boolean deleteObjectEnabled = false;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/consumer/MediaConfirmedEventConsumer.java
@@ -29,18 +29,24 @@ public class MediaConfirmedEventConsumer {
                 log.warn("[MediaWorker] invalid event payload. payload={}", payload);
                 return;
             }
-            MediaDerivativeTask task = mediaDerivativeTaskService.enqueuePending(
+            MediaDerivativeTask thumbnailTask = mediaDerivativeTaskService.enqueuePending(
                     event.getMediaId(),
                     normalizeMediaVersion(event.getMediaVersion()),
                     MediaDerivativeProfile.THUMBNAIL_WEBP,
                     event.getEventId()
             );
+            MediaDerivativeTask displayTask = mediaDerivativeTaskService.enqueuePending(
+                    event.getMediaId(),
+                    normalizeMediaVersion(event.getMediaVersion()),
+                    MediaDerivativeProfile.DISPLAY_WEBP,
+                    event.getEventId()
+            );
             log.info(
-                    "[MediaWorker] confirmed event accepted. taskId={}, mediaId={}, profile={}, version={}, ownerType={}, ownerId={}, usageType={}, objectKey={}",
-                    task.getId(),
-                    task.getMediaId(),
-                    task.getDerivativeProfile(),
-                    task.getMediaVersion(),
+                    "[MediaWorker] confirmed event accepted. mediaId={}, thumbnailTaskId={}, displayTaskId={}, version={}, ownerType={}, ownerId={}, usageType={}, objectKey={}",
+                    event.getMediaId(),
+                    thumbnailTask.getId(),
+                    displayTask.getId(),
+                    thumbnailTask.getMediaVersion(),
                     event.getOwnerType(),
                     event.getOwnerId(),
                     event.getUsageType(),

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivative.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivative.java
@@ -108,4 +108,9 @@ public class MediaDerivative extends BaseEntity {
         this.status = MediaDerivativeStatus.READY;
         restore();
     }
+
+    public void markDeleted() {
+        this.status = MediaDerivativeStatus.DELETED;
+        softDelete();
+    }
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeProfile.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaDerivativeProfile.java
@@ -1,5 +1,6 @@
 package com.example.mediaworker.entity;
 
 public enum MediaDerivativeProfile {
-    THUMBNAIL_WEBP
+    THUMBNAIL_WEBP,
+    DISPLAY_WEBP
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileRecord.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaFileRecord.java
@@ -1,5 +1,6 @@
 package com.example.mediaworker.entity;
 
+import com.example.data.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,12 +12,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "media_files")
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MediaFileRecord {
+public class MediaFileRecord extends BaseEntity {
 
     @Id
     private Long id;
@@ -31,11 +34,19 @@ public class MediaFileRecord {
     @Column(name = "status", nullable = false, length = 30)
     private MediaFileStatus status;
 
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
     public boolean isReadyForDerivative() {
         return status == MediaFileStatus.CONFIRMED || status == MediaFileStatus.READY;
     }
 
     public void markReady() {
         status = MediaFileStatus.READY;
+    }
+
+    public void markDeleted() {
+        status = MediaFileStatus.DELETED;
+        softDelete();
     }
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaLinkRecord.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/entity/MediaLinkRecord.java
@@ -1,0 +1,24 @@
+package com.example.mediaworker.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "media_links")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MediaLinkRecord {
+
+    @Id
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaDerivativeRepository.java
@@ -2,8 +2,13 @@ package com.example.mediaworker.repository;
 
 import com.example.mediaworker.entity.MediaDerivative;
 import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MediaDerivativeRepository extends JpaRepository<MediaDerivative, Long> {
@@ -12,5 +17,27 @@ public interface MediaDerivativeRepository extends JpaRepository<MediaDerivative
             Long mediaId,
             MediaDerivativeProfile derivativeProfile,
             Long mediaVersion
+    );
+
+    Optional<MediaDerivative> findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+            Long mediaId,
+            MediaDerivativeProfile derivativeProfile,
+            MediaDerivativeStatus status
+    );
+
+    @Query("""
+            select derivative
+            from MediaDerivative derivative
+            where derivative.status = :status
+              and not exists (
+                  select 1
+                  from MediaFileRecord mediaFile
+                  where mediaFile.id = derivative.mediaId
+              )
+            order by derivative.id asc
+            """)
+    List<MediaDerivative> findOrphanedDerivatives(
+            @Param("status") MediaDerivativeStatus status,
+            Pageable pageable
     );
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/repository/MediaFileRecordRepository.java
@@ -25,4 +25,20 @@ public interface MediaFileRecordRepository extends JpaRepository<MediaFileRecord
             @Param("toMediaId") Long toMediaId,
             Pageable pageable
     );
+
+    @Query("""
+            select record
+            from MediaFileRecord record
+            where record.status in :statuses
+              and not exists (
+                  select 1
+                  from MediaLinkRecord link
+                  where link.mediaId = record.id
+              )
+            order by record.id asc
+            """)
+    List<MediaFileRecord> findRawDeletionCandidates(
+            @Param("statuses") List<MediaFileStatus> statuses,
+            Pageable pageable
+    );
 }

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeCleanupScheduler.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeCleanupScheduler.java
@@ -1,0 +1,28 @@
+package com.example.mediaworker.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaDerivativeCleanupScheduler {
+
+    private final MediaDerivativeCleanupService mediaDerivativeCleanupService;
+
+    @Scheduled(fixedDelayString = "${media.worker.cleanup.fixed-delay-ms:60000}")
+    public void cleanupOrphanedDerivatives() {
+        MediaDerivativeCleanupService.CleanupResult result = mediaDerivativeCleanupService.cleanupOrphanedDerivatives();
+        if (result.orphanCount() > 0 || result.deleteFailedCount() > 0) {
+            log.info(
+                    "[MediaWorker][Cleanup] orphan={}, purged={}, deletedObjects={}, deleteFailed={}",
+                    result.orphanCount(),
+                    result.purgedCount(),
+                    result.deletedObjectCount(),
+                    result.deleteFailedCount()
+            );
+        }
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeCleanupService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaDerivativeCleanupService.java
@@ -1,0 +1,90 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerCleanupProperties;
+import com.example.mediaworker.config.MediaWorkerS3Properties;
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeStatus;
+import com.example.mediaworker.repository.MediaDerivativeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaDerivativeCleanupService {
+
+    private final MediaDerivativeRepository mediaDerivativeRepository;
+    private final MediaWorkerCleanupProperties mediaWorkerCleanupProperties;
+    private final MediaWorkerS3Properties mediaWorkerS3Properties;
+    private final S3Client mediaWorkerS3Client;
+
+    @Transactional
+    public CleanupResult cleanupOrphanedDerivatives() {
+        if (!mediaWorkerCleanupProperties.isEnabled()) {
+            return CleanupResult.disabled();
+        }
+
+        int batchSize = Math.max(1, mediaWorkerCleanupProperties.getBatchSize());
+        List<MediaDerivative> orphaned = mediaDerivativeRepository.findOrphanedDerivatives(
+                MediaDerivativeStatus.READY,
+                PageRequest.of(0, batchSize)
+        );
+        int purgedCount = 0;
+        int deletedObjectCount = 0;
+        int deleteFailedCount = 0;
+
+        for (MediaDerivative derivative : orphaned) {
+            if (mediaWorkerCleanupProperties.isDeleteObjectEnabled()) {
+                if (!deleteObjectQuietly(derivative)) {
+                    deleteFailedCount++;
+                    continue;
+                }
+                deletedObjectCount++;
+            }
+
+            derivative.markDeleted();
+            purgedCount++;
+        }
+
+        return new CleanupResult(orphaned.size(), purgedCount, deletedObjectCount, deleteFailedCount);
+    }
+
+    private boolean deleteObjectQuietly(MediaDerivative derivative) {
+        try {
+            mediaWorkerS3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(mediaWorkerS3Properties.getBucket())
+                            .key(derivative.getObjectKey())
+                            .build()
+            );
+            return true;
+        } catch (Exception e) {
+            log.warn(
+                    "[MediaWorker][Cleanup] derivative object delete failed. derivativeId={}, mediaId={}, objectKey={}, reason={}",
+                    derivative.getId(),
+                    derivative.getMediaId(),
+                    derivative.getObjectKey(),
+                    e.getMessage()
+            );
+            return false;
+        }
+    }
+
+    public record CleanupResult(
+            int orphanCount,
+            int purgedCount,
+            int deletedObjectCount,
+            int deleteFailedCount
+    ) {
+        static CleanupResult disabled() {
+            return new CleanupResult(0, 0, 0, 0);
+        }
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaRawCleanupScheduler.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaRawCleanupScheduler.java
@@ -1,0 +1,30 @@
+package com.example.mediaworker.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MediaRawCleanupScheduler {
+
+    private final MediaRawCleanupService mediaRawCleanupService;
+
+    @Scheduled(fixedDelayString = "${media.worker.raw-cleanup.fixed-delay-ms:3600000}")
+    public void cleanupRawAfterTransition() {
+        MediaRawCleanupService.CleanupResult result = mediaRawCleanupService.cleanupRawAfterTransition();
+        if (result.scannedCount() > 0 || result.deleteFailedCount() > 0) {
+            log.info(
+                    "[MediaWorker][RawCleanup] scanned={}, purged={}, deletedObjects={}, deleteFailed={}, skippedDerivativeNotReady={}, skippedGrace={}",
+                    result.scannedCount(),
+                    result.purgedCount(),
+                    result.deletedObjectCount(),
+                    result.deleteFailedCount(),
+                    result.skippedDerivativeNotReadyCount(),
+                    result.skippedGraceCount()
+            );
+        }
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaRawCleanupService.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/MediaRawCleanupService.java
@@ -1,0 +1,176 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerRawCleanupProperties;
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeStatus;
+import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.entity.MediaFileStatus;
+import com.example.mediaworker.repository.MediaDerivativeRepository;
+import com.example.mediaworker.repository.MediaFileRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaRawCleanupService {
+
+    private static final List<MediaFileStatus> RAW_DELETION_CANDIDATE_STATUSES =
+            List.of(MediaFileStatus.READY);
+    private static final int SCAN_MULTIPLIER = 5;
+
+    private final MediaFileRecordRepository mediaFileRecordRepository;
+    private final MediaDerivativeRepository mediaDerivativeRepository;
+    private final MediaWorkerRawCleanupProperties mediaWorkerRawCleanupProperties;
+    private final S3Client mediaWorkerS3Client;
+
+    @Transactional
+    public CleanupResult cleanupRawAfterTransition() {
+        if (!mediaWorkerRawCleanupProperties.isEnabled()) {
+            return CleanupResult.disabled();
+        }
+
+        int batchSize = Math.max(1, mediaWorkerRawCleanupProperties.getBatchSize());
+        int scanLimit = Math.max(batchSize, batchSize * SCAN_MULTIPLIER);
+        long graceDays = Math.max(0L, mediaWorkerRawCleanupProperties.getTransitionGraceDays());
+        LocalDateTime eligibleBefore = LocalDateTime.now().minusDays(graceDays);
+
+        List<MediaFileRecord> candidates = fetchCandidates(batchSize, scanLimit);
+
+        int purgedCount = 0;
+        int deletedObjectCount = 0;
+        int deleteFailedCount = 0;
+        int skippedDerivativeNotReadyCount = 0;
+        int skippedGraceCount = 0;
+
+        for (MediaFileRecord candidate : candidates) {
+            if (purgedCount >= batchSize) {
+                break;
+            }
+            Optional<MediaDerivative> thumbnail = findReadyDerivative(candidate.getId(), MediaDerivativeProfile.THUMBNAIL_WEBP);
+            Optional<MediaDerivative> display = findReadyDerivative(candidate.getId(), MediaDerivativeProfile.DISPLAY_WEBP);
+            if (thumbnail.isEmpty() || display.isEmpty()) {
+                skippedDerivativeNotReadyCount++;
+                continue;
+            }
+
+            LocalDateTime transitionReadyAt = latestReadyAt(thumbnail.get(), display.get());
+            if (transitionReadyAt == null || transitionReadyAt.isAfter(eligibleBefore)) {
+                skippedGraceCount++;
+                continue;
+            }
+
+            if (mediaWorkerRawCleanupProperties.isDeleteObjectEnabled()) {
+                if (!deleteRawObjectQuietly(candidate)) {
+                    deleteFailedCount++;
+                    continue;
+                }
+                deletedObjectCount++;
+            }
+
+            candidate.markDeleted();
+            purgedCount++;
+        }
+
+        return new CleanupResult(
+                candidates.size(),
+                purgedCount,
+                deletedObjectCount,
+                deleteFailedCount,
+                skippedDerivativeNotReadyCount,
+                skippedGraceCount
+        );
+    }
+
+    private List<MediaFileRecord> fetchCandidates(int pageSize, int scanLimit) {
+        List<MediaFileRecord> collected = new ArrayList<>();
+        int page = 0;
+        while (collected.size() < scanLimit) {
+            List<MediaFileRecord> pageCandidates = mediaFileRecordRepository.findRawDeletionCandidates(
+                    RAW_DELETION_CANDIDATE_STATUSES,
+                    PageRequest.of(page, pageSize)
+            );
+            if (pageCandidates.isEmpty()) {
+                break;
+            }
+            collected.addAll(pageCandidates);
+            if (pageCandidates.size() < pageSize) {
+                break;
+            }
+            page++;
+        }
+        return collected.size() <= scanLimit ? collected : collected.subList(0, scanLimit);
+    }
+
+    private Optional<MediaDerivative> findReadyDerivative(Long mediaId, MediaDerivativeProfile profile) {
+        return mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                mediaId,
+                profile,
+                MediaDerivativeStatus.READY
+        );
+    }
+
+    private LocalDateTime latestReadyAt(MediaDerivative first, MediaDerivative second) {
+        LocalDateTime firstReadyAt = resolveReadyAt(first);
+        LocalDateTime secondReadyAt = resolveReadyAt(second);
+        if (firstReadyAt == null) {
+            return secondReadyAt;
+        }
+        if (secondReadyAt == null) {
+            return firstReadyAt;
+        }
+        return firstReadyAt.isAfter(secondReadyAt) ? firstReadyAt : secondReadyAt;
+    }
+
+    private LocalDateTime resolveReadyAt(MediaDerivative derivative) {
+        if (derivative == null) {
+            return null;
+        }
+        return derivative.getUpdatedAt() != null ? derivative.getUpdatedAt() : derivative.getCreatedAt();
+    }
+
+    private boolean deleteRawObjectQuietly(MediaFileRecord candidate) {
+        try {
+            mediaWorkerS3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(candidate.getBucketName())
+                            .key(candidate.getObjectKey())
+                            .build()
+            );
+            return true;
+        } catch (Exception e) {
+            log.warn(
+                    "[MediaWorker][RawCleanup] raw object delete failed. mediaId={}, bucket={}, objectKey={}, reason={}",
+                    candidate.getId(),
+                    candidate.getBucketName(),
+                    candidate.getObjectKey(),
+                    e.getMessage()
+            );
+            return false;
+        }
+    }
+
+    public record CleanupResult(
+            int scannedCount,
+            int purgedCount,
+            int deletedObjectCount,
+            int deleteFailedCount,
+            int skippedDerivativeNotReadyCount,
+            int skippedGraceCount
+    ) {
+        static CleanupResult disabled() {
+            return new CleanupResult(0, 0, 0, 0, 0, 0);
+        }
+    }
+}

--- a/servers/services/media-worker/src/main/java/com/example/mediaworker/service/S3MediaDerivativeProcessor.java
+++ b/servers/services/media-worker/src/main/java/com/example/mediaworker/service/S3MediaDerivativeProcessor.java
@@ -66,7 +66,7 @@ public class S3MediaDerivativeProcessor implements MediaDerivativeProcessor {
         );
 
         BufferedImage sourceImage = decodeImage(sourceBytes.asByteArray());
-        DerivativeImageResult derivativeImage = toThumbnailImage(sourceImage);
+        DerivativeImageResult derivativeImage = transformByProfile(sourceImage, task.getDerivativeProfile());
         String objectKey = buildDerivativeObjectKey(mediaFileRecord.getObjectKey(), task, derivativeImage.extension());
         uploadDerivative(mediaFileRecord.getBucketName(), objectKey, derivativeImage);
 
@@ -104,6 +104,13 @@ public class S3MediaDerivativeProcessor implements MediaDerivativeProcessor {
         }
     }
 
+    private DerivativeImageResult transformByProfile(BufferedImage sourceImage, MediaDerivativeProfile derivativeProfile) {
+        if (derivativeProfile == MediaDerivativeProfile.THUMBNAIL_WEBP) {
+            return toThumbnailImage(sourceImage);
+        }
+        return toDisplayImage(sourceImage);
+    }
+
     private BufferedImage decodeImage(byte[] bytes) {
         try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
             BufferedImage sourceImage = ImageIO.read(input);
@@ -138,6 +145,10 @@ public class S3MediaDerivativeProcessor implements MediaDerivativeProcessor {
         }
 
         return encodeImage(resized);
+    }
+
+    private DerivativeImageResult toDisplayImage(BufferedImage sourceImage) {
+        return encodeImage(sourceImage);
     }
 
     private int[] calculateTargetSize(int sourceWidth, int sourceHeight, int maxWidth, int maxHeight) {

--- a/servers/services/media-worker/src/main/resources/application.yml
+++ b/servers/services/media-worker/src/main/resources/application.yml
@@ -48,6 +48,17 @@ media:
       stale-processing-seconds: ${MEDIA_WORKER_TASK_STALE_PROCESSING_SECONDS:180}
       retry-initial-delay-seconds: ${MEDIA_WORKER_TASK_RETRY_INITIAL_DELAY_SECONDS:5}
       retry-max-delay-seconds: ${MEDIA_WORKER_TASK_RETRY_MAX_DELAY_SECONDS:300}
+    cleanup:
+      enabled: ${MEDIA_WORKER_CLEANUP_ENABLED:true}
+      batch-size: ${MEDIA_WORKER_CLEANUP_BATCH_SIZE:100}
+      fixed-delay-ms: ${MEDIA_WORKER_CLEANUP_FIXED_DELAY_MS:60000}
+      delete-object-enabled: ${MEDIA_WORKER_CLEANUP_DELETE_OBJECT_ENABLED:false}
+    raw-cleanup:
+      enabled: ${MEDIA_WORKER_RAW_CLEANUP_ENABLED:true}
+      batch-size: ${MEDIA_WORKER_RAW_CLEANUP_BATCH_SIZE:100}
+      fixed-delay-ms: ${MEDIA_WORKER_RAW_CLEANUP_FIXED_DELAY_MS:3600000}
+      transition-grace-days: ${MEDIA_WORKER_RAW_CLEANUP_TRANSITION_GRACE_DAYS:7}
+      delete-object-enabled: ${MEDIA_WORKER_RAW_CLEANUP_DELETE_OBJECT_ENABLED:false}
 
 app:
   security:

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeCleanupSchedulerTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeCleanupSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.example.mediaworker.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaDerivativeCleanupSchedulerTest {
+
+    @Mock
+    private MediaDerivativeCleanupService mediaDerivativeCleanupService;
+
+    @Test
+    void cleanupOrphanedDerivatives_invokesCleanupService() {
+        MediaDerivativeCleanupScheduler scheduler = new MediaDerivativeCleanupScheduler(mediaDerivativeCleanupService);
+        when(mediaDerivativeCleanupService.cleanupOrphanedDerivatives())
+                .thenReturn(new MediaDerivativeCleanupService.CleanupResult(0, 0, 0, 0));
+
+        scheduler.cleanupOrphanedDerivatives();
+
+        verify(mediaDerivativeCleanupService).cleanupOrphanedDerivatives();
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeCleanupServiceTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaDerivativeCleanupServiceTest.java
@@ -1,0 +1,131 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerCleanupProperties;
+import com.example.mediaworker.config.MediaWorkerS3Properties;
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeStatus;
+import com.example.mediaworker.repository.MediaDerivativeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaDerivativeCleanupServiceTest {
+
+    @Mock
+    private MediaDerivativeRepository mediaDerivativeRepository;
+
+    @Mock
+    private S3Client mediaWorkerS3Client;
+
+    private MediaWorkerCleanupProperties mediaWorkerCleanupProperties;
+    private MediaWorkerS3Properties mediaWorkerS3Properties;
+    private MediaDerivativeCleanupService mediaDerivativeCleanupService;
+
+    @BeforeEach
+    void setUp() {
+        mediaWorkerCleanupProperties = new MediaWorkerCleanupProperties();
+        mediaWorkerCleanupProperties.setEnabled(true);
+        mediaWorkerCleanupProperties.setBatchSize(20);
+        mediaWorkerCleanupProperties.setDeleteObjectEnabled(false);
+
+        mediaWorkerS3Properties = new MediaWorkerS3Properties();
+        mediaWorkerS3Properties.setBucket("team2-donmoa-media-raw");
+
+        mediaDerivativeCleanupService = new MediaDerivativeCleanupService(
+                mediaDerivativeRepository,
+                mediaWorkerCleanupProperties,
+                mediaWorkerS3Properties,
+                mediaWorkerS3Client
+        );
+    }
+
+    @Test
+    void cleanupOrphanedDerivatives_whenDeleteEnabledAndSuccess_marksDeleted() {
+        mediaWorkerCleanupProperties.setDeleteObjectEnabled(true);
+        MediaDerivative derivative = createDerivative(1001L, 41L, "team2-donmoa-media/derived/sample_41.webp");
+        when(mediaDerivativeRepository.findOrphanedDerivatives(eq(MediaDerivativeStatus.READY), any(Pageable.class)))
+                .thenReturn(List.of(derivative));
+
+        MediaDerivativeCleanupService.CleanupResult result = mediaDerivativeCleanupService.cleanupOrphanedDerivatives();
+
+        assertThat(result.orphanCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(1);
+        assertThat(result.deletedObjectCount()).isEqualTo(1);
+        assertThat(result.deleteFailedCount()).isEqualTo(0);
+        assertThat(derivative.getStatus()).isEqualTo(MediaDerivativeStatus.DELETED);
+        assertThat(derivative.isDeleted()).isTrue();
+        verify(mediaWorkerS3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void cleanupOrphanedDerivatives_whenDeleteFails_keepsDerivativeForRetry() {
+        mediaWorkerCleanupProperties.setDeleteObjectEnabled(true);
+        MediaDerivative derivative = createDerivative(1002L, 42L, "team2-donmoa-media/derived/sample_42.webp");
+        when(mediaDerivativeRepository.findOrphanedDerivatives(eq(MediaDerivativeStatus.READY), any(Pageable.class)))
+                .thenReturn(List.of(derivative));
+        doThrow(new RuntimeException("s3 delete failed"))
+                .when(mediaWorkerS3Client)
+                .deleteObject(any(DeleteObjectRequest.class));
+
+        MediaDerivativeCleanupService.CleanupResult result = mediaDerivativeCleanupService.cleanupOrphanedDerivatives();
+
+        assertThat(result.orphanCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(0);
+        assertThat(result.deletedObjectCount()).isEqualTo(0);
+        assertThat(result.deleteFailedCount()).isEqualTo(1);
+        assertThat(derivative.getStatus()).isEqualTo(MediaDerivativeStatus.READY);
+        assertThat(derivative.isDeleted()).isFalse();
+    }
+
+    @Test
+    void cleanupOrphanedDerivatives_whenDeleteDisabled_softDeletesWithoutS3Call() {
+        mediaWorkerCleanupProperties.setDeleteObjectEnabled(false);
+        MediaDerivative derivative = createDerivative(1003L, 43L, "team2-donmoa-media/derived/sample_43.webp");
+        when(mediaDerivativeRepository.findOrphanedDerivatives(eq(MediaDerivativeStatus.READY), any(Pageable.class)))
+                .thenReturn(List.of(derivative));
+
+        MediaDerivativeCleanupService.CleanupResult result = mediaDerivativeCleanupService.cleanupOrphanedDerivatives();
+
+        assertThat(result.orphanCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(1);
+        assertThat(result.deletedObjectCount()).isEqualTo(0);
+        assertThat(result.deleteFailedCount()).isEqualTo(0);
+        assertThat(derivative.getStatus()).isEqualTo(MediaDerivativeStatus.DELETED);
+        assertThat(derivative.isDeleted()).isTrue();
+        verify(mediaWorkerS3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    private MediaDerivative createDerivative(Long derivativeId, Long mediaId, String objectKey) {
+        MediaDerivative derivative = MediaDerivative.createReady(
+                mediaId,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                1L,
+                objectKey,
+                "https://cdn.example.com/" + objectKey,
+                320,
+                180,
+                "image/webp",
+                2_048L
+        );
+        ReflectionTestUtils.setField(derivative, "id", derivativeId);
+        return derivative;
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaRawCleanupSchedulerTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaRawCleanupSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.example.mediaworker.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaRawCleanupSchedulerTest {
+
+    @Mock
+    private MediaRawCleanupService mediaRawCleanupService;
+
+    @Test
+    void cleanupRawAfterTransition_invokesCleanupService() {
+        MediaRawCleanupScheduler scheduler = new MediaRawCleanupScheduler(mediaRawCleanupService);
+        when(mediaRawCleanupService.cleanupRawAfterTransition())
+                .thenReturn(new MediaRawCleanupService.CleanupResult(0, 0, 0, 0, 0, 0));
+
+        scheduler.cleanupRawAfterTransition();
+
+        verify(mediaRawCleanupService).cleanupRawAfterTransition();
+    }
+}

--- a/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaRawCleanupServiceTest.java
+++ b/servers/services/media-worker/src/test/java/com/example/mediaworker/service/MediaRawCleanupServiceTest.java
@@ -1,0 +1,206 @@
+package com.example.mediaworker.service;
+
+import com.example.mediaworker.config.MediaWorkerRawCleanupProperties;
+import com.example.mediaworker.entity.MediaDerivative;
+import com.example.mediaworker.entity.MediaDerivativeProfile;
+import com.example.mediaworker.entity.MediaDerivativeStatus;
+import com.example.mediaworker.entity.MediaFileRecord;
+import com.example.mediaworker.entity.MediaFileStatus;
+import com.example.mediaworker.repository.MediaDerivativeRepository;
+import com.example.mediaworker.repository.MediaFileRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaRawCleanupServiceTest {
+
+    @Mock
+    private MediaFileRecordRepository mediaFileRecordRepository;
+
+    @Mock
+    private MediaDerivativeRepository mediaDerivativeRepository;
+
+    @Mock
+    private S3Client mediaWorkerS3Client;
+
+    private MediaWorkerRawCleanupProperties rawCleanupProperties;
+    private MediaRawCleanupService mediaRawCleanupService;
+
+    @BeforeEach
+    void setUp() {
+        rawCleanupProperties = new MediaWorkerRawCleanupProperties();
+        rawCleanupProperties.setEnabled(true);
+        rawCleanupProperties.setBatchSize(10);
+        rawCleanupProperties.setTransitionGraceDays(7);
+        rawCleanupProperties.setDeleteObjectEnabled(false);
+
+        mediaRawCleanupService = new MediaRawCleanupService(
+                mediaFileRecordRepository,
+                mediaDerivativeRepository,
+                rawCleanupProperties,
+                mediaWorkerS3Client
+        );
+    }
+
+    @Test
+    void cleanupRawAfterTransition_whenDerivativesNotReady_skipsCandidate() {
+        MediaFileRecord candidate = createFileRecord(101L, MediaFileStatus.READY, "raw/101.jpg");
+        when(mediaFileRecordRepository.findRawDeletionCandidates(any(), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                101L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.empty());
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                101L,
+                MediaDerivativeProfile.DISPLAY_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(101L, MediaDerivativeProfile.DISPLAY_WEBP, LocalDateTime.now().minusDays(10))));
+
+        MediaRawCleanupService.CleanupResult result = mediaRawCleanupService.cleanupRawAfterTransition();
+
+        assertThat(result.scannedCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(0);
+        assertThat(result.skippedDerivativeNotReadyCount()).isEqualTo(1);
+        assertThat(result.skippedGraceCount()).isEqualTo(0);
+        assertThat(candidate.getStatus()).isEqualTo(MediaFileStatus.READY);
+        assertThat(candidate.isDeleted()).isFalse();
+    }
+
+    @Test
+    void cleanupRawAfterTransition_whenGraceWindowNotElapsed_skipsCandidate() {
+        MediaFileRecord candidate = createFileRecord(102L, MediaFileStatus.READY, "raw/102.jpg");
+        when(mediaFileRecordRepository.findRawDeletionCandidates(any(), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                102L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(102L, MediaDerivativeProfile.THUMBNAIL_WEBP, LocalDateTime.now().minusDays(2))));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                102L,
+                MediaDerivativeProfile.DISPLAY_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(102L, MediaDerivativeProfile.DISPLAY_WEBP, LocalDateTime.now().minusDays(1))));
+
+        MediaRawCleanupService.CleanupResult result = mediaRawCleanupService.cleanupRawAfterTransition();
+
+        assertThat(result.scannedCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(0);
+        assertThat(result.skippedDerivativeNotReadyCount()).isEqualTo(0);
+        assertThat(result.skippedGraceCount()).isEqualTo(1);
+        verify(mediaWorkerS3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void cleanupRawAfterTransition_whenEligibleAndDeleteEnabled_marksDeleted() {
+        rawCleanupProperties.setDeleteObjectEnabled(true);
+        MediaFileRecord candidate = createFileRecord(103L, MediaFileStatus.READY, "raw/103.jpg");
+        when(mediaFileRecordRepository.findRawDeletionCandidates(any(), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                103L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(103L, MediaDerivativeProfile.THUMBNAIL_WEBP, LocalDateTime.now().minusDays(10))));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                103L,
+                MediaDerivativeProfile.DISPLAY_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(103L, MediaDerivativeProfile.DISPLAY_WEBP, LocalDateTime.now().minusDays(9))));
+
+        MediaRawCleanupService.CleanupResult result = mediaRawCleanupService.cleanupRawAfterTransition();
+
+        assertThat(result.scannedCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(1);
+        assertThat(result.deletedObjectCount()).isEqualTo(1);
+        assertThat(result.deleteFailedCount()).isEqualTo(0);
+        assertThat(candidate.getStatus()).isEqualTo(MediaFileStatus.DELETED);
+        assertThat(candidate.isDeleted()).isTrue();
+        verify(mediaWorkerS3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void cleanupRawAfterTransition_whenDeleteFails_keepsRecordForRetry() {
+        rawCleanupProperties.setDeleteObjectEnabled(true);
+        MediaFileRecord candidate = createFileRecord(104L, MediaFileStatus.READY, "raw/104.jpg");
+        when(mediaFileRecordRepository.findRawDeletionCandidates(any(), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                104L,
+                MediaDerivativeProfile.THUMBNAIL_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(104L, MediaDerivativeProfile.THUMBNAIL_WEBP, LocalDateTime.now().minusDays(12))));
+        when(mediaDerivativeRepository.findTopByMediaIdAndDerivativeProfileAndStatusOrderByMediaVersionDescCreatedAtDesc(
+                104L,
+                MediaDerivativeProfile.DISPLAY_WEBP,
+                MediaDerivativeStatus.READY
+        )).thenReturn(Optional.of(createDerivative(104L, MediaDerivativeProfile.DISPLAY_WEBP, LocalDateTime.now().minusDays(11))));
+        doThrow(new RuntimeException("delete failed"))
+                .when(mediaWorkerS3Client)
+                .deleteObject(any(DeleteObjectRequest.class));
+
+        MediaRawCleanupService.CleanupResult result = mediaRawCleanupService.cleanupRawAfterTransition();
+
+        assertThat(result.scannedCount()).isEqualTo(1);
+        assertThat(result.purgedCount()).isEqualTo(0);
+        assertThat(result.deletedObjectCount()).isEqualTo(0);
+        assertThat(result.deleteFailedCount()).isEqualTo(1);
+        assertThat(candidate.getStatus()).isEqualTo(MediaFileStatus.READY);
+        assertThat(candidate.isDeleted()).isFalse();
+    }
+
+    private MediaDerivative createDerivative(Long mediaId,
+                                             MediaDerivativeProfile profile,
+                                             LocalDateTime readyAt) {
+        MediaDerivative derivative = MediaDerivative.createReady(
+                mediaId,
+                profile,
+                1L,
+                "derived/" + mediaId + ".webp",
+                "https://cdn.example.com/derived/" + mediaId + ".webp",
+                640,
+                360,
+                "image/webp",
+                1024L
+        );
+        ReflectionTestUtils.setField(derivative, "createdAt", readyAt.minusMinutes(1));
+        ReflectionTestUtils.setField(derivative, "updatedAt", readyAt);
+        return derivative;
+    }
+
+    private MediaFileRecord createFileRecord(Long mediaId, MediaFileStatus status, String objectKey) {
+        try {
+            Constructor<MediaFileRecord> constructor = MediaFileRecord.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            MediaFileRecord record = constructor.newInstance();
+            ReflectionTestUtils.setField(record, "id", mediaId);
+            ReflectionTestUtils.setField(record, "status", status);
+            ReflectionTestUtils.setField(record, "bucketName", "team2-donmoa-media-raw");
+            ReflectionTestUtils.setField(record, "objectKey", objectKey);
+            return record;
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to create media file record test fixture", e);
+        }
+    }
+}

--- a/servers/services/product/src/main/java/com/example/product/service/command/image/MediaReferenceService.java
+++ b/servers/services/product/src/main/java/com/example/product/service/command/image/MediaReferenceService.java
@@ -6,6 +6,8 @@ import com.example.clients.media.exception.MediaClientException;
 import com.example.clients.media.facade.MediaClientFacade;
 import com.example.clients.media.impl.MediaClientValidator;
 import com.example.clients.media.dto.MediaLinksSyncCommand;
+import com.example.clients.media.dto.MediaOwnerType;
+import com.example.clients.media.dto.MediaUsageType;
 import com.example.product.exception.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,15 +59,15 @@ public class MediaReferenceService {
             List<Long> normalizedGalleryMediaIds = mediaClientValidator.normalizeMediaIds(galleryMediaIds);
 
             mediaClientFacade.syncLinks(new MediaLinksSyncCommand(
-                    "ITEM",
+                    MediaOwnerType.ITEM,
                     itemId,
                     List.of(
                             new MediaLinksSyncCommand.MediaUsageSet(
-                                    "THUMBNAIL",
+                                    MediaUsageType.THUMBNAIL,
                                     thumbnailMediaIds
                             ),
                             new MediaLinksSyncCommand.MediaUsageSet(
-                                    "GALLERY",
+                                    MediaUsageType.GALLERY,
                                     normalizedGalleryMediaIds
                             )
                     )

--- a/servers/services/product/src/test/java/com/example/product/service/command/image/MediaReferenceServiceTest.java
+++ b/servers/services/product/src/test/java/com/example/product/service/command/image/MediaReferenceServiceTest.java
@@ -5,6 +5,8 @@ import com.example.clients.media.exception.MediaClientException;
 import com.example.clients.media.facade.MediaClientFacade;
 import com.example.clients.media.impl.MediaClientValidator;
 import com.example.clients.media.dto.MediaLinksSyncCommand;
+import com.example.clients.media.dto.MediaOwnerType;
+import com.example.clients.media.dto.MediaUsageType;
 import com.example.core.exception.BusinessException;
 import com.example.product.exception.ProductErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,13 +83,13 @@ class MediaReferenceServiceTest {
         verify(mediaClientFacade).syncLinks(commandCaptor.capture());
 
         MediaLinksSyncCommand command = commandCaptor.getValue();
-        assertThat(command.ownerType()).isEqualTo("ITEM");
+        assertThat(command.ownerType()).isEqualTo(MediaOwnerType.ITEM);
         assertThat(command.ownerId()).isEqualTo(100L);
         assertThat(command.sets()).hasSize(2);
 
-        assertThat(command.sets().get(0).usageType()).isEqualTo("THUMBNAIL");
+        assertThat(command.sets().get(0).usageType()).isEqualTo(MediaUsageType.THUMBNAIL);
         assertThat(command.sets().get(0).mediaIds()).containsExactly(10L);
-        assertThat(command.sets().get(1).usageType()).isEqualTo("GALLERY");
+        assertThat(command.sets().get(1).usageType()).isEqualTo(MediaUsageType.GALLERY);
         assertThat(command.sets().get(1).mediaIds()).containsExactly(20L, 21L);
     }
 

--- a/servers/services/profile/build.gradle.kts
+++ b/servers/services/profile/build.gradle.kts
@@ -41,7 +41,9 @@ dependencies {
     runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
     implementation (project(":libs:clients:auth-client"))
+    implementation(project(":libs:clients:media-client"))
 
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.springframework:spring-webflux")
 

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserCreatedPayload.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserCreatedPayload.java
@@ -1,0 +1,8 @@
+package com.example.profile.consumer;
+
+public record UserCreatedPayload(
+        Long userId,
+        String email,
+        String nickname
+) implements UserProjectionPayload {
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserEmailChangedPayload.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserEmailChangedPayload.java
@@ -1,0 +1,8 @@
+package com.example.profile.consumer;
+
+public record UserEmailChangedPayload(
+        Long userId,
+        String oldEmail,
+        String newEmail
+) implements UserProjectionPayload {
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
@@ -1,0 +1,166 @@
+package com.example.profile.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonDeserializationException;
+import com.example.core.util.JsonUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.example.profile.service.command.ProfileProjectionSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+import java.util.Locale;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserEventConsumer {
+
+    private static final String IDEMPOTENT_EVENT_TYPE = "USER_EVENT";
+    private static final String USER_CREATED_EVENT_TYPE = "USERCREATED";
+    private static final String USER_EMAIL_CHANGED_EVENT_TYPE = "USEREMAILCHANGED";
+    private static final String USER_WITHDRAWN_EVENT_TYPE = "USERWITHDRAWN";
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final ProfileProjectionSyncService profileProjectionSyncService;
+
+    @KafkaListener(topics = "user-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) {
+        Map<String, Object> messageMap = parseMessageMap(message);
+        if (messageMap == null) {
+            return;
+        }
+
+        UserEventEnvelope envelope = parseEnvelope(messageMap);
+        if (!hasRequiredEnvelope(envelope)) {
+            return;
+        }
+
+        String normalizedEventType = normalizeEventType(envelope.eventType());
+        if (!isSupportedType(normalizedEventType)) {
+            log.debug("[ProfileUserEventConsumer] ignore unsupported type. eventId={}, eventType={}",
+                    envelope.eventId(), envelope.eventType());
+            return;
+        }
+
+        UserProjectionPayload payload = parsePayload(messageMap, normalizedEventType);
+        if (!hasRequiredPayload(payload, normalizedEventType)) {
+            log.warn("[ProfileUserEventConsumer] skip invalid payload. eventId={}, eventType={}, userId={}",
+                    envelope.eventId(), envelope.eventType(), payload == null ? null : payload.userId());
+            return;
+        }
+
+        try {
+            idempotentConsumerService.executeIdempotent(envelope.eventId(), IDEMPOTENT_EVENT_TYPE, () -> {
+                routeProjectionEvent(payload, normalizedEventType);
+                log.info("[ProfileUserEventConsumer] projection synced. eventId={}, eventType={}, userId={}",
+                        envelope.eventId(), envelope.eventType(), payload.userId());
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("[ProfileUserEventConsumer] consume failed. eventId={}, eventType={}, userId={}",
+                    envelope.eventId(), envelope.eventType(), payload.userId(), e);
+            throw e;
+        }
+    }
+
+    private Map<String, Object> parseMessageMap(String message) {
+        try {
+            return JsonUtils.fromJson(message, new TypeReference<>() {
+            });
+        } catch (JsonDeserializationException e) {
+            log.warn("[ProfileUserEventConsumer] skip malformed message. payload={}", message);
+            return null;
+        }
+    }
+
+    private UserEventEnvelope parseEnvelope(Map<String, Object> messageMap) {
+        try {
+            return JsonUtils.fromMap(messageMap, UserEventEnvelope.class);
+        } catch (IllegalArgumentException e) {
+            log.warn("[ProfileUserEventConsumer] skip message. envelope parse failed. payload={}", messageMap);
+            return null;
+        }
+    }
+
+    private boolean hasRequiredEnvelope(UserEventEnvelope envelope) {
+        if (envelope == null) {
+            return false;
+        }
+        if (!StringUtils.hasText(envelope.eventId()) || !StringUtils.hasText(envelope.eventType())) {
+            log.warn("[ProfileUserEventConsumer] skip invalid envelope. eventId={}, eventType={}",
+                    envelope.eventId(), envelope.eventType());
+            return false;
+        }
+        return true;
+    }
+
+    private UserProjectionPayload parsePayload(Map<String, Object> messageMap, String normalizedEventType) {
+        try {
+            return switch (normalizedEventType) {
+                case USER_CREATED_EVENT_TYPE -> JsonUtils.fromMap(messageMap, UserCreatedPayload.class);
+                case USER_EMAIL_CHANGED_EVENT_TYPE -> JsonUtils.fromMap(messageMap, UserEmailChangedPayload.class);
+                case USER_WITHDRAWN_EVENT_TYPE -> JsonUtils.fromMap(messageMap, UserWithdrawnPayload.class);
+                default -> null;
+            };
+        } catch (IllegalArgumentException e) {
+            log.warn("[ProfileUserEventConsumer] payload parse failed. eventType={}, payload={}",
+                    normalizedEventType, messageMap);
+            return null;
+        }
+    }
+
+    private boolean hasRequiredPayload(UserProjectionPayload payload, String normalizedEventType) {
+        if (payload == null || payload.userId() == null) {
+            return false;
+        }
+
+        return switch (normalizedEventType) {
+            case USER_CREATED_EVENT_TYPE -> {
+                UserCreatedPayload userCreated = (UserCreatedPayload) payload;
+                yield StringUtils.hasText(userCreated.email()) && StringUtils.hasText(userCreated.nickname());
+            }
+            case USER_EMAIL_CHANGED_EVENT_TYPE -> {
+                UserEmailChangedPayload emailChanged = (UserEmailChangedPayload) payload;
+                yield StringUtils.hasText(emailChanged.newEmail());
+            }
+            case USER_WITHDRAWN_EVENT_TYPE -> true;
+            default -> false;
+        };
+    }
+
+    private boolean isSupportedType(String normalizedEventType) {
+        return USER_CREATED_EVENT_TYPE.equals(normalizedEventType)
+                || USER_EMAIL_CHANGED_EVENT_TYPE.equals(normalizedEventType)
+                || USER_WITHDRAWN_EVENT_TYPE.equals(normalizedEventType);
+    }
+
+    private void routeProjectionEvent(UserProjectionPayload payload, String normalizedEventType) {
+        switch (normalizedEventType) {
+            case USER_CREATED_EVENT_TYPE -> {
+                UserCreatedPayload userCreated = (UserCreatedPayload) payload;
+                profileProjectionSyncService.upsertFromUserCreated(
+                        userCreated.userId(), userCreated.email(), userCreated.nickname()
+                );
+            }
+            case USER_EMAIL_CHANGED_EVENT_TYPE -> {
+                UserEmailChangedPayload emailChanged = (UserEmailChangedPayload) payload;
+                profileProjectionSyncService.applyUserEmailChanged(
+                        emailChanged.userId(), emailChanged.newEmail()
+                );
+            }
+            case USER_WITHDRAWN_EVENT_TYPE ->
+                    profileProjectionSyncService.withdrawProjection(payload.userId());
+            default -> throw new IllegalArgumentException("Unsupported event type: " + normalizedEventType);
+        }
+    }
+
+    private String normalizeEventType(String eventType) {
+        return eventType == null ? "" : eventType.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventEnvelope.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventEnvelope.java
@@ -1,0 +1,7 @@
+package com.example.profile.consumer;
+
+public record UserEventEnvelope(
+        String eventId,
+        String eventType
+) {
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserProjectionPayload.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserProjectionPayload.java
@@ -1,0 +1,5 @@
+package com.example.profile.consumer;
+
+public interface UserProjectionPayload {
+    Long userId();
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserWithdrawnPayload.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserWithdrawnPayload.java
@@ -1,0 +1,6 @@
+package com.example.profile.consumer;
+
+public record UserWithdrawnPayload(
+        Long userId
+) implements UserProjectionPayload {
+}

--- a/servers/services/profile/src/main/java/com/example/profile/controller/api/command/ProfileCommandApi.java
+++ b/servers/services/profile/src/main/java/com/example/profile/controller/api/command/ProfileCommandApi.java
@@ -19,23 +19,4 @@ public interface ProfileCommandApi {
         @RequestHeader("X-User-Id") Long userId
     );
 
-    /*
-    put
-    profile 1
-        mediaId : null
-
-        -> mediaId :1
-
-    profile 1
-        mediaId : 1
-
-       -> 이미지 변경
-            mediaId:2
-
-        mediaId : null
-            patch ->  이미지변경x vs 이미지 삭제 ?
-           put -> 이미지 삭제
-
-
-     */
 }

--- a/servers/services/profile/src/main/java/com/example/profile/dto/request/ProfileRequest.java
+++ b/servers/services/profile/src/main/java/com/example/profile/dto/request/ProfileRequest.java
@@ -1,12 +1,16 @@
 package com.example.profile.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.example.core.id.jackson.SnowflakeId;
-import com.example.profile.entity.Profiles;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProfileRequest {
 
     @SnowflakeId
@@ -15,5 +19,33 @@ public class ProfileRequest {
     private String phone;
     private String delivery;
     private String nickname;
+    private String mediaRef;
 
+    @JsonSetter("mediaId")
+    public void setMediaIdRaw(Object mediaIdRaw) {
+        if (mediaIdRaw == null) {
+            this.mediaId = null;
+            return;
+        }
+
+        if (mediaIdRaw instanceof Number number) {
+            this.mediaId = number.longValue();
+            return;
+        }
+
+        if (mediaIdRaw instanceof String value) {
+            String normalized = value.trim();
+            if (normalized.isEmpty()) {
+                this.mediaId = null;
+                return;
+            }
+
+            try {
+                this.mediaId = Long.parseLong(normalized);
+            } catch (NumberFormatException ignored) {
+                this.mediaId = null;
+                this.mediaRef = normalized;
+            }
+        }
+    }
 }

--- a/servers/services/profile/src/main/java/com/example/profile/entity/Profiles.java
+++ b/servers/services/profile/src/main/java/com/example/profile/entity/Profiles.java
@@ -3,14 +3,16 @@ package com.example.profile.entity;
 import com.example.clients.auth.dto.profile.AuthSyncQuery;
 import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
-import com.example.profile.dto.request.ProfileCreateRequest;
 import com.example.profile.dto.request.ProfileRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.util.StringUtils;
 
 import java.util.Objects;
 
@@ -38,6 +40,9 @@ public class Profiles extends BaseEntity {
     @Column(name = "phone_number", length = 15)
     private String phoneNumber;
 
+    @OneToOne(mappedBy = "profile", fetch = FetchType.LAZY)
+    private ProfilesImage profileImage;
+
     public void updateProfile(ProfileRequest profile
     ){
         if (profile.getEmail() != null && !Objects.equals(this.email, profile.getEmail()))
@@ -57,5 +62,30 @@ public class Profiles extends BaseEntity {
             .build();
     }
 
+    public static Profiles createProjection(Long userId, String email, String nickname) {
+        return Profiles.builder()
+            .userId(userId)
+            .email(email)
+            .nickname(nickname)
+            .build();
+    }
 
+    public void applyUserCreatedProjection(String email, String nickname) {
+        if (StringUtils.hasText(email) && !Objects.equals(this.email, email)) {
+            this.email = email;
+        }
+        if (StringUtils.hasText(nickname) && !Objects.equals(this.nickname, nickname)) {
+            this.nickname = nickname;
+        }
+    }
+
+    public void applyEmailChangedProjection(String newEmail) {
+        if (StringUtils.hasText(newEmail) && !Objects.equals(this.email, newEmail)) {
+            this.email = newEmail;
+        }
+    }
+
+    public ProfilesImage getProfileImage() {
+        return profileImage;
+    }
 }

--- a/servers/services/profile/src/main/java/com/example/profile/entity/ProfilesImage.java
+++ b/servers/services/profile/src/main/java/com/example/profile/entity/ProfilesImage.java
@@ -16,19 +16,27 @@ public class ProfilesImage extends BaseEntity {
     @Column(name = "user_id")
     private Long userId;
 
-    @MapsId
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, insertable = false, updatable = false)
     private Profiles profile;
 
-    @Column(name = "media_id", nullable = false, length = 500)
+    @Column(name = "media_id", length = 500)
     private Long mediaId;
 
     @Column(name = "sort_order")
+    @Builder.Default
     private Integer sortOrder = 0;
 
     public void updateMediaId(Long mediaId) {
         this.mediaId = mediaId;
+    }
+
+    public static ProfilesImage createDefault(Profiles profile) {
+        return ProfilesImage.builder()
+            .userId(profile.getUserId())
+            .profile(profile)
+            .mediaId(null)
+            .build();
     }
 
 

--- a/servers/services/profile/src/main/java/com/example/profile/repository/ProfileRepository.java
+++ b/servers/services/profile/src/main/java/com/example/profile/repository/ProfileRepository.java
@@ -1,18 +1,19 @@
 package com.example.profile.repository;
 
 import com.example.profile.entity.Profiles;
-import io.lettuce.core.dynamic.annotation.Param;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<Profiles, Long> {
 
    Optional<Profiles>  findByUserId(Long userId);
+
+   @Query("select p from Profiles p left join fetch p.profileImage where p.userId = :userId")
+   Optional<Profiles> findByUserIdWithImage(@Param("userId") Long userId);
 
    boolean existsByNickname(String nickname);
 

--- a/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
+++ b/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
@@ -2,8 +2,6 @@ package com.example.profile.service.command;
 
 import com.example.clients.auth.dto.profile.AuthSyncQuery;
 import com.example.core.exception.BusinessException;
-import com.example.core.exception.CommonErrorCode;
-import com.example.core.exception.TechnicalException;
 import com.example.profile.dto.request.ProfileRequest;
 import com.example.profile.entity.ProfileAddress;
 import com.example.profile.entity.Profiles;
@@ -16,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,32 +27,22 @@ public class ProfileCommandService {
     private final ProfileImageRepository profilesImageRepository;
     private final ProfileRepository profileRepository;
     private final ProfileAddressRepository profileAddressRepository;
+    private final ProfileMediaReferenceService profileMediaReferenceService;
 
     @Transactional
-    public void createProfile(AuthSyncQuery req)
-    {
-        if(profileRepository.existsByNickname(req.profileInfo().nickname()))
-        {
+    public void createProfile(AuthSyncQuery req) {
+        if (profileRepository.existsByNickname(req.profileInfo().nickname())) {
             throw new BusinessException(ProfileErrorCode.PROFILE_ALREADY_NICKNAME);
         }
 
-        try {
-            Profiles profile = profileRepository.save(Profiles.create(req));
+        Profiles profile = profileRepository.save(Profiles.create(req));
+        profilesImageRepository.save(ProfilesImage.createDefault(profile));
 
-            profilesImageRepository.save(ProfilesImage.builder()
-                .userId(req.profileInfo().userId())
-                .build());
-
-            if (req.profileDeliveryInfo() != null && !req.profileDeliveryInfo().isEmpty()){
-                List<ProfileAddress> addresses = req.profileDeliveryInfo().stream()
-                    .map(addr -> ProfileAddress.create(profile.getUserId(), addr))
-                    .toList();
-                profileAddressRepository.saveAll(addresses);
-            }
-        } catch (BusinessException e){
-            throw new BusinessException(ProfileErrorCode.PROFILE_NOT_FOUND);
-        } catch (TechnicalException e){
-            throw   new TechnicalException(CommonErrorCode.INTERNAL_ERROR);
+        if (req.profileDeliveryInfo() != null && !req.profileDeliveryInfo().isEmpty()) {
+            List<ProfileAddress> addresses = req.profileDeliveryInfo().stream()
+                .map(addr -> ProfileAddress.create(profile.getUserId(), addr))
+                .toList();
+            profileAddressRepository.saveAll(addresses);
         }
     }
 
@@ -61,30 +50,27 @@ public class ProfileCommandService {
     public void updateProfile(ProfileRequest req, Long userId) {
         Profiles profile = profileRepository.findByUserId(userId)
             .orElseThrow(() -> new BusinessException(ProfileErrorCode.PROFILE_NOT_FOUND));
-        ProfilesImage findUser = profilesImageRepository.findByUserId(userId)
-            .orElseThrow(() -> new BusinessException(ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND));
 
-        if(req.getMediaId() != null){
-            findUser.updateMediaId(req.getMediaId());
-        } else {
-            findUser.updateMediaId(null);
+        Long canonicalMediaId = profileMediaReferenceService.resolveCanonicalMediaId(req.getMediaId(), req.getMediaRef());
+        profileMediaReferenceService.validateReadableMedia(canonicalMediaId);
 
-        }
+        ProfilesImage profileImage = profilesImageRepository.findByUserId(userId)
+            .orElseGet(() -> profilesImageRepository.save(ProfilesImage.createDefault(profile)));
+        profileImage.updateMediaId(canonicalMediaId);
 
-        if(existsMyNickname(req, profile)){
-            profile.updateProfile(req);
-        } else {
-            throw new TechnicalException(CommonErrorCode.INTERNAL_ERROR);
-        }
+        validateNicknameAvailability(req, profile);
+        profile.updateProfile(req);
+        profileMediaReferenceService.syncProfileImageLink(userId, canonicalMediaId);
     }
 
-    private boolean existsMyNickname(ProfileRequest req, Profiles profile) {
-        if(profileRepository.existsByNickname(req.getNickname()) && !Objects.equals(req.getNickname(), profile.getNickname())) {
+    private void validateNicknameAvailability(ProfileRequest req, Profiles profile) {
+        if (!StringUtils.hasText(req.getNickname())) {
+            return;
+        }
+
+        if (profileRepository.existsByNickname(req.getNickname())
+            && !Objects.equals(req.getNickname(), profile.getNickname())) {
             throw new BusinessException(ProfileErrorCode.PROFILE_ALREADY_NICKNAME);
         }
-        return true;
     }
-
-
-
 }

--- a/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileMediaReferenceService.java
+++ b/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileMediaReferenceService.java
@@ -1,0 +1,109 @@
+package com.example.profile.service.command;
+
+import com.example.clients.media.dto.MediaLinksSyncCommand;
+import com.example.clients.media.dto.MediaOwnerType;
+import com.example.clients.media.dto.MediaUsageType;
+import com.example.clients.media.exception.InvalidMediaReferenceException;
+import com.example.clients.media.exception.MediaClientException;
+import com.example.clients.media.facade.MediaClientFacade;
+import com.example.core.exception.BusinessException;
+import com.example.profile.exception.ProfileErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileMediaReferenceService {
+
+    private static final Pattern LEGACY_MEDIA_REF_PATTERN = Pattern.compile("(?i)^media[-_:]?(\\d+)$");
+
+    private final MediaClientFacade mediaClientFacade;
+
+    public Long resolveCanonicalMediaId(Long mediaId, String mediaRef) {
+        if (mediaId != null) {
+            return ensurePositiveMediaId(mediaId);
+        }
+
+        if (!StringUtils.hasText(mediaRef)) {
+            return null;
+        }
+
+        String normalizedRef = mediaRef.trim();
+        if (normalizedRef.chars().allMatch(Character::isDigit)) {
+            return ensurePositiveMediaId(parseLong(normalizedRef));
+        }
+
+        Matcher matcher = LEGACY_MEDIA_REF_PATTERN.matcher(normalizedRef);
+        if (matcher.matches()) {
+            return ensurePositiveMediaId(parseLong(matcher.group(1)));
+        }
+
+        throw new BusinessException(ProfileErrorCode.INVALID_MEDIA_ID);
+    }
+
+    public void validateReadableMedia(Long mediaId) {
+        if (mediaId == null) {
+            return;
+        }
+
+        try {
+            mediaClientFacade.getMediaUrl(mediaId);
+        } catch (InvalidMediaReferenceException e) {
+            throw new BusinessException(ProfileErrorCode.MEDIA_VALIDATION_FAILED, e);
+        } catch (MediaClientException e) {
+            throw new BusinessException(ProfileErrorCode.MEDIA_SERVICE_COMMUNICATION_ERROR, e);
+        }
+    }
+
+    public void syncProfileImageLink(Long userId, Long mediaId) {
+        List<Long> mediaIds = mediaId == null ? List.of() : List.of(mediaId);
+        MediaLinksSyncCommand command = new MediaLinksSyncCommand(
+                MediaOwnerType.USER_PROFILE,
+                userId,
+                List.of(new MediaLinksSyncCommand.MediaUsageSet(MediaUsageType.THUMBNAIL, mediaIds))
+        );
+
+        doSyncLinks(command);
+    }
+
+    public void clearProfileLinks(Long userId) {
+        MediaLinksSyncCommand command = new MediaLinksSyncCommand(
+                MediaOwnerType.USER_PROFILE,
+                userId,
+                List.of()
+        );
+
+        doSyncLinks(command);
+    }
+
+    private void doSyncLinks(MediaLinksSyncCommand command) {
+
+        try {
+            mediaClientFacade.syncLinks(command);
+        } catch (InvalidMediaReferenceException e) {
+            throw new BusinessException(ProfileErrorCode.MEDIA_VALIDATION_FAILED, e);
+        } catch (MediaClientException e) {
+            throw new BusinessException(ProfileErrorCode.MEDIA_SERVICE_COMMUNICATION_ERROR, e);
+        }
+    }
+
+    private Long parseLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ProfileErrorCode.INVALID_MEDIA_ID, e);
+        }
+    }
+
+    private Long ensurePositiveMediaId(Long mediaId) {
+        if (mediaId == null || mediaId <= 0) {
+            throw new BusinessException(ProfileErrorCode.INVALID_MEDIA_ID);
+        }
+        return mediaId;
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileProjectionSyncService.java
+++ b/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileProjectionSyncService.java
@@ -1,0 +1,58 @@
+package com.example.profile.service.command;
+
+import com.example.profile.entity.Profiles;
+import com.example.profile.entity.ProfilesImage;
+import com.example.profile.repository.ProfileImageRepository;
+import com.example.profile.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileProjectionSyncService {
+
+    private final ProfileRepository profileRepository;
+    private final ProfileImageRepository profileImageRepository;
+    private final ProfileMediaReferenceService profileMediaReferenceService;
+
+    @Transactional
+    public void upsertFromUserCreated(Long userId, String email, String nickname) {
+        Profiles profile = profileRepository.findByUserId(userId)
+                .map(existing -> {
+                    existing.applyUserCreatedProjection(email, nickname);
+                    return existing;
+                })
+                .orElseGet(() -> profileRepository.save(Profiles.createProjection(userId, email, nickname)));
+
+        profileImageRepository.findByUserId(userId)
+                .orElseGet(() -> profileImageRepository.save(ProfilesImage.createDefault(profile)));
+
+        log.info("[ProfileProjectionSync] user projection upsert completed. userId={}", userId);
+    }
+
+    @Transactional
+    public void applyUserEmailChanged(Long userId, String newEmail) {
+        profileRepository.findByUserId(userId)
+                .ifPresentOrElse(profile -> {
+                    profile.applyEmailChangedProjection(newEmail);
+                    log.info("[ProfileProjectionSync] email projection updated. userId={}", userId);
+                }, () -> log.warn("[ProfileProjectionSync] email change skipped. profile not found. userId={}", userId));
+    }
+
+    @Transactional
+    public void withdrawProjection(Long userId) {
+        profileMediaReferenceService.clearProfileLinks(userId);
+        profileRepository.findByUserIdWithImage(userId)
+                .ifPresentOrElse(profile -> {
+                    profile.softDelete();
+                    ProfilesImage image = profile.getProfileImage();
+                    if (image != null) {
+                        image.updateMediaId(null);
+                    }
+                    log.info("[ProfileProjectionSync] user projection withdrawn. userId={}", userId);
+                }, () -> log.warn("[ProfileProjectionSync] profile not found during withdraw projection. links cleared only. userId={}", userId));
+    }
+}

--- a/servers/services/profile/src/main/resources/application.yml
+++ b/servers/services/profile/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
     consumer:
-      group-id: sales-service-group
+      group-id: profile-service-group
       auto-offset-reset: earliest
   # ─── Snowflake ID ────────────────────────────
   app:

--- a/servers/services/profile/src/main/resources/db/migration/V4__align_profile_images_media_id_nullable.sql
+++ b/servers/services/profile/src/main/resources/db/migration/V4__align_profile_images_media_id_nullable.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'profile_images'
+          AND column_name = 'media_id'
+          AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE profile_images
+            ALTER COLUMN media_id DROP NOT NULL;
+    END IF;
+END $$;

--- a/servers/services/profile/src/test/java/com/example/profile/consumer/UserEventConsumerTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/consumer/UserEventConsumerTest.java
@@ -1,0 +1,155 @@
+package com.example.profile.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.profile.service.command.ProfileProjectionSyncService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventConsumerTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private ProfileProjectionSyncService profileProjectionSyncService;
+
+    private UserEventConsumer userEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        userEventConsumer = new UserEventConsumer(idempotentConsumerService, profileProjectionSyncService);
+    }
+
+    @Test
+    void consume_processesUserCreatedEventIdempotently() {
+        String message = """
+                {"eventId":"evt-1","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-1"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> processor = invocation.getArgument(2);
+                    processor.get();
+                    return Optional.empty();
+                });
+
+        userEventConsumer.consume(message);
+
+        verify(profileProjectionSyncService).upsertFromUserCreated(101L, "user@example.com", "tester");
+    }
+
+    @Test
+    void consume_skipsWhenEnvelopeIsInvalid() {
+        String message = """
+                {"eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                """;
+
+        userEventConsumer.consume(message);
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void consume_skipsUnsupportedEventType() {
+        String message = """
+                {"eventId":"evt-unsupported","eventType":"UserPasswordChanged","userId":101}
+                """;
+
+        userEventConsumer.consume(message);
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void consume_processesUserEmailChangedEventIdempotently() {
+        String message = """
+                {"eventId":"evt-2","eventType":"UserEmailChanged","userId":101,"oldEmail":"old@example.com","newEmail":"new@example.com"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-2"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> processor = invocation.getArgument(2);
+                    processor.get();
+                    return Optional.empty();
+                });
+
+        userEventConsumer.consume(message);
+
+        verify(profileProjectionSyncService).applyUserEmailChanged(101L, "new@example.com");
+    }
+
+    @Test
+    void consume_processesUserWithdrawnEventIdempotently() {
+        String message = """
+                {"eventId":"evt-5","eventType":"UserWithdrawn","userId":101}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-5"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> processor = invocation.getArgument(2);
+                    processor.get();
+                    return Optional.empty();
+                });
+
+        userEventConsumer.consume(message);
+
+        verify(profileProjectionSyncService).withdrawProjection(101L);
+    }
+
+    @Test
+    void consume_skipsWhenPayloadIsInvalid() {
+        String message = """
+                {"eventId":"evt-3","eventType":"UserCreated","userId":101,"email":"user@example.com"}
+                """;
+
+        userEventConsumer.consume(message);
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void consume_skipsWhenUserEmailChangedPayloadIsInvalid() {
+        String message = """
+                {"eventId":"evt-6","eventType":"UserEmailChanged","userId":101}
+                """;
+
+        userEventConsumer.consume(message);
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void consume_rethrowsWhenIdempotentProcessingFails() {
+        String message = """
+                {"eventId":"evt-4","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-4"), eq("USER_EVENT"), any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> userEventConsumer.consume(message))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("boom");
+
+        verify(profileProjectionSyncService, never()).upsertFromUserCreated(any(), any(), any());
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileCommandServiceTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileCommandServiceTest.java
@@ -1,0 +1,177 @@
+package com.example.profile.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.profile.dto.request.ProfileRequest;
+import com.example.profile.entity.Profiles;
+import com.example.profile.entity.ProfilesImage;
+import com.example.profile.exception.ProfileErrorCode;
+import com.example.profile.repository.ProfileAddressRepository;
+import com.example.profile.repository.ProfileImageRepository;
+import com.example.profile.repository.ProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileCommandServiceTest {
+
+    @Mock
+    private ProfileImageRepository profileImageRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ProfileAddressRepository profileAddressRepository;
+
+    @Mock
+    private ProfileMediaReferenceService profileMediaReferenceService;
+
+    private ProfileCommandService profileCommandService;
+
+    @BeforeEach
+    void setUp() {
+        profileCommandService = new ProfileCommandService(
+            profileImageRepository,
+            profileRepository,
+            profileAddressRepository,
+            profileMediaReferenceService
+        );
+    }
+
+    @Test
+    void updateProfile_updatesImageAndSyncsWhenMediaIdProvided() {
+        Long userId = 101L;
+        Profiles profile = createProfile(userId, "old@example.com", "oldNick");
+        ProfilesImage image = ProfilesImage.builder()
+            .userId(userId)
+            .profile(profile)
+            .mediaId(1L)
+            .build();
+        ProfileRequest request = ProfileRequest.builder()
+            .mediaId(777L)
+            .nickname("newNick")
+            .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(profileRepository.existsByNickname("newNick")).thenReturn(false);
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(image));
+        when(profileMediaReferenceService.resolveCanonicalMediaId(777L, null)).thenReturn(777L);
+
+        profileCommandService.updateProfile(request, userId);
+
+        assertThat(image.getMediaId()).isEqualTo(777L);
+        assertThat(profile.getNickname()).isEqualTo("newNick");
+        verify(profileMediaReferenceService).validateReadableMedia(777L);
+        verify(profileMediaReferenceService).syncProfileImageLink(userId, 777L);
+    }
+
+    @Test
+    void updateProfile_clearsImageAndSyncsWhenMediaIdIsNull() {
+        Long userId = 102L;
+        Profiles profile = createProfile(userId, "user@example.com", "nick");
+        ProfilesImage image = ProfilesImage.builder()
+            .userId(userId)
+            .profile(profile)
+            .mediaId(55L)
+            .build();
+        ProfileRequest request = ProfileRequest.builder()
+            .mediaId(null)
+            .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(image));
+        when(profileMediaReferenceService.resolveCanonicalMediaId(null, null)).thenReturn(null);
+
+        profileCommandService.updateProfile(request, userId);
+
+        assertThat(image.getMediaId()).isNull();
+        verify(profileMediaReferenceService).validateReadableMedia(null);
+        verify(profileMediaReferenceService).syncProfileImageLink(userId, null);
+    }
+
+    @Test
+    void updateProfile_createsDefaultImageRowWhenMissing() {
+        Long userId = 103L;
+        Profiles profile = createProfile(userId, "user103@example.com", "nick103");
+        ProfileRequest request = ProfileRequest.builder()
+            .mediaId(888L)
+            .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(profileImageRepository.save(any(ProfilesImage.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+        when(profileMediaReferenceService.resolveCanonicalMediaId(888L, null)).thenReturn(888L);
+
+        profileCommandService.updateProfile(request, userId);
+
+        verify(profileImageRepository).save(any(ProfilesImage.class));
+        verify(profileMediaReferenceService).syncProfileImageLink(userId, 888L);
+    }
+
+    @Test
+    void updateProfile_passesLegacyMediaRefToConverter() {
+        Long userId = 105L;
+        Profiles profile = createProfile(userId, "user105@example.com", "nick105");
+        ProfileRequest request = ProfileRequest.builder()
+            .mediaRef("media-4321")
+            .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(
+            ProfilesImage.builder().userId(userId).profile(profile).mediaId(null).build()
+        ));
+        when(profileMediaReferenceService.resolveCanonicalMediaId(null, "media-4321")).thenReturn(4321L);
+
+        profileCommandService.updateProfile(request, userId);
+
+        verify(profileMediaReferenceService).resolveCanonicalMediaId(null, "media-4321");
+        verify(profileMediaReferenceService).syncProfileImageLink(userId, 4321L);
+    }
+
+    @Test
+    void updateProfile_throwsWhenNicknameAlreadyExistsForAnotherUser() {
+        Long userId = 104L;
+        Profiles profile = createProfile(userId, "user104@example.com", "currentNick");
+        ProfileRequest request = ProfileRequest.builder()
+            .nickname("takenNick")
+            .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(
+            ProfilesImage.builder().userId(userId).profile(profile).mediaId(null).build()
+        ));
+        when(profileMediaReferenceService.resolveCanonicalMediaId(null, null)).thenReturn(null);
+        when(profileRepository.existsByNickname("takenNick")).thenReturn(true);
+
+        assertThatThrownBy(() -> profileCommandService.updateProfile(request, userId))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ProfileErrorCode.PROFILE_ALREADY_NICKNAME);
+
+        verify(profileMediaReferenceService, never()).syncProfileImageLink(eq(userId), any());
+    }
+
+    private Profiles createProfile(Long userId, String email, String nickname) {
+        return Profiles.builder()
+            .id(userId + 1000L)
+            .userId(userId)
+            .email(email)
+            .nickname(nickname)
+            .phoneNumber("010-0000-0000")
+            .build();
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileMediaReferenceServiceTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileMediaReferenceServiceTest.java
@@ -1,0 +1,107 @@
+package com.example.profile.service.command;
+
+import com.example.clients.media.dto.MediaLinksSyncCommand;
+import com.example.clients.media.dto.MediaOwnerType;
+import com.example.clients.media.dto.MediaUsageType;
+import com.example.clients.media.exception.InvalidMediaReferenceException;
+import com.example.clients.media.exception.MediaClientException;
+import com.example.clients.media.facade.MediaClientFacade;
+import com.example.core.exception.BusinessException;
+import com.example.profile.exception.ProfileErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileMediaReferenceServiceTest {
+
+    @Mock
+    private MediaClientFacade mediaClientFacade;
+
+    private ProfileMediaReferenceService profileMediaReferenceService;
+
+    @BeforeEach
+    void setUp() {
+        profileMediaReferenceService = new ProfileMediaReferenceService(mediaClientFacade);
+    }
+
+    @Test
+    void resolveCanonicalMediaId_returnsMediaIdWhenNumericValueProvided() {
+        Long mediaId = profileMediaReferenceService.resolveCanonicalMediaId(101L, null);
+
+        assertThat(mediaId).isEqualTo(101L);
+    }
+
+    @Test
+    void resolveCanonicalMediaId_convertsLegacyRefWithPrefix() {
+        Long mediaId = profileMediaReferenceService.resolveCanonicalMediaId(null, "media-202");
+
+        assertThat(mediaId).isEqualTo(202L);
+    }
+
+    @Test
+    void resolveCanonicalMediaId_throwsWhenLegacyRefIsInvalid() {
+        assertThatThrownBy(() -> profileMediaReferenceService.resolveCanonicalMediaId(null, "legacy-image-ref"))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ProfileErrorCode.INVALID_MEDIA_ID);
+    }
+
+    @Test
+    void validateReadableMedia_mapsInvalidReferenceToBusinessError() {
+        doThrow(new InvalidMediaReferenceException("invalid"))
+            .when(mediaClientFacade).getMediaUrl(303L);
+
+        assertThatThrownBy(() -> profileMediaReferenceService.validateReadableMedia(303L))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ProfileErrorCode.MEDIA_VALIDATION_FAILED);
+    }
+
+    @Test
+    void syncProfileImageLink_mapsCommunicationFailureToBusinessError() {
+        doThrow(new MediaClientException("downstream error"))
+            .when(mediaClientFacade).syncLinks(org.mockito.ArgumentMatchers.any(MediaLinksSyncCommand.class));
+
+        assertThatThrownBy(() -> profileMediaReferenceService.syncProfileImageLink(1L, 99L))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ProfileErrorCode.MEDIA_SERVICE_COMMUNICATION_ERROR);
+    }
+
+    @Test
+    void syncProfileImageLink_sendsOwnerAndUsageContract() {
+        profileMediaReferenceService.syncProfileImageLink(11L, 400L);
+
+        ArgumentCaptor<MediaLinksSyncCommand> captor = ArgumentCaptor.forClass(MediaLinksSyncCommand.class);
+        verify(mediaClientFacade).syncLinks(captor.capture());
+
+        MediaLinksSyncCommand command = captor.getValue();
+        assertThat(command.ownerType()).isEqualTo(MediaOwnerType.USER_PROFILE);
+        assertThat(command.ownerId()).isEqualTo(11L);
+        assertThat(command.sets()).hasSize(1);
+        assertThat(command.sets().get(0).usageType()).isEqualTo(MediaUsageType.THUMBNAIL);
+        assertThat(command.sets().get(0).mediaIds()).containsExactly(400L);
+    }
+
+    @Test
+    void clearProfileLinks_sendsEmptySetsForOwnerWideUnlink() {
+        profileMediaReferenceService.clearProfileLinks(12L);
+
+        ArgumentCaptor<MediaLinksSyncCommand> captor = ArgumentCaptor.forClass(MediaLinksSyncCommand.class);
+        verify(mediaClientFacade).syncLinks(captor.capture());
+
+        MediaLinksSyncCommand command = captor.getValue();
+        assertThat(command.ownerType()).isEqualTo(MediaOwnerType.USER_PROFILE);
+        assertThat(command.ownerId()).isEqualTo(12L);
+        assertThat(command.sets()).isEmpty();
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceIntegrationTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.example.profile.service.command;
+
+import com.example.profile.entity.Profiles;
+import com.example.profile.repository.ProfileImageRepository;
+import com.example.profile.repository.ProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({ProfileProjectionSyncService.class, ProfileProjectionSyncServiceIntegrationTest.JpaAuditTestConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ProfileProjectionSyncServiceIntegrationTest {
+
+    @TestConfiguration
+    @EnableJpaAuditing
+    static class JpaAuditTestConfig {
+    }
+
+    @Autowired
+    private ProfileProjectionSyncService profileProjectionSyncService;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Autowired
+    private ProfileImageRepository profileImageRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockBean
+    private ProfileMediaReferenceService profileMediaReferenceService;
+
+    @Test
+    void upsertFromUserCreated_updatesExistingProjectionConsistently() {
+        Long userId = 7001L;
+
+        Profiles existing = profileRepository.save(Profiles.createProjection(userId, "first@example.com", "firstNick"));
+        jdbcTemplate.update(
+                "insert into profile_images (user_id, media_id, sort_order, created_at, updated_at) values (?, ?, ?, current_timestamp, current_timestamp)",
+                userId,
+                null,
+                0
+        );
+
+        profileProjectionSyncService.upsertFromUserCreated(userId, "updated@example.com", "updatedNick");
+
+        Profiles updatedProjection = profileRepository.findByUserId(userId).orElseThrow();
+        assertThat(updatedProjection.getId()).isEqualTo(existing.getId());
+        assertThat(updatedProjection.getEmail()).isEqualTo("updated@example.com");
+        assertThat(updatedProjection.getNickname()).isEqualTo("updatedNick");
+        assertThat(profileRepository.findAll().stream().filter(profile -> userId.equals(profile.getUserId())).count())
+                .isEqualTo(1L);
+        assertThat(profileImageRepository.findByUserId(userId)).isPresent();
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceTest.java
@@ -1,0 +1,150 @@
+package com.example.profile.service.command;
+
+import com.example.profile.entity.Profiles;
+import com.example.profile.entity.ProfilesImage;
+import com.example.profile.repository.ProfileImageRepository;
+import com.example.profile.repository.ProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileProjectionSyncServiceTest {
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ProfileImageRepository profileImageRepository;
+
+    @Mock
+    private ProfileMediaReferenceService profileMediaReferenceService;
+
+    private ProfileProjectionSyncService profileProjectionSyncService;
+
+    @BeforeEach
+    void setUp() {
+        profileProjectionSyncService = new ProfileProjectionSyncService(
+                profileRepository,
+                profileImageRepository,
+                profileMediaReferenceService
+        );
+    }
+
+    @Test
+    void upsertFromUserCreated_createsProfileAndDefaultImageWhenMissing() {
+        Long userId = 501L;
+        Profiles createdProfile = Profiles.createProjection(userId, "new@example.com", "newbie");
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(profileRepository.save(any(Profiles.class))).thenReturn(createdProfile);
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(profileImageRepository.save(any(ProfilesImage.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        profileProjectionSyncService.upsertFromUserCreated(userId, "new@example.com", "newbie");
+
+        verify(profileRepository).save(any(Profiles.class));
+        verify(profileImageRepository).save(any(ProfilesImage.class));
+    }
+
+    @Test
+    void upsertFromUserCreated_updatesExistingProfileAndKeepsImageRow() {
+        Long userId = 502L;
+        Profiles existing = Profiles.builder()
+                .id(9002L)
+                .userId(userId)
+                .email("old@example.com")
+                .nickname("old-nick")
+                .build();
+        ProfilesImage existingImage = ProfilesImage.builder()
+                .userId(userId)
+                .profile(existing)
+                .mediaId(100L)
+                .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(existing));
+        when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(existingImage));
+
+        profileProjectionSyncService.upsertFromUserCreated(userId, "updated@example.com", "updated-nick");
+
+        assertThat(existing.getEmail()).isEqualTo("updated@example.com");
+        assertThat(existing.getNickname()).isEqualTo("updated-nick");
+        verify(profileRepository, never()).save(any(Profiles.class));
+        verify(profileImageRepository, never()).save(any(ProfilesImage.class));
+    }
+
+    @Test
+    void applyUserEmailChanged_updatesEmailWhenProfileExists() {
+        Long userId = 601L;
+        Profiles existing = Profiles.builder()
+                .id(9601L)
+                .userId(userId)
+                .email("old@example.com")
+                .nickname("tester")
+                .build();
+
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(existing));
+
+        profileProjectionSyncService.applyUserEmailChanged(userId, "new@example.com");
+
+        assertThat(existing.getEmail()).isEqualTo("new@example.com");
+        verify(profileRepository, never()).save(any(Profiles.class));
+    }
+
+    @Test
+    void applyUserEmailChanged_noopWhenProfileMissing() {
+        Long userId = 602L;
+        when(profileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        profileProjectionSyncService.applyUserEmailChanged(userId, "new@example.com");
+
+        verify(profileRepository, never()).save(any(Profiles.class));
+    }
+
+    @Test
+    void withdrawProjection_softDeletesProfileAndClearsMedia() {
+        Long userId = 603L;
+        Profiles existing = Profiles.builder()
+                .id(9603L)
+                .userId(userId)
+                .email("user603@example.com")
+                .nickname("user603")
+                .build();
+        ProfilesImage existingImage = ProfilesImage.builder()
+                .userId(userId)
+                .profile(existing)
+                .mediaId(999L)
+                .build();
+        ReflectionTestUtils.setField(existing, "profileImage", existingImage);
+
+        when(profileRepository.findByUserIdWithImage(userId)).thenReturn(Optional.of(existing));
+
+        profileProjectionSyncService.withdrawProjection(userId);
+
+        assertThat(existing.getDeletedAt()).isNotNull();
+        assertThat(existingImage.getMediaId()).isNull();
+        verify(profileMediaReferenceService).clearProfileLinks(userId);
+    }
+
+    @Test
+    void withdrawProjection_whenProfileMissing_stillClearsMediaLinks() {
+        Long userId = 604L;
+        when(profileRepository.findByUserIdWithImage(userId)).thenReturn(Optional.empty());
+
+        profileProjectionSyncService.withdrawProjection(userId);
+
+        verify(profileMediaReferenceService).clearProfileLinks(userId);
+    }
+}


### PR DESCRIPTION
## 개요
- Auth 서비스의 사용자 이벤트(생성/이메일변경/탈퇴)를 Profile 서비스에서 소비하여 프로젝션 동기화를 구현했습니다.
- 탈퇴 이벤트 처리 시 프로필 레코드가 없어도 미디어 링크 해제가 항상 실행되도록 보강했습니다.
- media-client 연동 계약을 enum 기반(`MediaOwnerType`, `MediaUsageType`)으로 정리하고, 프로필 이미지는 `THUMBNAIL` 용도로 동기화하도록 맞췄습니다.
- Media Worker에 파생본/원본 정리 스케줄러를 추가해 고아 리소스 정리와 원본 정리(유예기간 기반) 흐름을 구성했습니다.
- 미디어 URL 조회 정책은 썸네일/디스플레이 파생본 우선 + fallback 동작을 반영했습니다.
- 프로필 이미지 mediaId nullable 정렬을 위한 마이그레이션을 추가했습니다.

## 관련 이슈
- Closes #823

## 테스트
- `./gradlew :libs:clients:media-client:test`
- `./gradlew :servers:services:auth:test`
- `./gradlew :servers:services:media-api:test`
- `./gradlew :servers:services:media-worker:test`
- `./gradlew :servers:services:profile:test`
- `./gradlew :servers:services:product:test --tests "*MediaReferenceServiceTest" --tests "*ItemImageCommandServiceTest" --tests "*ItemMediaLinkSyncServiceTest" --tests "*ItemMediaLinkSyncRetryServiceTest" --tests "*ItemThumbnailSyncServiceTest"`

## 참고
- `resume/`, `docker/*`, `servers/services/auth/docs/*`는 이번 PR에 포함하지 않았습니다.
