### PR TITLE
feat(inbox): common inbox module + profile consumer migration

### DIFF
--- a/libs/event/inbox/MODULE.md
+++ b/libs/event/inbox/MODULE.md
@@ -1,0 +1,8 @@
+# inbox
+
+- 역할: Kafka listener가 적재한 이벤트를 Inbox 테이블 기준으로 push-first/poll-fallback 워커에서 처리합니다.
+- 핵심 기능:
+  - 중복 적재 방지(unique: consumer_name + event_id)
+  - 즉시 트리거(push-first) + 스케줄 폴백(poll-fallback)
+  - lease 기반 stale 복구 및 지수 백오프 재시도
+  - 이벤트 타입별 `InboxEventHandler` 라우팅

--- a/libs/event/inbox/build.gradle.kts
+++ b/libs/event/inbox/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    id("java-library")
+    id("org.springframework.boot") apply false
+    id("io.spring.dependency-management")
+}
+
+tasks.bootJar {
+    enabled = false
+}
+
+tasks.jar {
+    enabled = true
+}
+
+dependencies {
+    api(project(":libs:event:domain"))
+    api(project(":libs:data:entity"))
+
+    api("org.springframework.boot:spring-boot-starter-data-jpa")
+    api("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxAutoConfiguration.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxAutoConfiguration.java
@@ -1,0 +1,82 @@
+package com.example.event.inbox;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+@AutoConfiguration
+@ConditionalOnClass(EntityManagerFactory.class)
+@ConditionalOnProperty(prefix = "app.inbox", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(InboxProperties.class)
+@EntityScan(basePackageClasses = InboxMessage.class)
+@EnableJpaRepositories(basePackageClasses = InboxRepository.class)
+public class InboxAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public InboxHandlerRegistry inboxHandlerRegistry(ObjectProvider<List<InboxEventHandler>> handlerProvider) {
+        List<InboxEventHandler> handlers = handlerProvider.getIfAvailable(List::of);
+        return new InboxHandlerRegistry(handlers);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "inboxTaskExecutor")
+    public TaskExecutor inboxTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("inbox-trigger-");
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(1000);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "app.inbox.worker", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public InboxWorkerScheduler inboxWorkerScheduler(
+            InboxRepository inboxRepository,
+            InboxHandlerRegistry inboxHandlerRegistry,
+            InboxProperties inboxProperties,
+            TaskExecutor inboxTaskExecutor,
+            TransactionTemplate transactionTemplate
+    ) {
+        return new InboxWorkerScheduler(
+                inboxRepository,
+                inboxHandlerRegistry,
+                inboxProperties,
+                inboxTaskExecutor,
+                transactionTemplate
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(InboxSignalPublisher.class)
+    public InboxSignalPublisher inboxSignalPublisher() {
+        return consumerName -> {
+            // no-op fallback when worker is disabled
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public InboxEnqueueService inboxEnqueueService(
+            InboxRepository inboxRepository,
+            InboxSignalPublisher inboxSignalPublisher,
+            InboxProperties inboxProperties
+    ) {
+        return new InboxEnqueueService(inboxRepository, inboxSignalPublisher, inboxProperties);
+    }
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxEnqueueService.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxEnqueueService.java
@@ -1,0 +1,59 @@
+package com.example.event.inbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InboxEnqueueService {
+
+    private final InboxRepository inboxRepository;
+    private final InboxSignalPublisher inboxSignalPublisher;
+    private final InboxProperties inboxProperties;
+
+    @Transactional
+    public boolean enqueue(String consumerName, String eventId, String eventType, String payload) {
+        if (!StringUtils.hasText(consumerName)
+                || !StringUtils.hasText(eventId)
+                || !StringUtils.hasText(eventType)
+                || !StringUtils.hasText(payload)) {
+            return false;
+        }
+
+        try {
+            inboxRepository.save(InboxMessage.createPending(consumerName, eventId, eventType, payload));
+        } catch (DataIntegrityViolationException e) {
+            log.debug("[InboxEnqueue] duplicate ignored. consumerName={}, eventId={}, eventType={}",
+                    consumerName, eventId, eventType);
+            return false;
+        }
+
+        triggerAfterCommit(consumerName);
+        return true;
+    }
+
+    private void triggerAfterCommit(String consumerName) {
+        if (!inboxProperties.isImmediateTriggerEnabled()) {
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    inboxSignalPublisher.signal(consumerName);
+                }
+            });
+            return;
+        }
+
+        inboxSignalPublisher.signal(consumerName);
+    }
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxEventHandler.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxEventHandler.java
@@ -1,0 +1,10 @@
+package com.example.event.inbox;
+
+public interface InboxEventHandler {
+
+    String consumerName();
+
+    boolean supports(String eventType);
+
+    void handle(String eventId, String eventType, String payload) throws Exception;
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxHandlerRegistry.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxHandlerRegistry.java
@@ -1,0 +1,32 @@
+package com.example.event.inbox;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class InboxHandlerRegistry {
+
+    private final List<InboxEventHandler> handlers;
+
+    public InboxHandlerRegistry(List<InboxEventHandler> handlers) {
+        this.handlers = handlers == null ? List.of() : List.copyOf(handlers);
+    }
+
+    public Set<String> consumerNames() {
+        if (handlers.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return handlers.stream()
+                .map(InboxEventHandler::consumerName)
+                .collect(Collectors.toSet());
+    }
+
+    public Optional<InboxEventHandler> findHandler(String consumerName, String eventType) {
+        return handlers.stream()
+                .filter(handler -> handler.consumerName().equals(consumerName))
+                .filter(handler -> handler.supports(eventType))
+                .findFirst();
+    }
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxMessage.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxMessage.java
@@ -1,0 +1,150 @@
+package com.example.event.inbox;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "inbox_messages",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_inbox_consumer_event",
+                        columnNames = {"consumer_name", "event_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_inbox_status_nextretry", columnList = "status,next_retry_at"),
+                @Index(name = "idx_inbox_status_lease", columnList = "status,lease_until"),
+                @Index(name = "idx_inbox_consumer_status", columnList = "consumer_name,status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InboxMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @Column(name = "consumer_name", nullable = false, length = 120)
+    private String consumerName;
+
+    @Column(name = "event_id", nullable = false, length = 160)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 160)
+    private String eventType;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 24)
+    private InboxStatus status;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "lease_until")
+    private LocalDateTime leaseUntil;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Column(name = "last_error", length = 500)
+    private String lastError;
+
+    public static InboxMessage createPending(
+            String consumerName,
+            String eventId,
+            String eventType,
+            String payload
+    ) {
+        InboxMessage message = new InboxMessage();
+        message.consumerName = consumerName;
+        message.eventId = eventId;
+        message.eventType = eventType;
+        message.payload = payload;
+        message.status = InboxStatus.PENDING;
+        message.retryCount = 0;
+        return message;
+    }
+
+    public boolean isProcessingLeaseExpired(LocalDateTime now) {
+        return status == InboxStatus.PROCESSING
+                && leaseUntil != null
+                && !leaseUntil.isAfter(now);
+    }
+
+    public boolean exceedsRetryLimitOnNextFailure(int maxRetryCount) {
+        return retryCount + 1 > maxRetryCount;
+    }
+
+    public int nextRetryCount() {
+        return retryCount + 1;
+    }
+
+    public void markProcessing(LocalDateTime now, long leaseSeconds) {
+        this.status = InboxStatus.PROCESSING;
+        this.leaseUntil = now.plusSeconds(Math.max(1, leaseSeconds));
+        this.lastError = null;
+    }
+
+    public void markSucceeded(LocalDateTime now) {
+        this.status = InboxStatus.SUCCEEDED;
+        this.processedAt = now;
+        this.leaseUntil = null;
+        this.nextRetryAt = null;
+        this.lastError = null;
+    }
+
+    public void markRetry(LocalDateTime now, LocalDateTime nextRetryAt, String errorMessage, int maxErrorLength) {
+        this.status = InboxStatus.PENDING;
+        this.retryCount = this.retryCount + 1;
+        this.nextRetryAt = nextRetryAt;
+        this.leaseUntil = null;
+        this.processedAt = null;
+        this.lastError = truncate(errorMessage, maxErrorLength);
+    }
+
+    public void markDead(LocalDateTime now, String errorMessage, int maxErrorLength) {
+        this.status = InboxStatus.DEAD;
+        this.retryCount = this.retryCount + 1;
+        this.processedAt = now;
+        this.nextRetryAt = null;
+        this.leaseUntil = null;
+        this.lastError = truncate(errorMessage, maxErrorLength);
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxProperties.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxProperties.java
@@ -1,0 +1,124 @@
+package com.example.event.inbox;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.inbox")
+public class InboxProperties {
+
+    private boolean enabled = true;
+    private boolean immediateTriggerEnabled = true;
+    private final Worker worker = new Worker();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isImmediateTriggerEnabled() {
+        return immediateTriggerEnabled;
+    }
+
+    public void setImmediateTriggerEnabled(boolean immediateTriggerEnabled) {
+        this.immediateTriggerEnabled = immediateTriggerEnabled;
+    }
+
+    public Worker getWorker() {
+        return worker;
+    }
+
+    public static class Worker {
+        private boolean enabled = true;
+        private long fixedDelayMs = 2000;
+        private int batchSize = 100;
+        private long leaseSeconds = 30;
+        private int maxRetryCount = 5;
+        private long baseRetryDelaySeconds = 2;
+        private long maxRetryDelaySeconds = 300;
+        private int maxErrorMessageLength = 240;
+        private int staleRecoveryBatchSize = 100;
+        private int maxDrainLoops = 10;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public long getFixedDelayMs() {
+            return fixedDelayMs;
+        }
+
+        public void setFixedDelayMs(long fixedDelayMs) {
+            this.fixedDelayMs = fixedDelayMs;
+        }
+
+        public int getBatchSize() {
+            return batchSize;
+        }
+
+        public void setBatchSize(int batchSize) {
+            this.batchSize = batchSize;
+        }
+
+        public long getLeaseSeconds() {
+            return leaseSeconds;
+        }
+
+        public void setLeaseSeconds(long leaseSeconds) {
+            this.leaseSeconds = leaseSeconds;
+        }
+
+        public int getMaxRetryCount() {
+            return maxRetryCount;
+        }
+
+        public void setMaxRetryCount(int maxRetryCount) {
+            this.maxRetryCount = maxRetryCount;
+        }
+
+        public long getBaseRetryDelaySeconds() {
+            return baseRetryDelaySeconds;
+        }
+
+        public void setBaseRetryDelaySeconds(long baseRetryDelaySeconds) {
+            this.baseRetryDelaySeconds = baseRetryDelaySeconds;
+        }
+
+        public long getMaxRetryDelaySeconds() {
+            return maxRetryDelaySeconds;
+        }
+
+        public void setMaxRetryDelaySeconds(long maxRetryDelaySeconds) {
+            this.maxRetryDelaySeconds = maxRetryDelaySeconds;
+        }
+
+        public int getMaxErrorMessageLength() {
+            return maxErrorMessageLength;
+        }
+
+        public void setMaxErrorMessageLength(int maxErrorMessageLength) {
+            this.maxErrorMessageLength = maxErrorMessageLength;
+        }
+
+        public int getStaleRecoveryBatchSize() {
+            return staleRecoveryBatchSize;
+        }
+
+        public void setStaleRecoveryBatchSize(int staleRecoveryBatchSize) {
+            this.staleRecoveryBatchSize = staleRecoveryBatchSize;
+        }
+
+        public int getMaxDrainLoops() {
+            return maxDrainLoops;
+        }
+
+        public void setMaxDrainLoops(int maxDrainLoops) {
+            this.maxDrainLoops = maxDrainLoops;
+        }
+    }
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxRepository.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxRepository.java
@@ -1,0 +1,65 @@
+package com.example.event.inbox;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface InboxRepository extends JpaRepository<InboxMessage, Long> {
+
+    Optional<InboxMessage> findByConsumerNameAndEventId(String consumerName, String eventId);
+
+    @Query("""
+            select message
+            from InboxMessage message
+            where message.consumerName = :consumerName
+              and message.status = :status
+              and (message.nextRetryAt is null or message.nextRetryAt <= :baseTime)
+            order by message.createdAt asc
+            """)
+    List<InboxMessage> findDueMessages(
+            @Param("consumerName") String consumerName,
+            @Param("status") InboxStatus status,
+            @Param("baseTime") LocalDateTime baseTime,
+            Pageable pageable
+    );
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+            update InboxMessage message
+               set message.status = :nextStatus,
+                   message.leaseUntil = :leaseUntil,
+                   message.lastError = null
+             where message.id = :id
+               and message.status = :expectedStatus
+               and (message.nextRetryAt is null or message.nextRetryAt <= :baseTime)
+            """)
+    int claimDueMessage(
+            @Param("id") Long id,
+            @Param("expectedStatus") InboxStatus expectedStatus,
+            @Param("nextStatus") InboxStatus nextStatus,
+            @Param("leaseUntil") LocalDateTime leaseUntil,
+            @Param("baseTime") LocalDateTime baseTime
+    );
+
+    @Query("""
+            select message
+            from InboxMessage message
+            where message.consumerName = :consumerName
+              and message.status = :status
+              and message.leaseUntil is not null
+              and message.leaseUntil <= :baseTime
+            order by message.leaseUntil asc
+            """)
+    List<InboxMessage> findStaleProcessingMessages(
+            @Param("consumerName") String consumerName,
+            @Param("status") InboxStatus status,
+            @Param("baseTime") LocalDateTime baseTime,
+            Pageable pageable
+    );
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxSignalPublisher.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxSignalPublisher.java
@@ -1,0 +1,7 @@
+package com.example.event.inbox;
+
+@FunctionalInterface
+public interface InboxSignalPublisher {
+
+    void signal(String consumerName);
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxStatus.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxStatus.java
@@ -1,0 +1,8 @@
+package com.example.event.inbox;
+
+public enum InboxStatus {
+    PENDING,
+    PROCESSING,
+    SUCCEEDED,
+    DEAD
+}

--- a/libs/event/inbox/src/main/java/com/example/event/inbox/InboxWorkerScheduler.java
+++ b/libs/event/inbox/src/main/java/com/example/event/inbox/InboxWorkerScheduler.java
@@ -1,0 +1,246 @@
+package com.example.event.inbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class InboxWorkerScheduler implements InboxSignalPublisher {
+
+    private final InboxRepository inboxRepository;
+    private final InboxHandlerRegistry inboxHandlerRegistry;
+    private final InboxProperties inboxProperties;
+    private final TaskExecutor inboxTaskExecutor;
+    private final TransactionTemplate transactionTemplate;
+
+    private final ConcurrentMap<String, AtomicBoolean> consumerRunGuards = new ConcurrentHashMap<>();
+
+    @Override
+    public void signal(String consumerName) {
+        if (!inboxProperties.getWorker().isEnabled() || !inboxProperties.isImmediateTriggerEnabled()) {
+            return;
+        }
+        inboxTaskExecutor.execute(() -> processConsumerMessages(consumerName, "signal"));
+    }
+
+    @Scheduled(fixedDelayString = "${app.inbox.worker.fixed-delay-ms:2000}")
+    public void pollAndProcess() {
+        if (!inboxProperties.getWorker().isEnabled()) {
+            return;
+        }
+
+        for (String consumerName : inboxHandlerRegistry.consumerNames()) {
+            processConsumerMessages(consumerName, "poll");
+        }
+    }
+
+    private void processConsumerMessages(String consumerName, String trigger) {
+        if (consumerName == null || consumerName.isBlank()) {
+            return;
+        }
+
+        AtomicBoolean runGuard = consumerRunGuards.computeIfAbsent(consumerName, key -> new AtomicBoolean(false));
+        if (!runGuard.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            recoverStaleProcessingMessages(consumerName);
+            int maxDrainLoops = Math.max(1, inboxProperties.getWorker().getMaxDrainLoops());
+            for (int loop = 0; loop < maxDrainLoops; loop++) {
+                List<InboxMessage> claimedMessages = claimDueMessages(consumerName);
+                if (claimedMessages.isEmpty()) {
+                    return;
+                }
+
+                for (InboxMessage message : claimedMessages) {
+                    processClaimedMessage(message);
+                }
+
+                int batchSize = Math.max(1, inboxProperties.getWorker().getBatchSize());
+                if (claimedMessages.size() < batchSize) {
+                    return;
+                }
+            }
+
+            log.debug("[InboxWorker] drain-loop limit reached. consumerName={}, trigger={}", consumerName, trigger);
+        } finally {
+            runGuard.set(false);
+        }
+    }
+
+    private List<InboxMessage> claimDueMessages(String consumerName) {
+        LocalDateTime now = LocalDateTime.now();
+        int batchSize = Math.max(1, inboxProperties.getWorker().getBatchSize());
+
+        List<Long> candidateIds = transactionTemplate.execute(status ->
+                inboxRepository.findDueMessages(
+                                consumerName,
+                                InboxStatus.PENDING,
+                                now,
+                                PageRequest.of(0, batchSize)
+                        )
+                        .stream()
+                        .map(InboxMessage::getId)
+                        .toList()
+        );
+
+        if (candidateIds == null || candidateIds.isEmpty()) {
+            return List.of();
+        }
+
+        LocalDateTime leaseUntil = now.plusSeconds(Math.max(1, inboxProperties.getWorker().getLeaseSeconds()));
+        List<Long> claimedIds = transactionTemplate.execute(status -> {
+            List<Long> ids = new ArrayList<>();
+            for (Long candidateId : candidateIds) {
+                int updatedRows = inboxRepository.claimDueMessage(
+                        candidateId,
+                        InboxStatus.PENDING,
+                        InboxStatus.PROCESSING,
+                        leaseUntil,
+                        now
+                );
+                if (updatedRows > 0) {
+                    ids.add(candidateId);
+                }
+            }
+            return ids;
+        });
+
+        if (claimedIds == null || claimedIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<InboxMessage> claimedMessages = transactionTemplate.execute(status -> inboxRepository.findAllById(claimedIds));
+        if (claimedMessages == null || claimedMessages.isEmpty()) {
+            return List.of();
+        }
+
+        return claimedMessages.stream()
+                .sorted(Comparator.comparing(InboxMessage::getCreatedAt))
+                .toList();
+    }
+
+    private void recoverStaleProcessingMessages(String consumerName) {
+        LocalDateTime now = LocalDateTime.now();
+        int batchSize = Math.max(1, inboxProperties.getWorker().getStaleRecoveryBatchSize());
+
+        List<Long> staleMessageIds = transactionTemplate.execute(status ->
+                inboxRepository.findStaleProcessingMessages(
+                                consumerName,
+                                InboxStatus.PROCESSING,
+                                now,
+                                PageRequest.of(0, batchSize)
+                        )
+                        .stream()
+                        .filter(message -> message.isProcessingLeaseExpired(now))
+                        .map(InboxMessage::getId)
+                        .toList()
+        );
+
+        if (staleMessageIds == null || staleMessageIds.isEmpty()) {
+            return;
+        }
+
+        for (Long staleMessageId : staleMessageIds) {
+            markFailure(staleMessageId, "processing lease expired");
+        }
+
+        log.warn("[InboxWorker] stale processing recovered. consumerName={}, count={}",
+                consumerName, staleMessageIds.size());
+    }
+
+    private void processClaimedMessage(InboxMessage message) {
+        Optional<InboxEventHandler> optionalHandler = inboxHandlerRegistry.findHandler(
+                message.getConsumerName(), message.getEventType());
+        if (optionalHandler.isEmpty()) {
+            markDead(message.getId(), "unsupported eventType: " + message.getEventType());
+            return;
+        }
+
+        InboxEventHandler handler = optionalHandler.get();
+        try {
+            transactionTemplate.executeWithoutResult(status -> inboxRepository.findById(message.getId()).ifPresent(current -> {
+                if (current.getStatus() != InboxStatus.PROCESSING) {
+                    return;
+                }
+                try {
+                    handler.handle(current.getEventId(), current.getEventType(), current.getPayload());
+                    current.markSucceeded(LocalDateTime.now());
+                    inboxRepository.save(current);
+                } catch (Exception exception) {
+                    throw new InboxProcessingException(exception);
+                }
+            }));
+        } catch (InboxProcessingException exception) {
+            markFailure(message.getId(), exception.getCause() == null
+                    ? exception.getMessage()
+                    : exception.getCause().getMessage());
+        } catch (Exception exception) {
+            markFailure(message.getId(), exception.getMessage());
+        }
+    }
+
+    private void markFailure(Long messageId, String reason) {
+        transactionTemplate.executeWithoutResult(status -> inboxRepository.findById(messageId).ifPresent(message -> {
+            if (message.getStatus() != InboxStatus.PROCESSING) {
+                return;
+            }
+
+            int maxRetryCount = Math.max(0, inboxProperties.getWorker().getMaxRetryCount());
+            int maxErrorLength = Math.max(32, inboxProperties.getWorker().getMaxErrorMessageLength());
+            LocalDateTime now = LocalDateTime.now();
+            if (message.exceedsRetryLimitOnNextFailure(maxRetryCount)) {
+                message.markDead(now, reason, maxErrorLength);
+            } else {
+                long delaySeconds = computeBackoffSeconds(message.nextRetryCount());
+                message.markRetry(now, now.plusSeconds(delaySeconds), reason, maxErrorLength);
+            }
+            inboxRepository.save(message);
+        }));
+    }
+
+    private void markDead(Long messageId, String reason) {
+        transactionTemplate.executeWithoutResult(status -> inboxRepository.findById(messageId).ifPresent(message -> {
+            if (message.getStatus() != InboxStatus.PROCESSING && message.getStatus() != InboxStatus.PENDING) {
+                return;
+            }
+            int maxErrorLength = Math.max(32, inboxProperties.getWorker().getMaxErrorMessageLength());
+            message.markDead(LocalDateTime.now(), reason, maxErrorLength);
+            inboxRepository.save(message);
+        }));
+    }
+
+    private long computeBackoffSeconds(int nextRetryCount) {
+        long baseDelaySeconds = Math.max(1, inboxProperties.getWorker().getBaseRetryDelaySeconds());
+        long maxDelaySeconds = Math.max(baseDelaySeconds, inboxProperties.getWorker().getMaxRetryDelaySeconds());
+
+        long delaySeconds = baseDelaySeconds;
+        for (int i = 1; i < Math.max(1, nextRetryCount); i++) {
+            if (delaySeconds >= maxDelaySeconds / 2) {
+                return maxDelaySeconds;
+            }
+            delaySeconds = delaySeconds * 2;
+        }
+        return Math.min(delaySeconds, maxDelaySeconds);
+    }
+
+    private static class InboxProcessingException extends RuntimeException {
+        InboxProcessingException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/libs/event/inbox/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/event/inbox/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.example.event.inbox.InboxAutoConfiguration

--- a/libs/event/inbox/src/test/java/com/example/event/inbox/InboxMessageTest.java
+++ b/libs/event/inbox/src/test/java/com/example/event/inbox/InboxMessageTest.java
@@ -1,0 +1,37 @@
+package com.example.event.inbox;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InboxMessageTest {
+
+    @Test
+    void lifecycle_transitionsFromPendingToSucceeded() {
+        InboxMessage message = InboxMessage.createPending("consumer", "evt-1", "UserCreated", "{}");
+
+        LocalDateTime now = LocalDateTime.now();
+        message.markProcessing(now, 30);
+        message.markSucceeded(now.plusSeconds(1));
+
+        assertThat(message.getStatus()).isEqualTo(InboxStatus.SUCCEEDED);
+        assertThat(message.getProcessedAt()).isNotNull();
+        assertThat(message.getLeaseUntil()).isNull();
+    }
+
+    @Test
+    void markRetry_incrementsRetryAndSchedulesNextRetry() {
+        InboxMessage message = InboxMessage.createPending("consumer", "evt-2", "UserEmailChanged", "{}");
+
+        LocalDateTime now = LocalDateTime.now();
+        message.markProcessing(now, 10);
+        message.markRetry(now, now.plusSeconds(5), "temporary failure", 240);
+
+        assertThat(message.getStatus()).isEqualTo(InboxStatus.PENDING);
+        assertThat(message.getRetryCount()).isEqualTo(1);
+        assertThat(message.getNextRetryAt()).isEqualTo(now.plusSeconds(5));
+        assertThat(message.getLastError()).isEqualTo("temporary failure");
+    }
+}

--- a/libs/event/inbox/src/test/java/com/example/event/inbox/InboxPatternSimulationTest.java
+++ b/libs/event/inbox/src/test/java/com/example/event/inbox/InboxPatternSimulationTest.java
@@ -1,0 +1,307 @@
+package com.example.event.inbox;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InboxPatternSimulationTest {
+
+    private static final int EVENT_COUNT = 800;
+
+    @Test
+    void comparePollOnlyAndPushFallbackAcrossScenarios() throws Exception {
+        List<Integer> scheduleMs = buildSchedule(EVENT_COUNT, 1, 6, 42L);
+
+        ScenarioResult poll200NoFailure = runScenario("poll-only/200ms/no-failure", false, 200, 0, scheduleMs);
+        ScenarioResult push200NoFailure = runScenario("push+fallback/200ms/no-failure", true, 200, 0, scheduleMs);
+
+        ScenarioResult poll1000NoFailure = runScenario("poll-only/1000ms/no-failure", false, 1000, 0, scheduleMs);
+        ScenarioResult push1000NoFailure = runScenario("push+fallback/1000ms/no-failure", true, 1000, 0, scheduleMs);
+
+        ScenarioResult poll200FailOnce = runScenario("poll-only/200ms/fail-once", false, 200, 1, scheduleMs);
+        ScenarioResult push200FailOnce = runScenario("push+fallback/200ms/fail-once", true, 200, 1, scheduleMs);
+
+        print(poll200NoFailure);
+        print(push200NoFailure);
+        print(poll1000NoFailure);
+        print(push1000NoFailure);
+        print(poll200FailOnce);
+        print(push200FailOnce);
+
+        assertThat(push200NoFailure.p95Ms()).isLessThan(poll200NoFailure.p95Ms());
+        assertThat(push1000NoFailure.p95Ms()).isLessThan(poll1000NoFailure.p95Ms());
+
+        assertThat(poll200FailOnce.successCount()).isEqualTo(EVENT_COUNT);
+        assertThat(push200FailOnce.successCount()).isEqualTo(EVENT_COUNT);
+        assertThat(poll200FailOnce.retryCount()).isGreaterThanOrEqualTo(EVENT_COUNT);
+        assertThat(push200FailOnce.retryCount()).isGreaterThanOrEqualTo(EVENT_COUNT);
+    }
+
+    private ScenarioResult runScenario(
+            String name,
+            boolean pushFirst,
+            int pollMs,
+            int forcedFailuresPerEvent,
+            List<Integer> scheduleMs
+    ) throws Exception {
+        Worker worker = new Worker(pushFirst, pollMs, forcedFailuresPerEvent);
+        worker.start();
+
+        long startedAt = System.nanoTime();
+        for (int i = 0; i < scheduleMs.size(); i++) {
+            TimeUnit.MILLISECONDS.sleep(scheduleMs.get(i));
+            worker.enqueue("evt-" + i);
+        }
+
+        boolean completed = worker.awaitSuccessCount(scheduleMs.size(), 60_000);
+        assertThat(completed)
+                .as("worker should process all events. scenario=%s", name)
+                .isTrue();
+
+        long endedAt = System.nanoTime();
+        worker.shutdown();
+
+        return worker.summarize(name, pollMs, scheduleMs.size(), startedAt, endedAt);
+    }
+
+    private List<Integer> buildSchedule(int count, int minDelayMs, int maxDelayMs, long seed) {
+        Random random = new Random(seed);
+        List<Integer> scheduleMs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            scheduleMs.add(minDelayMs + random.nextInt(maxDelayMs - minDelayMs + 1));
+        }
+        return scheduleMs;
+    }
+
+    private void print(ScenarioResult result) {
+        System.out.printf(
+                Locale.US,
+                "scenario=%s pollMs=%d events=%d duration=%.2fs avg=%.2fms p95=%.2fms p99=%.2fms wakeups=%d emptyWakeups=%d retries=%d success=%d%n",
+                result.name(),
+                result.pollMs(),
+                result.events(),
+                result.durationSec(),
+                result.avgMs(),
+                result.p95Ms(),
+                result.p99Ms(),
+                result.wakeups(),
+                result.emptyWakeups(),
+                result.retryCount(),
+                result.successCount()
+        );
+    }
+
+    record ScenarioResult(
+            String name,
+            int pollMs,
+            int events,
+            double durationSec,
+            double avgMs,
+            double p95Ms,
+            double p99Ms,
+            long wakeups,
+            long emptyWakeups,
+            long retryCount,
+            int successCount
+    ) {
+    }
+
+    private static final class Worker {
+
+        private final boolean pushFirst;
+        private final int pollMs;
+        private final int forcedFailuresPerEvent;
+
+        private final Object monitor = new Object();
+        private final PriorityQueue<EventTask> queue = new PriorityQueue<>(Comparator.comparingLong(task -> task.availableAtNanos));
+        private final List<Long> latenciesNanos = new ArrayList<>();
+
+        private Thread thread;
+        private boolean running = true;
+        private long wakeups;
+        private long emptyWakeups;
+        private long retryCount;
+        private int successCount;
+
+        private Worker(boolean pushFirst, int pollMs, int forcedFailuresPerEvent) {
+            this.pushFirst = pushFirst;
+            this.pollMs = pollMs;
+            this.forcedFailuresPerEvent = forcedFailuresPerEvent;
+        }
+
+        void start() {
+            thread = new Thread(this::runLoop, "inbox-pattern-sim-worker");
+            thread.start();
+        }
+
+        void enqueue(String eventId) {
+            long now = System.nanoTime();
+            synchronized (monitor) {
+                queue.add(new EventTask(eventId, now, now));
+                if (pushFirst) {
+                    monitor.notifyAll();
+                }
+            }
+        }
+
+        boolean awaitSuccessCount(int expectedSuccessCount, long timeoutMillis) throws InterruptedException {
+            long deadline = System.currentTimeMillis() + timeoutMillis;
+            while (System.currentTimeMillis() < deadline) {
+                synchronized (monitor) {
+                    if (successCount >= expectedSuccessCount) {
+                        return true;
+                    }
+                }
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+            synchronized (monitor) {
+                return successCount >= expectedSuccessCount;
+            }
+        }
+
+        void shutdown() throws InterruptedException {
+            synchronized (monitor) {
+                running = false;
+                monitor.notifyAll();
+            }
+            thread.join();
+        }
+
+        ScenarioResult summarize(String name, int pollMs, int events, long startedAtNanos, long endedAtNanos) {
+            List<Long> sorted;
+            synchronized (monitor) {
+                sorted = new ArrayList<>(latenciesNanos);
+            }
+            sorted.sort(Long::compareTo);
+
+            double avgMs = sorted.stream().mapToDouble(v -> v / 1_000_000.0).average().orElse(0.0);
+            double p95Ms = percentile(sorted, 95);
+            double p99Ms = percentile(sorted, 99);
+
+            return new ScenarioResult(
+                    name,
+                    pollMs,
+                    events,
+                    (endedAtNanos - startedAtNanos) / 1_000_000_000.0,
+                    avgMs,
+                    p95Ms,
+                    p99Ms,
+                    wakeups,
+                    emptyWakeups,
+                    retryCount,
+                    successCount
+            );
+        }
+
+        private double percentile(List<Long> sortedNanos, int percentile) {
+            if (sortedNanos.isEmpty()) {
+                return 0.0;
+            }
+            int index = (int) Math.ceil((percentile / 100.0) * sortedNanos.size()) - 1;
+            int boundedIndex = Math.max(0, Math.min(index, sortedNanos.size() - 1));
+            return sortedNanos.get(boundedIndex) / 1_000_000.0;
+        }
+
+        private void runLoop() {
+            while (true) {
+                long waitMillis;
+                synchronized (monitor) {
+                    wakeups++;
+                    int processed = processDueTasks(System.nanoTime());
+                    if (processed == 0) {
+                        emptyWakeups++;
+                    }
+
+                    if (!running && queue.isEmpty()) {
+                        return;
+                    }
+
+                    waitMillis = computeWaitMillis();
+                    try {
+                        monitor.wait(waitMillis);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        }
+
+        private int processDueTasks(long nowNanos) {
+            int processed = 0;
+            while (!queue.isEmpty()) {
+                EventTask head = queue.peek();
+                if (head.availableAtNanos > nowNanos) {
+                    break;
+                }
+
+                queue.poll();
+                head.attempts++;
+
+                if (head.attempts <= forcedFailuresPerEvent) {
+                    retryCount++;
+                    long delayNanos = computeBackoffNanos(head.attempts);
+                    head.availableAtNanos = System.nanoTime() + delayNanos;
+                    queue.add(head);
+                } else {
+                    successCount++;
+                    latenciesNanos.add(System.nanoTime() - head.enqueuedAtNanos);
+                }
+                processed++;
+                nowNanos = System.nanoTime();
+            }
+            return processed;
+        }
+
+        private long computeWaitMillis() {
+            long fallbackWaitMs = Math.max(1, pollMs);
+            if (!pushFirst) {
+                return fallbackWaitMs;
+            }
+            if (queue.isEmpty()) {
+                return fallbackWaitMs;
+            }
+
+            long nowNanos = System.nanoTime();
+            long delayNanos = queue.peek().availableAtNanos - nowNanos;
+            if (delayNanos <= 0) {
+                return 1;
+            }
+
+            long dueWaitMs = TimeUnit.NANOSECONDS.toMillis(delayNanos);
+            if (dueWaitMs <= 0) {
+                dueWaitMs = 1;
+            }
+            return Math.min(fallbackWaitMs, dueWaitMs);
+        }
+
+        private long computeBackoffNanos(int attempt) {
+            long baseMs = 50L;
+            long multiplier = 1L << Math.max(0, attempt - 1);
+            long backoffMs = Math.min(baseMs * multiplier, 400L);
+            return TimeUnit.MILLISECONDS.toNanos(backoffMs);
+        }
+    }
+
+    private static final class EventTask {
+        private final String eventId;
+        private final long enqueuedAtNanos;
+        private long availableAtNanos;
+        private int attempts;
+
+        private EventTask(String eventId, long enqueuedAtNanos, long availableAtNanos) {
+            this.eventId = eventId;
+            this.enqueuedAtNanos = enqueuedAtNanos;
+            this.availableAtNanos = availableAtNanos;
+            this.attempts = 0;
+        }
+    }
+}

--- a/servers/services/profile/build.gradle.kts
+++ b/servers/services/profile/build.gradle.kts
@@ -1,6 +1,8 @@
 dependencies {
     // Web
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
 
     // Common libs
     implementation(project(":libs:core:exception"))
@@ -9,6 +11,7 @@ dependencies {
     implementation(project(":libs:api:exception-handler"))
     implementation(project(":libs:data:entity"))
     implementation(project(":libs:core:id"))
+    implementation(project(":libs:security:crypto"))
 
     // OpenAPI
     implementation(project(":libs:openapi:config"))
@@ -21,6 +24,7 @@ dependencies {
     // Event
     implementation(project(":libs:event:domain"))
     implementation(project(":libs:event:outbox"))
+    implementation(project(":libs:event:inbox"))
 
     // JPA
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventInboxHandler.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventInboxHandler.java
@@ -1,0 +1,29 @@
+package com.example.profile.consumer;
+
+import com.example.event.inbox.InboxEventHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileUserEventInboxHandler implements InboxEventHandler {
+
+    public static final String CONSUMER_NAME = "profile-user-events-consumer";
+
+    private final ProfileUserEventProcessor profileUserEventProcessor;
+
+    @Override
+    public String consumerName() {
+        return CONSUMER_NAME;
+    }
+
+    @Override
+    public boolean supports(String eventType) {
+        return profileUserEventProcessor.supports(eventType);
+    }
+
+    @Override
+    public void handle(String eventId, String eventType, String payload) {
+        profileUserEventProcessor.process(payload, eventId, eventType);
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventProcessor.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventProcessor.java
@@ -1,0 +1,113 @@
+package com.example.profile.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.util.JsonDeserializationException;
+import com.example.core.util.JsonUtils;
+import com.example.profile.service.command.ProfileProjectionSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProfileUserEventProcessor {
+
+    private static final String IDEMPOTENT_EVENT_TYPE = "USER_EVENT";
+
+    public static final String USER_CREATED_EVENT_TYPE = "UserCreated";
+    public static final String USER_EMAIL_CHANGED_EVENT_TYPE = "UserEmailChanged";
+    public static final String USER_WITHDRAWN_EVENT_TYPE = "UserWithdrawn";
+
+    private static final Set<String> SUPPORTED_EVENT_TYPES = Set.of(
+            USER_CREATED_EVENT_TYPE,
+            USER_EMAIL_CHANGED_EVENT_TYPE,
+            USER_WITHDRAWN_EVENT_TYPE
+    );
+
+    private final IdempotentConsumerService idempotentConsumerService;
+    private final ProfileProjectionSyncService profileProjectionSyncService;
+
+    public boolean supports(String eventType) {
+        return StringUtils.hasText(eventType) && SUPPORTED_EVENT_TYPES.contains(eventType);
+    }
+
+    public void process(String message, String eventId, String eventType) {
+        if (!supports(eventType)) {
+            log.debug("[ProfileUserEventProcessor] ignore unsupported type. eventId={}, eventType={}", eventId, eventType);
+            return;
+        }
+
+        switch (eventType) {
+            case USER_CREATED_EVENT_TYPE -> processUserCreated(message, eventId, eventType);
+            case USER_EMAIL_CHANGED_EVENT_TYPE -> processUserEmailChanged(message, eventId, eventType);
+            case USER_WITHDRAWN_EVENT_TYPE -> processUserWithdrawn(message, eventId, eventType);
+            default -> log.debug("[ProfileUserEventProcessor] ignore unsupported type. eventId={}, eventType={}", eventId, eventType);
+        }
+    }
+
+    private void processUserCreated(String message, String eventId, String rawEventType) {
+        UserCreatedEventDto event = parseEvent(message, UserCreatedEventDto.class, rawEventType);
+        if (event == null || event.userId() == null
+                || !StringUtils.hasText(event.email())
+                || !StringUtils.hasText(event.nickname())) {
+            log.warn("[ProfileUserEventProcessor] skip invalid payload. eventId={}, eventType={}, userId={}",
+                    eventId, rawEventType, event == null ? null : event.userId());
+            return;
+        }
+
+        executeIdempotent(eventId, rawEventType, event.userId(),
+                () -> profileProjectionSyncService.upsertFromUserCreated(event.userId(), event.email(), event.nickname()));
+    }
+
+    private void processUserEmailChanged(String message, String eventId, String rawEventType) {
+        UserEmailChangedEventDto event = parseEvent(message, UserEmailChangedEventDto.class, rawEventType);
+        if (event == null || event.userId() == null || !StringUtils.hasText(event.newEmail())) {
+            log.warn("[ProfileUserEventProcessor] skip invalid payload. eventId={}, eventType={}, userId={}",
+                    eventId, rawEventType, event == null ? null : event.userId());
+            return;
+        }
+
+        executeIdempotent(eventId, rawEventType, event.userId(),
+                () -> profileProjectionSyncService.applyUserEmailChanged(event.userId(), event.newEmail()));
+    }
+
+    private void processUserWithdrawn(String message, String eventId, String rawEventType) {
+        UserWithdrawnEventDto event = parseEvent(message, UserWithdrawnEventDto.class, rawEventType);
+        if (event == null || event.userId() == null) {
+            log.warn("[ProfileUserEventProcessor] skip invalid payload. eventId={}, eventType={}, userId={}",
+                    eventId, rawEventType, event == null ? null : event.userId());
+            return;
+        }
+
+        executeIdempotent(eventId, rawEventType, event.userId(),
+                () -> profileProjectionSyncService.withdrawProjection(event.userId()));
+    }
+
+    private <T> T parseEvent(String message, Class<T> clazz, String eventType) {
+        try {
+            return JsonUtils.fromJson(message, clazz);
+        } catch (JsonDeserializationException e) {
+            log.warn("[ProfileUserEventProcessor] payload parse failed. eventType={}, payload={}", eventType, message);
+            return null;
+        }
+    }
+
+    private void executeIdempotent(String eventId, String rawEventType, Long userId, Runnable action) {
+        try {
+            idempotentConsumerService.executeIdempotent(eventId, IDEMPOTENT_EVENT_TYPE, () -> {
+                action.run();
+                log.info("[ProfileUserEventProcessor] projection synced. eventId={}, eventType={}, userId={}",
+                        eventId, rawEventType, userId);
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("[ProfileUserEventProcessor] consume failed. eventId={}, eventType={}, userId={}",
+                    eventId, rawEventType, userId, e);
+            throw e;
+        }
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventRoutingProperties.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/ProfileUserEventRoutingProperties.java
@@ -1,0 +1,28 @@
+package com.example.profile.consumer;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "profile.user-events")
+public class ProfileUserEventRoutingProperties {
+
+    private RoutingMode routingMode = RoutingMode.DIRECT;
+
+    public RoutingMode getRoutingMode() {
+        return routingMode;
+    }
+
+    public void setRoutingMode(RoutingMode routingMode) {
+        this.routingMode = routingMode;
+    }
+
+    public boolean isInboxMode() {
+        return routingMode == RoutingMode.INBOX;
+    }
+
+    public enum RoutingMode {
+        DIRECT,
+        INBOX
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
@@ -85,6 +85,7 @@ public class UserEventConsumer {
                 () -> profileProjectionSyncService.withdrawProjection(event.userId()));
     }
 
+
     private JsonNode parsePayload(String message) {
         try {
             return JsonUtils.fromJson(message, JsonNode.class);

--- a/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
+++ b/servers/services/profile/src/main/java/com/example/profile/consumer/UserEventConsumer.java
@@ -1,10 +1,11 @@
 package com.example.profile.consumer;
 
-import com.example.config.kafka.IdempotentConsumerService;
 import com.example.core.util.JsonDeserializationException;
+import com.example.core.util.JsonSerializationException;
 import com.example.core.util.JsonUtils;
-import com.example.profile.service.command.ProfileProjectionSyncService;
+import com.example.event.inbox.InboxEnqueueService;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -17,17 +18,18 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class UserEventConsumer {
 
-    private static final String IDEMPOTENT_EVENT_TYPE = "USER_EVENT";
-    private static final String USER_CREATED_EVENT_TYPE = "UserCreated";
-    private static final String USER_EMAIL_CHANGED_EVENT_TYPE = "UserEmailChanged";
-    private static final String USER_WITHDRAWN_EVENT_TYPE = "UserWithdrawn";
-
-    private final IdempotentConsumerService idempotentConsumerService;
-    private final ProfileProjectionSyncService profileProjectionSyncService;
+    private final InboxEnqueueService inboxEnqueueService;
+    private final ProfileUserEventProcessor profileUserEventProcessor;
+    private final ProfileUserEventRoutingProperties profileUserEventRoutingProperties;
 
     @KafkaListener(topics = "user-events", groupId = "${spring.kafka.consumer.group-id}")
     @Transactional
-    public void consume(String message) {
+    public void consume(ConsumerRecord<String, Object> record) {
+        String message = normalizePayload(record == null ? null : record.value());
+        if (message == null) {
+            return;
+        }
+
         JsonNode payload = parsePayload(message);
         if (payload == null) {
             return;
@@ -39,67 +41,49 @@ public class UserEventConsumer {
             return;
         }
 
-        switch (eventType) {
-            case USER_CREATED_EVENT_TYPE -> consumeUserCreated(message, eventId, eventType);
-            case USER_EMAIL_CHANGED_EVENT_TYPE -> consumeUserEmailChanged(message, eventId, eventType);
-            case USER_WITHDRAWN_EVENT_TYPE -> consumeUserWithdrawn(message, eventId, eventType);
-            default -> log.debug("[ProfileUserEventConsumer] ignore unsupported type. eventId={}, eventType={}", eventId, eventType);
-        }
-    }
-
-    private void consumeUserCreated(String message, String eventId, String rawEventType) {
-        UserCreatedEventDto event = parseEvent(message, UserCreatedEventDto.class, rawEventType);
-        if (event == null || event.userId() == null
-                || !StringUtils.hasText(event.email())
-                || !StringUtils.hasText(event.nickname())) {
-            log.warn("[ProfileUserEventConsumer] skip invalid payload. eventId={}, eventType={}, userId={}",
-                    eventId, rawEventType, event == null ? null : event.userId());
+        if (!profileUserEventProcessor.supports(eventType)) {
+            log.debug("[ProfileUserEventConsumer] ignore unsupported type. eventId={}, eventType={}", eventId, eventType);
             return;
         }
 
-        executeIdempotent(eventId, rawEventType, event.userId(),
-                () -> profileProjectionSyncService.upsertFromUserCreated(event.userId(), event.email(), event.nickname()));
-    }
-
-    private void consumeUserEmailChanged(String message, String eventId, String rawEventType) {
-        UserEmailChangedEventDto event = parseEvent(message, UserEmailChangedEventDto.class, rawEventType);
-        if (event == null || event.userId() == null || !StringUtils.hasText(event.newEmail())) {
-            log.warn("[ProfileUserEventConsumer] skip invalid payload. eventId={}, eventType={}, userId={}",
-                    eventId, rawEventType, event == null ? null : event.userId());
+        if (profileUserEventRoutingProperties.isInboxMode()) {
+            boolean enqueued = inboxEnqueueService.enqueue(
+                    ProfileUserEventInboxHandler.CONSUMER_NAME,
+                    eventId,
+                    eventType,
+                    message
+            );
+            if (!enqueued) {
+                log.debug("[ProfileUserEventConsumer] inbox enqueue skipped. eventId={}, eventType={}", eventId, eventType);
+            }
             return;
         }
 
-        executeIdempotent(eventId, rawEventType, event.userId(),
-                () -> profileProjectionSyncService.applyUserEmailChanged(event.userId(), event.newEmail()));
+        profileUserEventProcessor.process(message, eventId, eventType);
     }
 
-    private void consumeUserWithdrawn(String message, String eventId, String rawEventType) {
-        UserWithdrawnEventDto event = parseEvent(message, UserWithdrawnEventDto.class, rawEventType);
-        if (event == null || event.userId() == null) {
-            log.warn("[ProfileUserEventConsumer] skip invalid payload. eventId={}, eventType={}, userId={}",
-                    eventId, rawEventType, event == null ? null : event.userId());
-            return;
+    private String normalizePayload(Object rawMessage) {
+        if (rawMessage == null) {
+            log.warn("[ProfileUserEventConsumer] skip null payload");
+            return null;
         }
-
-        executeIdempotent(eventId, rawEventType, event.userId(),
-                () -> profileProjectionSyncService.withdrawProjection(event.userId()));
+        if (rawMessage instanceof String text) {
+            return text;
+        }
+        try {
+            return JsonUtils.toJson(rawMessage);
+        } catch (JsonSerializationException e) {
+            log.warn("[ProfileUserEventConsumer] skip unsupported payload type. payloadType={}",
+                    rawMessage.getClass().getName());
+            return null;
+        }
     }
-
 
     private JsonNode parsePayload(String message) {
         try {
             return JsonUtils.fromJson(message, JsonNode.class);
         } catch (JsonDeserializationException e) {
             log.warn("[ProfileUserEventConsumer] skip malformed message. payload={}", message);
-            return null;
-        }
-    }
-
-    private <T> T parseEvent(String message, Class<T> clazz, String eventType) {
-        try {
-            return JsonUtils.fromJson(message, clazz);
-        } catch (JsonDeserializationException e) {
-            log.warn("[ProfileUserEventConsumer] payload parse failed. eventType={}, payload={}", eventType, message);
             return null;
         }
     }
@@ -117,20 +101,5 @@ public class UserEventConsumer {
             return null;
         }
         return payload.path(field).asText(null);
-    }
-
-    private void executeIdempotent(String eventId, String rawEventType, Long userId, Runnable action) {
-        try {
-            idempotentConsumerService.executeIdempotent(eventId, IDEMPOTENT_EVENT_TYPE, () -> {
-                action.run();
-                log.info("[ProfileUserEventConsumer] projection synced. eventId={}, eventType={}, userId={}",
-                        eventId, rawEventType, userId);
-                return null;
-            });
-        } catch (Exception e) {
-            log.error("[ProfileUserEventConsumer] consume failed. eventId={}, eventType={}, userId={}",
-                    eventId, rawEventType, userId, e);
-            throw e;
-        }
     }
 }

--- a/servers/services/profile/src/main/java/com/example/profile/crypto/EncryptedStringAttributeConverter.java
+++ b/servers/services/profile/src/main/java/com/example/profile/crypto/EncryptedStringAttributeConverter.java
@@ -1,0 +1,45 @@
+package com.example.profile.crypto;
+
+import com.example.security.crypto.encryption.EncryptionException;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.util.StringUtils;
+
+@Converter
+public class EncryptedStringAttributeConverter implements AttributeConverter<String, String> {
+
+    static final String ENCRYPTED_PREFIX = "enc::";
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (!StringUtils.hasText(attribute)) {
+            return attribute;
+        }
+        if (isEncrypted(attribute)) {
+            return attribute;
+        }
+        return ENCRYPTED_PREFIX + ProfileEncryptorHolder.getEncryptor().encrypt(attribute);
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (!StringUtils.hasText(dbData)) {
+            return dbData;
+        }
+        if (!isEncrypted(dbData)) {
+            // Backward compatibility for legacy plaintext rows.
+            return dbData;
+        }
+
+        String cipherText = dbData.substring(ENCRYPTED_PREFIX.length());
+        try {
+            return ProfileEncryptorHolder.getEncryptor().decrypt(cipherText);
+        } catch (EncryptionException exception) {
+            throw new IllegalStateException("Failed to decrypt profile sensitive field", exception);
+        }
+    }
+
+    static boolean isEncrypted(String value) {
+        return StringUtils.hasText(value) && value.startsWith(ENCRYPTED_PREFIX);
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileCryptoConfiguration.java
+++ b/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileCryptoConfiguration.java
@@ -1,0 +1,19 @@
+package com.example.profile.crypto;
+
+import com.example.security.crypto.encryption.AesGcmEncryptor;
+import com.example.security.crypto.encryption.Encryptor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ProfileCryptoProperties.class)
+public class ProfileCryptoConfiguration {
+
+    @Bean
+    public Encryptor profileEncryptor(ProfileCryptoProperties properties) {
+        Encryptor encryptor = new AesGcmEncryptor(properties.getEncryptionKey());
+        ProfileEncryptorHolder.setEncryptor(encryptor);
+        return encryptor;
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileCryptoProperties.java
+++ b/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileCryptoProperties.java
@@ -1,0 +1,17 @@
+package com.example.profile.crypto;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security.crypto")
+public class ProfileCryptoProperties {
+
+    private String encryptionKey = ProfileEncryptorHolder.DEFAULT_KEY;
+
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = encryptionKey;
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileEncryptorHolder.java
+++ b/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileEncryptorHolder.java
@@ -1,0 +1,58 @@
+package com.example.profile.crypto;
+
+import com.example.security.crypto.encryption.AesGcmEncryptor;
+import com.example.security.crypto.encryption.Encryptor;
+
+import java.util.Objects;
+
+public final class ProfileEncryptorHolder {
+
+    static final String KEY_PROPERTY = "app.security.crypto.encryption-key";
+    static final String KEY_ENV = "APP_SECURITY_CRYPTO_ENCRYPTION_KEY";
+    static final String DEFAULT_KEY = "1234567890abcdef";
+
+    private static volatile Encryptor encryptor;
+
+    private ProfileEncryptorHolder() {
+    }
+
+    public static Encryptor getEncryptor() {
+        Encryptor current = encryptor;
+        if (current != null) {
+            return current;
+        }
+
+        synchronized (ProfileEncryptorHolder.class) {
+            if (encryptor == null) {
+                encryptor = new AesGcmEncryptor(resolveKey());
+            }
+            return encryptor;
+        }
+    }
+
+    public static void setEncryptor(Encryptor customEncryptor) {
+        encryptor = Objects.requireNonNull(customEncryptor, "customEncryptor must not be null");
+    }
+
+    private static String resolveKey() {
+        String fromProperty = trimToNull(System.getProperty(KEY_PROPERTY));
+        if (fromProperty != null) {
+            return fromProperty;
+        }
+
+        String fromEnv = trimToNull(System.getenv(KEY_ENV));
+        if (fromEnv != null) {
+            return fromEnv;
+        }
+
+        return DEFAULT_KEY;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileSensitiveDataEncryptionMigrationRunner.java
+++ b/servers/services/profile/src/main/java/com/example/profile/crypto/ProfileSensitiveDataEncryptionMigrationRunner.java
@@ -1,0 +1,108 @@
+package com.example.profile.crypto;
+
+import com.example.security.crypto.encryption.Encryptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "app.security.crypto.migration",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
+public class ProfileSensitiveDataEncryptionMigrationRunner implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Encryptor encryptor;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        int migratedEmailCount = migrateColumn("email");
+        int migratedPhoneNumberCount = migrateColumn("phone_number");
+
+        if (migratedEmailCount > 0 || migratedPhoneNumberCount > 0) {
+            log.info("[ProfileSensitiveDataMigration] completed. email={}, phoneNumber={}",
+                    migratedEmailCount, migratedPhoneNumberCount);
+            return;
+        }
+
+        // Legacy schema fallback.
+        int migratedLegacyPhoneCount = migrateColumn("phone");
+        if (migratedLegacyPhoneCount > 0) {
+            log.info("[ProfileSensitiveDataMigration] completed with legacy phone column. phone={}",
+                    migratedLegacyPhoneCount);
+        } else {
+            log.debug("[ProfileSensitiveDataMigration] no plaintext sensitive data found");
+        }
+    }
+
+    private int migrateColumn(String columnName) {
+        if (!columnExists("profiles", columnName)) {
+            return 0;
+        }
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "SELECT user_id, " + columnName + " AS value " +
+                        "FROM profiles WHERE " + columnName + " IS NOT NULL"
+        );
+
+        int migrated = 0;
+        for (Map<String, Object> row : rows) {
+            Long userId = toLong(row.get("user_id"));
+            String currentValue = row.get("value") == null ? null : String.valueOf(row.get("value"));
+            if (userId == null || !StringUtils.hasText(currentValue) || EncryptedStringAttributeConverter.isEncrypted(currentValue)) {
+                continue;
+            }
+
+            String encrypted = EncryptedStringAttributeConverter.ENCRYPTED_PREFIX + encryptor.encrypt(currentValue);
+            int updated = jdbcTemplate.update(
+                    "UPDATE profiles SET " + columnName + " = ? WHERE user_id = ?",
+                    encrypted,
+                    userId
+            );
+            if (updated > 0) {
+                migrated++;
+            }
+        }
+        return migrated;
+    }
+
+    private boolean columnExists(String tableName, String columnName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.columns " +
+                        "WHERE table_schema = current_schema() AND table_name = ? AND column_name = ?",
+                Integer.class,
+                tableName,
+                columnName
+        );
+        return count != null && count > 0;
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(String.valueOf(value));
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+}

--- a/servers/services/profile/src/main/java/com/example/profile/entity/Profiles.java
+++ b/servers/services/profile/src/main/java/com/example/profile/entity/Profiles.java
@@ -2,9 +2,11 @@ package com.example.profile.entity;
 
 import com.example.clients.auth.dto.profile.AuthSyncQuery;
 import com.example.core.id.jpa.SnowflakeGenerated;
+import com.example.profile.crypto.EncryptedStringAttributeConverter;
 import com.example.data.entity.BaseEntity;
 import com.example.profile.dto.request.ProfileRequest;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
@@ -31,13 +33,15 @@ public class Profiles extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "email", nullable = false, length = 255)
+    @Convert(converter = EncryptedStringAttributeConverter.class)
+    @Column(name = "email", nullable = false, length = 512)
     private String email;
 
     @Column(name = "nickname", length = 100)
     private String nickname;
 
-    @Column(name = "phone_number", length = 15)
+    @Convert(converter = EncryptedStringAttributeConverter.class)
+    @Column(name = "phone_number", length = 256)
     private String phoneNumber;
 
     @OneToOne(mappedBy = "profile", fetch = FetchType.LAZY)

--- a/servers/services/profile/src/main/java/com/example/profile/entity/ProfilesImage.java
+++ b/servers/services/profile/src/main/java/com/example/profile/entity/ProfilesImage.java
@@ -34,10 +34,7 @@ public class ProfilesImage extends BaseEntity {
     public static ProfilesImage createDefault(Profiles profile) {
         return ProfilesImage.builder()
             .userId(profile.getUserId())
-            .profile(profile)
             .mediaId(null)
             .build();
     }
-
-
 }

--- a/servers/services/profile/src/main/java/com/example/profile/repository/ProfileImageRepository.java
+++ b/servers/services/profile/src/main/java/com/example/profile/repository/ProfileImageRepository.java
@@ -1,9 +1,7 @@
 package com.example.profile.repository;
 
-import com.example.profile.entity.Profiles;
 import com.example.profile.entity.ProfilesImage;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 

--- a/servers/services/profile/src/main/resources/application.yml
+++ b/servers/services/profile/src/main/resources/application.yml
@@ -53,6 +53,34 @@ spring:
 
   profiles:
     active: ${SPRING_PROFILE_ACTIVE:local}
+
+# ─── App ───────────────────────────────────────
+app:
+  snowflake:
+    datacenter-id: ${SNOWFLAKE_DATACENTER_ID:1}
+    worker-id: ${SNOWFLAKE_WORKER_ID:7}
+  security:
+    crypto:
+      encryption-key: ${APP_SECURITY_CRYPTO_ENCRYPTION_KEY:1234567890abcdef}
+      migration:
+        enabled: ${APP_SECURITY_CRYPTO_MIGRATION_ENABLED:true}
+  inbox:
+    enabled: ${APP_INBOX_ENABLED:true}
+    immediate-trigger-enabled: ${APP_INBOX_IMMEDIATE_TRIGGER_ENABLED:true}
+    worker:
+      enabled: ${APP_INBOX_WORKER_ENABLED:true}
+      fixed-delay-ms: ${APP_INBOX_WORKER_FIXED_DELAY_MS:1000}
+      batch-size: ${APP_INBOX_WORKER_BATCH_SIZE:100}
+      lease-seconds: ${APP_INBOX_WORKER_LEASE_SECONDS:30}
+      max-retry-count: ${APP_INBOX_WORKER_MAX_RETRY_COUNT:5}
+      base-retry-delay-seconds: ${APP_INBOX_WORKER_BASE_RETRY_DELAY_SECONDS:2}
+      max-retry-delay-seconds: ${APP_INBOX_WORKER_MAX_RETRY_DELAY_SECONDS:300}
+      stale-recovery-batch-size: ${APP_INBOX_WORKER_STALE_RECOVERY_BATCH_SIZE:100}
+      max-drain-loops: ${APP_INBOX_WORKER_MAX_DRAIN_LOOPS:10}
+
+profile:
+  user-events:
+    routing-mode: ${PROFILE_USER_EVENTS_ROUTING_MODE:INBOX}
 # ─── Actuator ─────────────────────────────────
 management:
   endpoints:

--- a/servers/services/profile/src/main/resources/db/migration/V5__create_inbox_messages.sql
+++ b/servers/services/profile/src/main/resources/db/migration/V5__create_inbox_messages.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS inbox_messages (
+    id BIGSERIAL PRIMARY KEY,
+    version BIGINT,
+    consumer_name VARCHAR(120) NOT NULL,
+    event_id VARCHAR(160) NOT NULL,
+    event_type VARCHAR(160) NOT NULL,
+    payload TEXT NOT NULL,
+    status VARCHAR(24) NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    next_retry_at TIMESTAMP,
+    lease_until TIMESTAMP,
+    processed_at TIMESTAMP,
+    last_error VARCHAR(500),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP,
+    CONSTRAINT uk_inbox_consumer_event UNIQUE (consumer_name, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_inbox_status_nextretry
+    ON inbox_messages (status, next_retry_at);
+
+CREATE INDEX IF NOT EXISTS idx_inbox_status_lease
+    ON inbox_messages (status, lease_until);
+
+CREATE INDEX IF NOT EXISTS idx_inbox_consumer_status
+    ON inbox_messages (consumer_name, status);

--- a/servers/services/profile/src/main/resources/db/migration/V6__expand_sensitive_columns_for_encryption.sql
+++ b/servers/services/profile/src/main/resources/db/migration/V6__expand_sensitive_columns_for_encryption.sql
@@ -1,0 +1,35 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'profiles'
+          AND column_name = 'email'
+    ) THEN
+        ALTER TABLE profiles
+            ALTER COLUMN email TYPE VARCHAR(512);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'profiles'
+          AND column_name = 'phone_number'
+    ) THEN
+        ALTER TABLE profiles
+            ALTER COLUMN phone_number TYPE VARCHAR(256);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'profiles'
+          AND column_name = 'phone'
+    ) THEN
+        ALTER TABLE profiles
+            ALTER COLUMN phone TYPE VARCHAR(256);
+    END IF;
+END $$;

--- a/servers/services/profile/src/test/java/com/example/profile/consumer/ProfileUserEventProcessorTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/consumer/ProfileUserEventProcessorTest.java
@@ -1,0 +1,131 @@
+package com.example.profile.consumer;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.profile.service.command.ProfileProjectionSyncService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileUserEventProcessorTest {
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    @Mock
+    private ProfileProjectionSyncService profileProjectionSyncService;
+
+    private ProfileUserEventProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new ProfileUserEventProcessor(idempotentConsumerService, profileProjectionSyncService);
+    }
+
+    @Test
+    void process_userCreated_runsProjectionSync() {
+        String message = """
+                {"eventId":"evt-1","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-1"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        processor.process(message, "evt-1", ProfileUserEventProcessor.USER_CREATED_EVENT_TYPE);
+
+        verify(profileProjectionSyncService).upsertFromUserCreated(101L, "user@example.com", "tester");
+    }
+
+    @Test
+    void process_userEmailChanged_runsProjectionSync() {
+        String message = """
+                {"eventId":"evt-2","eventType":"UserEmailChanged","userId":101,"newEmail":"new@example.com"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-2"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        processor.process(message, "evt-2", ProfileUserEventProcessor.USER_EMAIL_CHANGED_EVENT_TYPE);
+
+        verify(profileProjectionSyncService).applyUserEmailChanged(101L, "new@example.com");
+    }
+
+    @Test
+    void process_userWithdrawn_runsProjectionSync() {
+        String message = """
+                {"eventId":"evt-3","eventType":"UserWithdrawn","userId":101}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-3"), eq("USER_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        processor.process(message, "evt-3", ProfileUserEventProcessor.USER_WITHDRAWN_EVENT_TYPE);
+
+        verify(profileProjectionSyncService).withdrawProjection(101L);
+    }
+
+    @Test
+    void process_skipsInvalidPayload() {
+        String message = """
+                {"eventId":"evt-4","eventType":"UserCreated","userId":101,"email":"user@example.com"}
+                """;
+
+        processor.process(message, "evt-4", ProfileUserEventProcessor.USER_CREATED_EVENT_TYPE);
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void process_ignoresUnsupportedEventType() {
+        String message = """
+                {"eventId":"evt-5","eventType":"UserPasswordChanged","userId":101}
+                """;
+
+        processor.process(message, "evt-5", "UserPasswordChanged");
+
+        verifyNoInteractions(idempotentConsumerService);
+        verifyNoInteractions(profileProjectionSyncService);
+    }
+
+    @Test
+    void process_rethrowsWhenIdempotentFails() {
+        String message = """
+                {"eventId":"evt-6","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                """;
+
+        when(idempotentConsumerService.executeIdempotent(eq("evt-6"), eq("USER_EVENT"), any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> processor.process(message, "evt-6", ProfileUserEventProcessor.USER_CREATED_EVENT_TYPE))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("boom");
+
+        verify(profileProjectionSyncService, never()).upsertFromUserCreated(any(), any(), any());
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/consumer/UserEventConsumerTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/consumer/UserEventConsumerTest.java
@@ -1,18 +1,13 @@
 package com.example.profile.consumer;
 
-import com.example.config.kafka.IdempotentConsumerService;
-import com.example.profile.service.command.ProfileProjectionSyncService;
+import com.example.event.inbox.InboxEnqueueService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,133 +18,89 @@ import static org.mockito.Mockito.when;
 class UserEventConsumerTest {
 
     @Mock
-    private IdempotentConsumerService idempotentConsumerService;
+    private InboxEnqueueService inboxEnqueueService;
 
     @Mock
-    private ProfileProjectionSyncService profileProjectionSyncService;
+    private ProfileUserEventProcessor profileUserEventProcessor;
 
+    private ProfileUserEventRoutingProperties routingProperties;
     private UserEventConsumer userEventConsumer;
+
+    private ConsumerRecord<String, Object> recordOf(Object value) {
+        return new ConsumerRecord<>("user-events", 0, 0L, null, value);
+    }
 
     @BeforeEach
     void setUp() {
-        userEventConsumer = new UserEventConsumer(idempotentConsumerService, profileProjectionSyncService);
+        routingProperties = new ProfileUserEventRoutingProperties();
+        userEventConsumer = new UserEventConsumer(inboxEnqueueService, profileUserEventProcessor, routingProperties);
     }
 
     @Test
-    void consume_processesUserCreatedEventIdempotently() {
+    void consume_directMode_dispatchesToProcessor() {
         String message = """
                 {"eventId":"evt-1","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
                 """;
+        when(profileUserEventProcessor.supports("UserCreated")).thenReturn(true);
 
-        when(idempotentConsumerService.executeIdempotent(eq("evt-1"), eq("USER_EVENT"), any()))
-                .thenAnswer(invocation -> {
-                    Supplier<?> processor = invocation.getArgument(2);
-                    processor.get();
-                    return Optional.empty();
-                });
+        userEventConsumer.consume(recordOf(message));
 
-        userEventConsumer.consume(message);
-
-        verify(profileProjectionSyncService).upsertFromUserCreated(101L, "user@example.com", "tester");
+        verify(profileUserEventProcessor).process(eq(message), eq("evt-1"), eq("UserCreated"));
+        verifyNoInteractions(inboxEnqueueService);
     }
 
     @Test
-    void consume_skipsWhenEnvelopeIsInvalid() {
+    void consume_inboxMode_enqueuesMessage() {
+        routingProperties.setRoutingMode(ProfileUserEventRoutingProperties.RoutingMode.INBOX);
         String message = """
-                {"eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
+                {"eventId":"evt-2","eventType":"UserEmailChanged","userId":101,"newEmail":"new@example.com"}
                 """;
+        when(profileUserEventProcessor.supports("UserEmailChanged")).thenReturn(true);
 
-        userEventConsumer.consume(message);
+        userEventConsumer.consume(recordOf(message));
 
-        verifyNoInteractions(idempotentConsumerService);
-        verifyNoInteractions(profileProjectionSyncService);
+        verify(inboxEnqueueService).enqueue(
+                ProfileUserEventInboxHandler.CONSUMER_NAME,
+                "evt-2",
+                "UserEmailChanged",
+                message
+        );
+        verify(profileUserEventProcessor, never()).process(message, "evt-2", "UserEmailChanged");
     }
 
     @Test
-    void consume_skipsUnsupportedEventType() {
+    void consume_skipsInvalidEnvelope() {
         String message = """
-                {"eventId":"evt-unsupported","eventType":"UserPasswordChanged","userId":101}
+                {"eventType":"UserCreated","userId":101}
                 """;
 
-        userEventConsumer.consume(message);
+        userEventConsumer.consume(recordOf(message));
 
-        verifyNoInteractions(idempotentConsumerService);
-        verifyNoInteractions(profileProjectionSyncService);
+        verifyNoInteractions(profileUserEventProcessor);
+        verifyNoInteractions(inboxEnqueueService);
     }
 
     @Test
-    void consume_processesUserEmailChangedEventIdempotently() {
-        String message = """
-                {"eventId":"evt-2","eventType":"UserEmailChanged","userId":101,"oldEmail":"old@example.com","newEmail":"new@example.com"}
-                """;
+    void consume_skipsMalformedPayload() {
+        String malformed = "not-json";
 
-        when(idempotentConsumerService.executeIdempotent(eq("evt-2"), eq("USER_EVENT"), any()))
-                .thenAnswer(invocation -> {
-                    Supplier<?> processor = invocation.getArgument(2);
-                    processor.get();
-                    return Optional.empty();
-                });
+        userEventConsumer.consume(recordOf(malformed));
 
-        userEventConsumer.consume(message);
-
-        verify(profileProjectionSyncService).applyUserEmailChanged(101L, "new@example.com");
+        verifyNoInteractions(profileUserEventProcessor);
+        verifyNoInteractions(inboxEnqueueService);
     }
 
     @Test
-    void consume_processesUserWithdrawnEventIdempotently() {
+    void consume_skipsUnsupportedType() {
         String message = """
-                {"eventId":"evt-5","eventType":"UserWithdrawn","userId":101}
+                {"eventId":"evt-3","eventType":"UserPasswordChanged","userId":101}
                 """;
+        when(profileUserEventProcessor.supports("UserPasswordChanged")).thenReturn(false);
 
-        when(idempotentConsumerService.executeIdempotent(eq("evt-5"), eq("USER_EVENT"), any()))
-                .thenAnswer(invocation -> {
-                    Supplier<?> processor = invocation.getArgument(2);
-                    processor.get();
-                    return Optional.empty();
-                });
+        userEventConsumer.consume(recordOf(message));
 
-        userEventConsumer.consume(message);
-
-        verify(profileProjectionSyncService).withdrawProjection(101L);
-    }
-
-    @Test
-    void consume_skipsWhenPayloadIsInvalid() {
-        String message = """
-                {"eventId":"evt-3","eventType":"UserCreated","userId":101,"email":"user@example.com"}
-                """;
-
-        userEventConsumer.consume(message);
-
-        verifyNoInteractions(idempotentConsumerService);
-        verifyNoInteractions(profileProjectionSyncService);
-    }
-
-    @Test
-    void consume_skipsWhenUserEmailChangedPayloadIsInvalid() {
-        String message = """
-                {"eventId":"evt-6","eventType":"UserEmailChanged","userId":101}
-                """;
-
-        userEventConsumer.consume(message);
-
-        verifyNoInteractions(idempotentConsumerService);
-        verifyNoInteractions(profileProjectionSyncService);
-    }
-
-    @Test
-    void consume_rethrowsWhenIdempotentProcessingFails() {
-        String message = """
-                {"eventId":"evt-4","eventType":"UserCreated","userId":101,"email":"user@example.com","nickname":"tester"}
-                """;
-
-        when(idempotentConsumerService.executeIdempotent(eq("evt-4"), eq("USER_EVENT"), any()))
-                .thenThrow(new RuntimeException("boom"));
-
-        assertThatThrownBy(() -> userEventConsumer.consume(message))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("boom");
-
-        verify(profileProjectionSyncService, never()).upsertFromUserCreated(any(), any(), any());
+        verify(profileUserEventProcessor).supports("UserPasswordChanged");
+        verify(profileUserEventProcessor, never()).process(message, "evt-3", "UserPasswordChanged");
+        verifyNoInteractions(inboxEnqueueService);
     }
 }

--- a/servers/services/profile/src/test/java/com/example/profile/crypto/EncryptedStringAttributeConverterTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/crypto/EncryptedStringAttributeConverterTest.java
@@ -1,0 +1,48 @@
+package com.example.profile.crypto;
+
+import com.example.security.crypto.encryption.AesGcmEncryptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EncryptedStringAttributeConverterTest {
+
+    private EncryptedStringAttributeConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        ProfileEncryptorHolder.setEncryptor(new AesGcmEncryptor("1234567890abcdef"));
+        converter = new EncryptedStringAttributeConverter();
+    }
+
+    @Test
+    void convert_roundTrip_encryptsAndDecrypts() {
+        String plain = "alice@example.com";
+
+        String encrypted = converter.convertToDatabaseColumn(plain);
+        String decrypted = converter.convertToEntityAttribute(encrypted);
+
+        assertThat(encrypted).startsWith(EncryptedStringAttributeConverter.ENCRYPTED_PREFIX);
+        assertThat(encrypted).isNotEqualTo(plain);
+        assertThat(decrypted).isEqualTo(plain);
+    }
+
+    @Test
+    void convertToEntityAttribute_legacyPlainText_isReturnedAsIs() {
+        String legacy = "010-1234-5678";
+
+        String decrypted = converter.convertToEntityAttribute(legacy);
+
+        assertThat(decrypted).isEqualTo(legacy);
+    }
+
+    @Test
+    void convertToDatabaseColumn_alreadyEncryptedValue_isNotEncryptedTwice() {
+        String encrypted = converter.convertToDatabaseColumn("alice@example.com");
+
+        String unchanged = converter.convertToDatabaseColumn(encrypted);
+
+        assertThat(unchanged).isEqualTo(encrypted);
+    }
+}

--- a/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceTest.java
+++ b/servers/services/profile/src/test/java/com/example/profile/service/command/ProfileProjectionSyncServiceTest.java
@@ -79,7 +79,6 @@ class ProfileProjectionSyncServiceTest {
                 .profile(existing)
                 .mediaId(100L)
                 .build();
-
         when(profileRepository.findByUserId(userId)).thenReturn(Optional.of(existing));
         when(profileImageRepository.findByUserId(userId)).thenReturn(Optional.of(existingImage));
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ include(":libs:config:shedlock")
 // 이벤트 모듈
 include(":libs:event:domain")
 include(":libs:event:outbox")
+include(":libs:event:inbox")
 
 // API 문서
 include(":libs:openapi:config")


### PR DESCRIPTION
## Summary
- add new `libs:event:inbox` common module with enqueue/claim/worker/retry orchestration
- migrate profile `user-events` consumer to inbox routing with event-type DTO processor split
- add profile inbox schema (`inbox_messages`) and sensitive column expansion migrations
- add profile encryption support for email/phone via attribute converter and migration runner
- add inbox simulation tests and profile consumer/processor/encryption tests

## Why
- separate Kafka listener enqueue from business processing for idempotent, recoverable consumption
- support push-first + poll-fallback inbox worker model and event-type based processing
- improve profile PII storage safety by encrypting sensitive fields at rest

## Validation
- `./gradlew :servers:services:profile:test --tests "*ProfileProjectionSyncServiceIntegrationTest" --tests "*ProfileProjectionSyncServiceTest" --tests "*UserEventConsumerTest" --tests "*ProfileUserEventProcessorTest" :libs:event:inbox:test`

Closes #829
