### PR TITLE
feat(order) : createOrder 내부 API 구현  

### DIFF
--- a/servers/services/order/build.gradle.kts
+++ b/servers/services/order/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
     implementation(project(":libs:config:redis"))
 
     // ─── Event ────────────────────────────────────
+    implementation(project(":libs:event:consumer"))
     implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:inbox"))
     implementation(project(":libs:event:outbox"))
 
     // ─── Security ─────────────────────────────────
@@ -41,5 +43,7 @@ dependencies {
 
     // Database
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.flywaydb:flyway-core")
+    runtimeOnly("org.flywaydb:flyway-database-postgresql")
     testRuntimeOnly("com.h2database:h2")
 }

--- a/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
@@ -1,0 +1,22 @@
+package com.example.order.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Order Command (Internal)", description = "주문 생성 내부 API")
+public interface InternalOrderCommandApi {
+
+    @Operation(summary = "주문 생성", description = "오케스트레이터로부터 주문을 생성합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주문 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 주문")
+    })
+    @PostMapping("/internal/v1/orders")
+    ApiResponse<InternalCreateOrderResponse> createOrder(@RequestBody InternalCreateOrderRequest request);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
@@ -1,0 +1,16 @@
+package com.example.order.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Order Query (Internal)", description = "주문 조회 내부 API")
+public interface InternalOrderQueryApi {
+
+    @Operation(summary = "주문 단건 조회 (내부)", description = "orderId로 주문을 조회합니다")
+    @GetMapping("/internal/v1/orders/{orderId}")
+    ApiResponse<InternalOrderDetailResponse> getOrder(@PathVariable Long orderId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
@@ -1,0 +1,23 @@
+package com.example.order.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.command.InternalOrderCommandApi;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.service.command.OrderCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InternalOrderCommandController implements InternalOrderCommandApi {
+
+    private final OrderCommandService orderCommandService;
+
+    @Override
+    public ApiResponse<InternalCreateOrderResponse> createOrder(@Valid @RequestBody InternalCreateOrderRequest request) {
+        return ApiResponse.success(orderCommandService.createOrder(request));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
@@ -1,0 +1,21 @@
+package com.example.order.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.query.InternalOrderQueryApi;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import com.example.order.service.query.OrderQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InternalOrderQueryController implements InternalOrderQueryApi {
+
+    private final OrderQueryService orderQueryService;
+
+    @Override
+    public ApiResponse<InternalOrderDetailResponse> getOrder(@PathVariable Long orderId) {
+        return ApiResponse.success(orderQueryService.getOrder(orderId));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/domain/Order.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/Order.java
@@ -1,6 +1,5 @@
 package com.example.order.domain;
 
-import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,15 +7,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "orders",
         indexes = {
-                @Index(name = "idx_order_user_id", columnList = "user_id"),
-                @Index(name = "idx_order_purchase_id", columnList = "purchase_id", unique = true),
-                @Index(name = "idx_order_status", columnList = "status")
+                @Index(name = "idx_orders_user_id", columnList = "user_id"),
+                @Index(name = "idx_orders_status", columnList = "status")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,38 +23,50 @@ import java.util.List;
 public class Order extends BaseEntity {
 
     @Id
-    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "purchase_id", nullable = false)
-    private Long purchaseId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private OrderStatus status;
 
     @Column(name = "total_amount", nullable = false)
     private Long totalAmount;
 
-    @Column(name = "reservation_id")
-    private Long reservationId;
+    @Column(name = "recipient_name", length = 100)
+    private String recipientName;
 
-    @Column(name = "payment_id")
-    private Long paymentId;
+    @Column(name = "recipient_phone", length = 20)
+    private String recipientPhone;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
-    private OrderStatus status;
+    @Column(name = "delivery_address_id")
+    private Long deliveryAddressId;
+
+    @Column(name = "delivery_memo", length = 500)
+    private String deliveryMemo;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    public static Order create(Long userId, Long purchaseId, Long totalAmount, Long reservationId) {
+    public static Order create(Long orderId, Long userId, Long totalAmount,
+                               String recipientName, String recipientPhone,
+                               Long deliveryAddressId, String deliveryMemo,
+                               LocalDateTime expiresAt) {
         Order order = new Order();
+        order.id = orderId;
         order.userId = userId;
-        order.purchaseId = purchaseId;
+        order.status = OrderStatus.PAYMENT_PENDING;
         order.totalAmount = totalAmount;
-        order.reservationId = reservationId;
-        order.status = OrderStatus.CREATED;
+        order.recipientName = recipientName;
+        order.recipientPhone = recipientPhone;
+        order.deliveryAddressId = deliveryAddressId;
+        order.deliveryMemo = deliveryMemo;
+        order.expiresAt = expiresAt;
         return order;
     }
 
@@ -64,29 +75,8 @@ public class Order extends BaseEntity {
         item.setOrder(this);
     }
 
-    public void markAsPaid(Long paymentId) {
-        status.validateTransitionTo(OrderStatus.PAID);
-        this.status = OrderStatus.PAID;
-        this.paymentId = paymentId;
-    }
-
-    public void complete() {
-        status.validateTransitionTo(OrderStatus.COMPLETED);
-        this.status = OrderStatus.COMPLETED;
-    }
-
-    public void cancel() {
-        status.validateTransitionTo(OrderStatus.CANCELLED);
-        this.status = OrderStatus.CANCELLED;
-    }
-
-    public void requestRefund() {
-        status.validateTransitionTo(OrderStatus.REFUND_REQUESTED);
-        this.status = OrderStatus.REFUND_REQUESTED;
-    }
-
-    public void markAsRefunded() {
-        status.validateTransitionTo(OrderStatus.REFUNDED);
-        this.status = OrderStatus.REFUNDED;
+    public void transitTo(OrderStatus next) {
+        this.status.validateTransitionTo(next);
+        this.status = next;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
@@ -7,17 +7,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "order_items",
         indexes = {
-                @Index(name = "idx_order_item_order_id", columnList = "order_id"),
-                @Index(name = "idx_order_item_item_id", columnList = "item_id")
+                @Index(name = "idx_order_items_order_id", columnList = "order_id"),
+                @Index(name = "idx_order_items_item_id", columnList = "item_id")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("deleted_at IS NULL")
 public class OrderItem extends BaseEntity {
 
     @Id
@@ -29,11 +27,17 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
+    @Column(name = "channel_type", nullable = false, length = 20)
+    private String channelType;
+
+    @Column(name = "channel_ref_id")
+    private Long channelRefId;
+
     @Column(name = "item_id", nullable = false)
     private Long itemId;
 
-    @Column(name = "item_name", nullable = false)
-    private String itemName;
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
@@ -41,16 +45,20 @@ public class OrderItem extends BaseEntity {
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
-    @Column(name = "subtotal", nullable = false)
-    private Long subtotal;
+    @Column(name = "line_amount", nullable = false)
+    private Long lineAmount;
 
-    public static OrderItem create(Long itemId, String itemName, Integer quantity, Long unitPrice) {
+    public static OrderItem create(String channelType, Long channelRefId,
+                                   Long itemId, Long storeId,
+                                   Integer quantity, Long unitPrice, Long lineAmount) {
         OrderItem item = new OrderItem();
+        item.channelType = channelType;
+        item.channelRefId = channelRefId;
         item.itemId = itemId;
-        item.itemName = itemName;
+        item.storeId = storeId;
         item.quantity = quantity;
         item.unitPrice = unitPrice;
-        item.subtotal = unitPrice * quantity;
+        item.lineAmount = lineAmount;
         return item;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
@@ -1,28 +1,10 @@
 package com.example.order.domain;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    Optional<Order> findByPurchaseId(Long purchaseId);
-
-    @Query("""
-            SELECT o FROM Order o
-            WHERE o.userId = :userId
-              AND (:cursorId IS NULL OR o.id < :cursorId)
-            ORDER BY o.id DESC
-            """)
-    List<Order> findByUserIdWithCursor(
-            @Param("userId") Long userId,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
-    long countByUserId(Long userId);
+    Page<Order> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
@@ -8,17 +8,21 @@ import java.util.Set;
 
 public enum OrderStatus {
 
-    CREATED,
+    PAYMENT_PENDING,
     PAID,
+    SHIPPING,
+    DELIVERED,
     COMPLETED,
     CANCELLED,
     REFUND_REQUESTED,
     REFUNDED;
 
     private static final Map<OrderStatus, Set<OrderStatus>> TRANSITIONS = Map.of(
-            CREATED, Set.of(PAID, CANCELLED),
-            PAID, Set.of(COMPLETED, REFUND_REQUESTED),
-            COMPLETED, Set.of(),
+            PAYMENT_PENDING, Set.of(PAID, CANCELLED),
+            PAID, Set.of(SHIPPING, REFUND_REQUESTED),
+            SHIPPING, Set.of(DELIVERED),
+            DELIVERED, Set.of(COMPLETED),
+            COMPLETED, Set.of(REFUND_REQUESTED),
             CANCELLED, Set.of(),
             REFUND_REQUESTED, Set.of(REFUNDED),
             REFUNDED, Set.of()

--- a/servers/services/order/src/main/java/com/example/order/dto/request/InternalCreateOrderRequest.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/request/InternalCreateOrderRequest.java
@@ -1,0 +1,59 @@
+package com.example.order.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class InternalCreateOrderRequest {
+
+    @NotNull
+    private Long orderId;
+
+    @NotNull
+    private Long userId;
+
+    private LocalDateTime expiresAt;
+
+    @NotNull
+    private Long totalAmount;
+
+    private String recipientName;
+    private String recipientPhone;
+    private Long deliveryAddressId;
+    private String deliveryMemo;
+
+    @NotEmpty
+    @Valid
+    private List<LineItem> lineItems;
+
+    @Getter
+    @NoArgsConstructor
+    public static class LineItem {
+        private String channelType;
+        private Long channelRefId;
+        @NotNull
+        private Long itemId;
+        private String itemType;
+        private String title;
+        private Long sellerId;
+        @NotNull
+        private Long storeId;
+        private String stockItemType;
+        private Long referenceId;
+        private String referenceName;
+        @NotNull
+        private Integer quantity;
+        private Long baseUnitPrice;
+        @NotNull
+        private Long finalUnitPrice;
+        @NotNull
+        private Long lineAmount;
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/InternalCreateOrderResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/InternalCreateOrderResponse.java
@@ -1,0 +1,19 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InternalCreateOrderResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/InternalOrderDetailResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/InternalOrderDetailResponse.java
@@ -1,0 +1,73 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class InternalOrderDetailResponse {
+
+    @SnowflakeId
+    private Long orderId;
+    private Long userId;
+    private String status;
+    private Long totalAmount;
+    private String recipientName;
+    private String recipientPhone;
+    private Long deliveryAddressId;
+    private String deliveryMemo;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+    private List<OrderItemDto> items;
+
+    @Getter
+    @Builder
+    public static class OrderItemDto {
+        @SnowflakeId
+        private Long id;
+        private String channelType;
+        private Long channelRefId;
+        private Long itemId;
+        private Long storeId;
+        private Integer quantity;
+        private Long unitPrice;
+        private Long lineAmount;
+    }
+
+    public static InternalOrderDetailResponse from(Order order) {
+        return InternalOrderDetailResponse.builder()
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .status(order.getStatus().name())
+                .totalAmount(order.getTotalAmount())
+                .recipientName(order.getRecipientName())
+                .recipientPhone(order.getRecipientPhone())
+                .deliveryAddressId(order.getDeliveryAddressId())
+                .deliveryMemo(order.getDeliveryMemo())
+                .expiresAt(order.getExpiresAt())
+                .createdAt(order.getCreatedAt())
+                .items(order.getOrderItems().stream()
+                        .map(InternalOrderDetailResponse::toItemDto)
+                        .toList())
+                .build();
+    }
+
+    private static OrderItemDto toItemDto(OrderItem item) {
+        return OrderItemDto.builder()
+                .id(item.getId())
+                .channelType(item.getChannelType())
+                .channelRefId(item.getChannelRefId())
+                .itemId(item.getItemId())
+                .storeId(item.getStoreId())
+                .quantity(item.getQuantity())
+                .unitPrice(item.getUnitPrice())
+                .lineAmount(item.getLineAmount())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
@@ -1,0 +1,61 @@
+package com.example.order.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderCommandService {
+
+    private final OrderRepository orderRepository;
+
+    public InternalCreateOrderResponse createOrder(InternalCreateOrderRequest request) {
+        if (orderRepository.existsById(request.getOrderId())) {
+            throw new BusinessException(OrderErrorCode.ORDER_ALREADY_EXISTS);
+        }
+
+        Order order = Order.create(
+                request.getOrderId(),
+                request.getUserId(),
+                request.getTotalAmount(),
+                request.getRecipientName(),
+                request.getRecipientPhone(),
+                request.getDeliveryAddressId(),
+                request.getDeliveryMemo(),
+                request.getExpiresAt()
+        );
+
+        for (InternalCreateOrderRequest.LineItem lineItem : request.getLineItems()) {
+            OrderItem orderItem = OrderItem.create(
+                    lineItem.getChannelType(),
+                    lineItem.getChannelRefId(),
+                    lineItem.getItemId(),
+                    lineItem.getStoreId(),
+                    lineItem.getQuantity(),
+                    lineItem.getFinalUnitPrice(),
+                    lineItem.getLineAmount()
+            );
+            order.addItem(orderItem);
+        }
+
+        orderRepository.save(order);
+        log.info("주문 생성 완료: orderId={}", order.getId());
+
+        return InternalCreateOrderResponse.builder()
+                .orderId(order.getId())
+                .status(order.getStatus().name())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
@@ -1,0 +1,24 @@
+package com.example.order.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryService {
+
+    private final OrderRepository orderRepository;
+
+    public InternalOrderDetailResponse getOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        return InternalOrderDetailResponse.from(order);
+    }
+}

--- a/servers/services/order/src/main/resources/application.yml
+++ b/servers/services/order/src/main/resources/application.yml
@@ -15,13 +15,18 @@ spring:
   # ─── JPA ──────────────────────────────────────
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:update}
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
     show-sql: true
     open-in-view: false
+
+  # ─── Flyway ─────────────────────────────────
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
   # ─── Redis ────────────────────────────────────
   data:

--- a/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE orders (
+    id                  BIGINT PRIMARY KEY,
+    user_id             BIGINT NOT NULL,
+    status              VARCHAR(30) NOT NULL DEFAULT 'PAYMENT_PENDING',
+    total_amount        BIGINT NOT NULL,
+    recipient_name      VARCHAR(100),
+    recipient_phone     VARCHAR(20),
+    delivery_address_id BIGINT,
+    delivery_memo       VARCHAR(500),
+    expires_at          TIMESTAMP,
+    is_deleted          BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at          TIMESTAMP,
+    created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_status ON orders(status);

--- a/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE order_items (
+    id              BIGINT PRIMARY KEY,
+    order_id        BIGINT NOT NULL REFERENCES orders(id),
+    channel_type    VARCHAR(20) NOT NULL,
+    channel_ref_id  BIGINT,
+    item_id         BIGINT NOT NULL,
+    store_id        BIGINT NOT NULL,
+    quantity        INTEGER NOT NULL,
+    unit_price      BIGINT NOT NULL,
+    line_amount     BIGINT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+CREATE INDEX idx_order_items_item_id ON order_items(item_id);


### PR DESCRIPTION
## 개요                                                                                       
                
  ### 관련 이슈                                                                                 
  - Closes #816                                                                                 
  - Closes #817                                                                                 
  - Closes #818                                                                                 
  - Related: #807 (Epic), #809 (Story)                                                          

  ### 작업 / 변경 내용

  **InternalCreateOrderRequest DTO**
  - order-client의 `OrderCreateRequest` 필드를 그대로 수신
  - Order가 필요한 필드만 엔티티에 매핑, 나머지(title, sellerId, itemType, referenceId,
  referenceName, stockItemType, baseUnitPrice)는 무시
  - `finalUnitPrice` → `OrderItem.unitPrice`로 매핑
  - Validation: `@NotNull` orderId/userId/totalAmount, `@NotEmpty` lineItems

  **InternalCreateOrderResponse DTO**
  - orderId(`@SnowflakeId`), status(`PAYMENT_PENDING`), createdAt 반환

  **OrderCommandService.createOrder**
  - 중복 검사: `orderRepository.existsById(orderId)` → `ORDER_ALREADY_EXISTS` (409)
  - Order 엔티티 생성 (외부 orderId를 PK로 사용)
  - OrderItem 리스트 생성 (channelType, channelRefId, itemId, storeId, quantity, unitPrice,
  lineAmount)
  - createOrder에서 Outbox 미발행 — Order는 하류 서비스이므로 이벤트 발행은 상태 변경 시에만

  **OrderQueryService.getOrder (내부 API용)**
  - orderId로 단건 조회 (userId 검증 없음)
  - InternalOrderDetailResponse: 주문 전체 필드 + items 목록

  **Controller + API 인터페이스**
  - `InternalOrderCommandController`: `POST /internal/v1/orders` → createOrder
  - `InternalOrderQueryController`: `GET /internal/v1/orders/{orderId}` → getOrder
  - `InternalOrderCommandApi`, `InternalOrderQueryApi` 인터페이스 분리 (Swagger @Tag, @Operation
   문서화)
  - 응답: `ApiResponse<T>` 래핑 (공통 모듈)

  ### 테스트 / 체크리스트
  - [ ] 로컬에서 빌드 확인 (`./gradlew build`)

  ### 참고사항
  - order-client DTO는 수정하지 않음 -> 현재 DTO 그대로 수신하고 Order가 필요한 것만 매핑
  - 기존 계획에 있던 `ORDER_CREATED` Outbox 발행은 제거 — Order는 오케스트레이터가 아닌 하류
  서비스
  - Public 조회 API(GET /api/v1/orders)는 `feature/order-query-api` 브랜치(#868)에서 별도 구현