### PR TITLE
feat(order): Order/OrderItem 엔티티, OrderStatus 상태 및 레포지토리 생성

### DIFF
--- a/servers/services/order/build.gradle.kts
+++ b/servers/services/order/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
     implementation(project(":libs:config:redis"))
 
     // ─── Event ────────────────────────────────────
+    implementation(project(":libs:event:consumer"))
     implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:inbox"))
     implementation(project(":libs:event:outbox"))
 
     // ─── Security ─────────────────────────────────
@@ -41,5 +43,7 @@ dependencies {
 
     // Database
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.flywaydb:flyway-core")
+    runtimeOnly("org.flywaydb:flyway-database-postgresql")
     testRuntimeOnly("com.h2database:h2")
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/Order.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/Order.java
@@ -1,6 +1,5 @@
 package com.example.order.domain;
 
-import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,15 +7,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "orders",
         indexes = {
-                @Index(name = "idx_order_user_id", columnList = "user_id"),
-                @Index(name = "idx_order_purchase_id", columnList = "purchase_id", unique = true),
-                @Index(name = "idx_order_status", columnList = "status")
+                @Index(name = "idx_orders_user_id", columnList = "user_id"),
+                @Index(name = "idx_orders_status", columnList = "status")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,38 +23,50 @@ import java.util.List;
 public class Order extends BaseEntity {
 
     @Id
-    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "purchase_id", nullable = false)
-    private Long purchaseId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private OrderStatus status;
 
     @Column(name = "total_amount", nullable = false)
     private Long totalAmount;
 
-    @Column(name = "reservation_id")
-    private Long reservationId;
+    @Column(name = "recipient_name", length = 100)
+    private String recipientName;
 
-    @Column(name = "payment_id")
-    private Long paymentId;
+    @Column(name = "recipient_phone", length = 20)
+    private String recipientPhone;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
-    private OrderStatus status;
+    @Column(name = "delivery_address_id")
+    private Long deliveryAddressId;
+
+    @Column(name = "delivery_memo", length = 500)
+    private String deliveryMemo;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    public static Order create(Long userId, Long purchaseId, Long totalAmount, Long reservationId) {
+    public static Order create(Long orderId, Long userId, Long totalAmount,
+                               String recipientName, String recipientPhone,
+                               Long deliveryAddressId, String deliveryMemo,
+                               LocalDateTime expiresAt) {
         Order order = new Order();
+        order.id = orderId;
         order.userId = userId;
-        order.purchaseId = purchaseId;
+        order.status = OrderStatus.PAYMENT_PENDING;
         order.totalAmount = totalAmount;
-        order.reservationId = reservationId;
-        order.status = OrderStatus.CREATED;
+        order.recipientName = recipientName;
+        order.recipientPhone = recipientPhone;
+        order.deliveryAddressId = deliveryAddressId;
+        order.deliveryMemo = deliveryMemo;
+        order.expiresAt = expiresAt;
         return order;
     }
 
@@ -64,29 +75,8 @@ public class Order extends BaseEntity {
         item.setOrder(this);
     }
 
-    public void markAsPaid(Long paymentId) {
-        status.validateTransitionTo(OrderStatus.PAID);
-        this.status = OrderStatus.PAID;
-        this.paymentId = paymentId;
-    }
-
-    public void complete() {
-        status.validateTransitionTo(OrderStatus.COMPLETED);
-        this.status = OrderStatus.COMPLETED;
-    }
-
-    public void cancel() {
-        status.validateTransitionTo(OrderStatus.CANCELLED);
-        this.status = OrderStatus.CANCELLED;
-    }
-
-    public void requestRefund() {
-        status.validateTransitionTo(OrderStatus.REFUND_REQUESTED);
-        this.status = OrderStatus.REFUND_REQUESTED;
-    }
-
-    public void markAsRefunded() {
-        status.validateTransitionTo(OrderStatus.REFUNDED);
-        this.status = OrderStatus.REFUNDED;
+    public void transitTo(OrderStatus next) {
+        this.status.validateTransitionTo(next);
+        this.status = next;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
@@ -7,17 +7,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "order_items",
         indexes = {
-                @Index(name = "idx_order_item_order_id", columnList = "order_id"),
-                @Index(name = "idx_order_item_item_id", columnList = "item_id")
+                @Index(name = "idx_order_items_order_id", columnList = "order_id"),
+                @Index(name = "idx_order_items_item_id", columnList = "item_id")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("deleted_at IS NULL")
 public class OrderItem extends BaseEntity {
 
     @Id
@@ -29,11 +27,17 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
+    @Column(name = "channel_type", nullable = false, length = 20)
+    private String channelType;
+
+    @Column(name = "channel_ref_id")
+    private Long channelRefId;
+
     @Column(name = "item_id", nullable = false)
     private Long itemId;
 
-    @Column(name = "item_name", nullable = false)
-    private String itemName;
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
@@ -41,16 +45,20 @@ public class OrderItem extends BaseEntity {
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
-    @Column(name = "subtotal", nullable = false)
-    private Long subtotal;
+    @Column(name = "line_amount", nullable = false)
+    private Long lineAmount;
 
-    public static OrderItem create(Long itemId, String itemName, Integer quantity, Long unitPrice) {
+    public static OrderItem create(String channelType, Long channelRefId,
+                                   Long itemId, Long storeId,
+                                   Integer quantity, Long unitPrice, Long lineAmount) {
         OrderItem item = new OrderItem();
+        item.channelType = channelType;
+        item.channelRefId = channelRefId;
         item.itemId = itemId;
-        item.itemName = itemName;
+        item.storeId = storeId;
         item.quantity = quantity;
         item.unitPrice = unitPrice;
-        item.subtotal = unitPrice * quantity;
+        item.lineAmount = lineAmount;
         return item;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
@@ -1,28 +1,10 @@
 package com.example.order.domain;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    Optional<Order> findByPurchaseId(Long purchaseId);
-
-    @Query("""
-            SELECT o FROM Order o
-            WHERE o.userId = :userId
-              AND (:cursorId IS NULL OR o.id < :cursorId)
-            ORDER BY o.id DESC
-            """)
-    List<Order> findByUserIdWithCursor(
-            @Param("userId") Long userId,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
-    long countByUserId(Long userId);
+    Page<Order> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
@@ -8,17 +8,21 @@ import java.util.Set;
 
 public enum OrderStatus {
 
-    CREATED,
+    PAYMENT_PENDING,
     PAID,
+    SHIPPING,
+    DELIVERED,
     COMPLETED,
     CANCELLED,
     REFUND_REQUESTED,
     REFUNDED;
 
     private static final Map<OrderStatus, Set<OrderStatus>> TRANSITIONS = Map.of(
-            CREATED, Set.of(PAID, CANCELLED),
-            PAID, Set.of(COMPLETED, REFUND_REQUESTED),
-            COMPLETED, Set.of(),
+            PAYMENT_PENDING, Set.of(PAID, CANCELLED),
+            PAID, Set.of(SHIPPING, REFUND_REQUESTED),
+            SHIPPING, Set.of(DELIVERED),
+            DELIVERED, Set.of(COMPLETED),
+            COMPLETED, Set.of(REFUND_REQUESTED),
             CANCELLED, Set.of(),
             REFUND_REQUESTED, Set.of(REFUNDED),
             REFUNDED, Set.of()

--- a/servers/services/order/src/main/resources/application.yml
+++ b/servers/services/order/src/main/resources/application.yml
@@ -15,13 +15,18 @@ spring:
   # ─── JPA ──────────────────────────────────────
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:update}
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
     show-sql: true
     open-in-view: false
+
+  # ─── Flyway ─────────────────────────────────
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
   # ─── Redis ────────────────────────────────────
   data:

--- a/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE orders (
+    id                  BIGINT PRIMARY KEY,
+    user_id             BIGINT NOT NULL,
+    status              VARCHAR(30) NOT NULL DEFAULT 'PAYMENT_PENDING',
+    total_amount        BIGINT NOT NULL,
+    recipient_name      VARCHAR(100),
+    recipient_phone     VARCHAR(20),
+    delivery_address_id BIGINT,
+    delivery_memo       VARCHAR(500),
+    expires_at          TIMESTAMP,
+    is_deleted          BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at          TIMESTAMP,
+    created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_status ON orders(status);

--- a/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE order_items (
+    id              BIGINT PRIMARY KEY,
+    order_id        BIGINT NOT NULL REFERENCES orders(id),
+    channel_type    VARCHAR(20) NOT NULL,
+    channel_ref_id  BIGINT,
+    item_id         BIGINT NOT NULL,
+    store_id        BIGINT NOT NULL,
+    quantity        INTEGER NOT NULL,
+    unit_price      BIGINT NOT NULL,
+    line_amount     BIGINT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+CREATE INDEX idx_order_items_item_id ON order_items(item_id);


### PR DESCRIPTION
## 개요                                                                                       
                                                                                             
  ### 관련 이슈                                                                                 
  - Closes #815                                                                               
  - Related: #807 (Epic)
  - Related: #808 (Story)                                                          
                                                                                                
  ### 작업 / 변경 내용

  **Order 엔티티 재설계**
  - `orderId`를 외부에서 전달받은 Snowflake BIGINT를 PK로 사용 (`@SnowflakeGenerated` 제거)
  - 타 서비스 내부 ID(`purchaseId`, `reservationId`, `paymentId`) 필드 제거 — 서비스 간 결합
  방지
  - 배송지 정보 필드 추가: `recipientName`, `recipientPhone`, `deliveryAddressId`,
  `deliveryMemo`
  - `expiresAt` 필드 추가 (저장만, 만료 스케줄링은 Stock/Sales 담당)

  **OrderItem 엔티티 슬림화**
  - 기존 `itemName`, `subtotal` 제거
  - `channelType`(FUNDING/NORMAL/HOTDEAL), `channelRefId`, `storeId`, `lineAmount` 추가
  - 스냅샷 필드(title, sellerId, itemType 등) 미저장 — 필요 시 `itemId`로 Product 서비스 조회

  **OrderStatus 상태 머신 확장**
  - 기존 6개 → 8개 상태: `PAYMENT_PENDING`, `PAID`, `SHIPPING`, `DELIVERED`, `COMPLETED`,
  `CANCELLED`, `REFUND_REQUESTED`, `REFUNDED`
  - `CREATED` → `PAYMENT_PENDING`으로 변경 (결제 대기 의미 명확화)
  - 전이 맵 확장: `PAID→SHIPPING`, `SHIPPING→DELIVERED`, `DELIVERED→COMPLETED`,
  `COMPLETED→REFUND_REQUESTED`

  **Flyway 마이그레이션 도입**
  - `ddl-auto: update` → `ddl-auto: validate` + Flyway로 전환
  - `V1__create_orders_table.sql`: orders 테이블 + user_id/status 인덱스
  - `V2__create_order_items_table.sql`: order_items 테이블 + order_id/item_id 인덱스

  **build.gradle.kts 의존성 추가**
  - `libs:event:consumer`, `libs:event:inbox`, `libs:event:outbox` (이벤트 처리 준비)
  - `flyway-core`, `flyway-database-postgresql`

  ### 테스트 / 체크리스트
  - [ ] 로컬에서 빌드 확인 (`./gradlew build`)


  ### 참고사항
  - Order에 `sourceType` 없음: 채널 구분은 `OrderItem.channelType`으로 충분 (추후 필요 시 추가
  검토)
  - `OrderItem`에서 `@SQLRestriction` 제거: 독립 soft delete 불필요 (Order와 함께 관리)
  - `OrderRepository`: 커서 기반 페이징 → 일반 `Pageable` 페이징으로 변경
  (`findByUserIdAndDeletedAtIsNull`)