### PR TITLE
[Task] Order 단위/통합/이벤트 Consumer 테스트 구현

### DIFF
--- a/servers/services/order/build.gradle.kts
+++ b/servers/services/order/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
     implementation(project(":libs:config:redis"))
 
     // ─── Event ────────────────────────────────────
+    implementation(project(":libs:event:consumer"))
     implementation(project(":libs:event:domain"))
+    implementation(project(":libs:event:inbox"))
     implementation(project(":libs:event:outbox"))
 
     // ─── Security ─────────────────────────────────
@@ -41,5 +43,7 @@ dependencies {
 
     // Database
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.flywaydb:flyway-core")
+    runtimeOnly("org.flywaydb:flyway-database-postgresql")
     testRuntimeOnly("com.h2database:h2")
 }

--- a/servers/services/order/build.gradle.kts
+++ b/servers/services/order/build.gradle.kts
@@ -46,4 +46,8 @@ dependencies {
     runtimeOnly("org.flywaydb:flyway-core")
     runtimeOnly("org.flywaydb:flyway-database-postgresql")
     testRuntimeOnly("com.h2database:h2")
+
+    // ─── Test ───────────────────────────────────
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 }

--- a/servers/services/order/src/main/java/com/example/order/consumer/payment/OrderPaymentEventProcessor.java
+++ b/servers/services/order/src/main/java/com/example/order/consumer/payment/OrderPaymentEventProcessor.java
@@ -1,0 +1,117 @@
+package com.example.order.consumer.payment;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.exception.BusinessException;
+import com.example.event.consumer.AbstractIdempotentEventSpecProcessor;
+import com.example.event.consumer.EventEnvelope;
+import com.example.event.consumer.EventSpec;
+import com.example.event.inbox.InboxConsumerBinding;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.domain.OrderStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@InboxConsumerBinding(consumerName = OrderPaymentEventProcessor.CONSUMER_NAME)
+public class OrderPaymentEventProcessor extends AbstractIdempotentEventSpecProcessor {
+
+    public static final String CONSUMER_NAME = "order-payment-events-consumer";
+    private static final String IDEMPOTENT_EVENT_TYPE = "PAYMENT_EVENT";
+
+    private final OrderRepository orderRepository;
+    private final Map<String, EventSpec<PaymentEventMessage>> eventSpecs;
+
+    public OrderPaymentEventProcessor(
+            OrderRepository orderRepository,
+            IdempotentConsumerService idempotentConsumerService
+    ) {
+        super(idempotentConsumerService);
+        this.orderRepository = orderRepository;
+        this.eventSpecs = Map.of(
+                "PAYMENT_COMPLETED", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentCompleted),
+                "PAYMENT_FAILED", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentFailed),
+                "PAYMENT_TIMED_OUT", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentTimedOut)
+        );
+    }
+
+    @Override
+    protected String idempotentEventType() {
+        return IDEMPOTENT_EVENT_TYPE;
+    }
+
+    @Override
+    protected <T extends EventEnvelope> void onInvalidPayload(T event, String message, String eventId, String eventType) {
+        log.error("[OrderPaymentConsumer] orderId가 null입니다. message={}", message);
+    }
+
+    @Override
+    protected void onInvalidEnvelope(String eventId, String eventType, String message) {
+        log.error("[OrderPaymentConsumer] eventId 또는 eventType이 null입니다. message={}", message);
+    }
+
+    @Override
+    protected <T extends EventEnvelope> void onProcessingException(
+            T event, String message, String eventId, String eventType, Exception exception
+    ) {
+        log.error("[OrderPaymentConsumer] 이벤트 처리 실패: {}", message, exception);
+        throw propagate(exception);
+    }
+
+    @Override
+    protected Map<String, EventSpec<PaymentEventMessage>> eventSpecs() {
+        return eventSpecs;
+    }
+
+    private boolean hasOrderId(PaymentEventMessage event) {
+        return event.getOrderId() != null;
+    }
+
+    private void handlePaymentCompleted(PaymentEventMessage event) {
+        Order order = findOrder(event.getOrderId());
+        if (order == null) return;
+
+        try {
+            order.transitTo(OrderStatus.PAID);
+            log.info("결제 완료 → 주문 PAID 전이: orderId={}", event.getOrderId());
+            // TODO: Delivery 서비스 구현 시 ORDER_PAID_EVENT Outbox 발행 추가
+            // payload에 배송지 포함 여부도 Delivery 구현 시 결정
+        } catch (BusinessException e) {
+            log.warn("주문 상태 전이 불가 (이미 처리됨): orderId={}, currentStatus={}", event.getOrderId(), order.getStatus());
+        }
+    }
+
+    private void handlePaymentFailed(PaymentEventMessage event) {
+        Order order = findOrder(event.getOrderId());
+        if (order == null) return;
+
+        try {
+            order.transitTo(OrderStatus.CANCELLED);
+            log.info("결제 실패 → 주문 CANCELLED 전이: orderId={}, reason={}", event.getOrderId(), event.getFailReason());
+        } catch (BusinessException e) {
+            log.warn("주문 상태 전이 불가 (이미 처리됨): orderId={}, currentStatus={}", event.getOrderId(), order.getStatus());
+        }
+    }
+
+    private void handlePaymentTimedOut(PaymentEventMessage event) {
+        Order order = findOrder(event.getOrderId());
+        if (order == null) return;
+
+        try {
+            order.transitTo(OrderStatus.CANCELLED);
+            log.info("결제 타임아웃 → 주문 CANCELLED 전이: orderId={}", event.getOrderId());
+        } catch (BusinessException e) {
+            log.warn("주문 상태 전이 불가 (이미 처리됨): orderId={}, currentStatus={}", event.getOrderId(), order.getStatus());
+        }
+    }
+
+    private Order findOrder(Long orderId) {
+        return orderRepository.findById(orderId).orElseGet(() -> {
+            log.warn("주문을 찾을 수 없습니다. 스킵합니다: orderId={}", orderId);
+            return null;
+        });
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/consumer/payment/OrderPaymentEventProcessor.java
+++ b/servers/services/order/src/main/java/com/example/order/consumer/payment/OrderPaymentEventProcessor.java
@@ -4,11 +4,14 @@ import com.example.config.kafka.IdempotentConsumerService;
 import com.example.core.exception.BusinessException;
 import com.example.event.consumer.AbstractIdempotentEventSpecProcessor;
 import com.example.event.consumer.EventEnvelope;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
 import com.example.event.consumer.EventSpec;
 import com.example.event.inbox.InboxConsumerBinding;
 import com.example.order.domain.Order;
 import com.example.order.domain.OrderRepository;
 import com.example.order.domain.OrderStatus;
+import com.example.order.event.OrderRefundedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -23,18 +26,22 @@ public class OrderPaymentEventProcessor extends AbstractIdempotentEventSpecProce
     private static final String IDEMPOTENT_EVENT_TYPE = "PAYMENT_EVENT";
 
     private final OrderRepository orderRepository;
+    private final EventPublisher eventPublisher;
     private final Map<String, EventSpec<PaymentEventMessage>> eventSpecs;
 
     public OrderPaymentEventProcessor(
             OrderRepository orderRepository,
+            EventPublisher eventPublisher,
             IdempotentConsumerService idempotentConsumerService
     ) {
         super(idempotentConsumerService);
         this.orderRepository = orderRepository;
+        this.eventPublisher = eventPublisher;
         this.eventSpecs = Map.of(
                 "PAYMENT_COMPLETED", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentCompleted),
                 "PAYMENT_FAILED", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentFailed),
-                "PAYMENT_TIMED_OUT", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentTimedOut)
+                "PAYMENT_TIMED_OUT", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentTimedOut),
+                "PAYMENT_REFUNDED", EventSpec.of(PaymentEventMessage.class, this::hasOrderId, this::handlePaymentRefunded)
         );
     }
 
@@ -103,6 +110,23 @@ public class OrderPaymentEventProcessor extends AbstractIdempotentEventSpecProce
         try {
             order.transitTo(OrderStatus.CANCELLED);
             log.info("결제 타임아웃 → 주문 CANCELLED 전이: orderId={}", event.getOrderId());
+        } catch (BusinessException e) {
+            log.warn("주문 상태 전이 불가 (이미 처리됨): orderId={}, currentStatus={}", event.getOrderId(), order.getStatus());
+        }
+    }
+
+    private void handlePaymentRefunded(PaymentEventMessage event) {
+        Order order = findOrder(event.getOrderId());
+        if (order == null) return;
+
+        try {
+            order.transitTo(OrderStatus.REFUNDED);
+            log.info("환불 완료 → 주문 REFUNDED 전이: orderId={}", event.getOrderId());
+
+            eventPublisher.publish(
+                    new OrderRefundedEvent(event.getOrderId(), order.getUserId()),
+                    EventMetadata.of("Order", String.valueOf(event.getOrderId()))
+            );
         } catch (BusinessException e) {
             log.warn("주문 상태 전이 불가 (이미 처리됨): orderId={}, currentStatus={}", event.getOrderId(), order.getStatus());
         }

--- a/servers/services/order/src/main/java/com/example/order/consumer/payment/PaymentEventConsumer.java
+++ b/servers/services/order/src/main/java/com/example/order/consumer/payment/PaymentEventConsumer.java
@@ -1,0 +1,33 @@
+package com.example.order.consumer.payment;
+
+import com.example.event.consumer.ConsumerRoutingMode;
+import com.example.event.consumer.RoutedEventConsumer;
+import com.example.event.inbox.AbstractProcessorRoutingConsumer;
+import com.example.event.inbox.InboxRoutingSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RoutedEventConsumer(
+        consumerName = OrderPaymentEventProcessor.CONSUMER_NAME,
+        defaultMode = ConsumerRoutingMode.INBOX
+)
+public class PaymentEventConsumer extends AbstractProcessorRoutingConsumer {
+
+    public PaymentEventConsumer(
+            InboxRoutingSupport inboxRoutingSupport,
+            OrderPaymentEventProcessor orderPaymentEventProcessor
+    ) {
+        super(inboxRoutingSupport, orderPaymentEventProcessor);
+    }
+
+    @KafkaListener(topics = "payment-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(ConsumerRecord<String, Object> record) {
+        consumeRecord(record);
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/consumer/payment/PaymentEventMessage.java
+++ b/servers/services/order/src/main/java/com/example/order/consumer/payment/PaymentEventMessage.java
@@ -1,0 +1,21 @@
+package com.example.order.consumer.payment;
+
+import com.example.event.consumer.EventEnvelope;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PaymentEventMessage implements EventEnvelope {
+
+    private String eventId;
+    private String eventType;
+    private Long paymentId;
+    private Long orderId;
+    private Long userId;
+    private Long amount;
+    private LocalDateTime paidAt;
+    private String failReason;
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/command/InternalOrderCommandApi.java
@@ -1,0 +1,22 @@
+package com.example.order.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Order Command (Internal)", description = "주문 생성 내부 API")
+public interface InternalOrderCommandApi {
+
+    @Operation(summary = "주문 생성", description = "오케스트레이터로부터 주문을 생성합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주문 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 주문")
+    })
+    @PostMapping("/internal/v1/orders")
+    ApiResponse<InternalCreateOrderResponse> createOrder(@RequestBody InternalCreateOrderRequest request);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/command/OrderCommandApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/command/OrderCommandApi.java
@@ -1,0 +1,15 @@
+package com.example.order.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Order Command", description = "주문 변경 외부 API")
+public interface OrderCommandApi {
+
+    @Operation(summary = "주문 취소", description = "결제 전(PAYMENT_PENDING) 주문을 취소합니다")
+    @PostMapping("/api/v1/orders/{orderId}/cancel")
+    ApiResponse<Void> cancelOrder(@PathVariable Long orderId, Long userId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/command/OrderCommandApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/command/OrderCommandApi.java
@@ -12,4 +12,8 @@ public interface OrderCommandApi {
     @Operation(summary = "주문 취소", description = "결제 전(PAYMENT_PENDING) 주문을 취소합니다")
     @PostMapping("/api/v1/orders/{orderId}/cancel")
     ApiResponse<Void> cancelOrder(@PathVariable Long orderId, Long userId);
+
+    @Operation(summary = "환불 요청", description = "결제 완료 이후 주문의 전액 환불을 요청합니다")
+    @PostMapping("/api/v1/orders/{orderId}/refund")
+    ApiResponse<Void> requestRefund(@PathVariable Long orderId, Long userId);
 }

--- a/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/query/InternalOrderQueryApi.java
@@ -1,0 +1,16 @@
+package com.example.order.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Order Query (Internal)", description = "주문 조회 내부 API")
+public interface InternalOrderQueryApi {
+
+    @Operation(summary = "주문 단건 조회 (내부)", description = "orderId로 주문을 조회합니다")
+    @GetMapping("/internal/v1/orders/{orderId}")
+    ApiResponse<InternalOrderDetailResponse> getOrder(@PathVariable Long orderId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/api/query/OrderQueryApi.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/api/query/OrderQueryApi.java
@@ -1,0 +1,23 @@
+package com.example.order.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Order Query", description = "주문 조회 외부 API")
+public interface OrderQueryApi {
+
+    @Operation(summary = "내 주문 목록 조회", description = "로그인한 사용자의 주문 목록을 페이징 조회합니다")
+    @GetMapping("/api/v1/orders")
+    ApiResponse<Page<OrderListResponse>> getMyOrders(Long userId, Pageable pageable);
+
+    @Operation(summary = "주문 상세 조회", description = "주문 상세 정보를 조회합니다 (본인 주문만)")
+    @GetMapping("/api/v1/orders/{orderId}")
+    ApiResponse<OrderDetailResponse> getOrderDetail(@PathVariable Long orderId, Long userId);
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/command/InternalOrderCommandController.java
@@ -1,0 +1,23 @@
+package com.example.order.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.command.InternalOrderCommandApi;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.service.command.OrderCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InternalOrderCommandController implements InternalOrderCommandApi {
+
+    private final OrderCommandService orderCommandService;
+
+    @Override
+    public ApiResponse<InternalCreateOrderResponse> createOrder(@Valid @RequestBody InternalCreateOrderRequest request) {
+        return ApiResponse.success(orderCommandService.createOrder(request));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/command/OrderCommandController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/command/OrderCommandController.java
@@ -1,0 +1,22 @@
+package com.example.order.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.command.OrderCommandApi;
+import com.example.order.service.command.OrderCommandService;
+import com.example.security.gateway.CurrentUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderCommandController implements OrderCommandApi {
+
+    private final OrderCommandService orderCommandService;
+
+    @Override
+    public ApiResponse<Void> cancelOrder(@PathVariable Long orderId, @CurrentUserId Long userId) {
+        orderCommandService.cancelOrder(orderId, userId);
+        return ApiResponse.success();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/command/OrderCommandController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/command/OrderCommandController.java
@@ -19,4 +19,10 @@ public class OrderCommandController implements OrderCommandApi {
         orderCommandService.cancelOrder(orderId, userId);
         return ApiResponse.success();
     }
+
+    @Override
+    public ApiResponse<Void> requestRefund(@PathVariable Long orderId, @CurrentUserId Long userId) {
+        orderCommandService.requestRefund(orderId, userId);
+        return ApiResponse.success();
+    }
 }

--- a/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/query/InternalOrderQueryController.java
@@ -1,0 +1,21 @@
+package com.example.order.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.query.InternalOrderQueryApi;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import com.example.order.service.query.OrderQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InternalOrderQueryController implements InternalOrderQueryApi {
+
+    private final OrderQueryService orderQueryService;
+
+    @Override
+    public ApiResponse<InternalOrderDetailResponse> getOrder(@PathVariable Long orderId) {
+        return ApiResponse.success(orderQueryService.getOrder(orderId));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/controller/query/OrderQueryController.java
+++ b/servers/services/order/src/main/java/com/example/order/controller/query/OrderQueryController.java
@@ -1,0 +1,35 @@
+package com.example.order.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.order.controller.api.query.OrderQueryApi;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
+import com.example.order.service.query.OrderQueryService;
+import com.example.security.gateway.CurrentUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderQueryController implements OrderQueryApi {
+
+    private final OrderQueryService orderQueryService;
+
+    @Override
+    public ApiResponse<Page<OrderListResponse>> getMyOrders(
+            @CurrentUserId Long userId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.success(orderQueryService.getMyOrders(userId, pageable));
+    }
+
+    @Override
+    public ApiResponse<OrderDetailResponse> getOrderDetail(
+            @PathVariable Long orderId,
+            @CurrentUserId Long userId) {
+        return ApiResponse.success(orderQueryService.getOrderDetail(orderId, userId));
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/domain/Order.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/Order.java
@@ -1,6 +1,5 @@
 package com.example.order.domain;
 
-import com.example.core.id.jpa.SnowflakeGenerated;
 import com.example.data.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,15 +7,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "orders",
         indexes = {
-                @Index(name = "idx_order_user_id", columnList = "user_id"),
-                @Index(name = "idx_order_purchase_id", columnList = "purchase_id", unique = true),
-                @Index(name = "idx_order_status", columnList = "status")
+                @Index(name = "idx_orders_user_id", columnList = "user_id"),
+                @Index(name = "idx_orders_status", columnList = "status")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,38 +23,50 @@ import java.util.List;
 public class Order extends BaseEntity {
 
     @Id
-    @SnowflakeGenerated
     private Long id;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "purchase_id", nullable = false)
-    private Long purchaseId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private OrderStatus status;
 
     @Column(name = "total_amount", nullable = false)
     private Long totalAmount;
 
-    @Column(name = "reservation_id")
-    private Long reservationId;
+    @Column(name = "recipient_name", length = 100)
+    private String recipientName;
 
-    @Column(name = "payment_id")
-    private Long paymentId;
+    @Column(name = "recipient_phone", length = 20)
+    private String recipientPhone;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
-    private OrderStatus status;
+    @Column(name = "delivery_address_id")
+    private Long deliveryAddressId;
+
+    @Column(name = "delivery_memo", length = 500)
+    private String deliveryMemo;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    public static Order create(Long userId, Long purchaseId, Long totalAmount, Long reservationId) {
+    public static Order create(Long orderId, Long userId, Long totalAmount,
+                               String recipientName, String recipientPhone,
+                               Long deliveryAddressId, String deliveryMemo,
+                               LocalDateTime expiresAt) {
         Order order = new Order();
+        order.id = orderId;
         order.userId = userId;
-        order.purchaseId = purchaseId;
+        order.status = OrderStatus.PAYMENT_PENDING;
         order.totalAmount = totalAmount;
-        order.reservationId = reservationId;
-        order.status = OrderStatus.CREATED;
+        order.recipientName = recipientName;
+        order.recipientPhone = recipientPhone;
+        order.deliveryAddressId = deliveryAddressId;
+        order.deliveryMemo = deliveryMemo;
+        order.expiresAt = expiresAt;
         return order;
     }
 
@@ -64,29 +75,8 @@ public class Order extends BaseEntity {
         item.setOrder(this);
     }
 
-    public void markAsPaid(Long paymentId) {
-        status.validateTransitionTo(OrderStatus.PAID);
-        this.status = OrderStatus.PAID;
-        this.paymentId = paymentId;
-    }
-
-    public void complete() {
-        status.validateTransitionTo(OrderStatus.COMPLETED);
-        this.status = OrderStatus.COMPLETED;
-    }
-
-    public void cancel() {
-        status.validateTransitionTo(OrderStatus.CANCELLED);
-        this.status = OrderStatus.CANCELLED;
-    }
-
-    public void requestRefund() {
-        status.validateTransitionTo(OrderStatus.REFUND_REQUESTED);
-        this.status = OrderStatus.REFUND_REQUESTED;
-    }
-
-    public void markAsRefunded() {
-        status.validateTransitionTo(OrderStatus.REFUNDED);
-        this.status = OrderStatus.REFUNDED;
+    public void transitTo(OrderStatus next) {
+        this.status.validateTransitionTo(next);
+        this.status = next;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderItem.java
@@ -7,17 +7,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "order_items",
         indexes = {
-                @Index(name = "idx_order_item_order_id", columnList = "order_id"),
-                @Index(name = "idx_order_item_item_id", columnList = "item_id")
+                @Index(name = "idx_order_items_order_id", columnList = "order_id"),
+                @Index(name = "idx_order_items_item_id", columnList = "item_id")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("deleted_at IS NULL")
 public class OrderItem extends BaseEntity {
 
     @Id
@@ -29,11 +27,17 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
+    @Column(name = "channel_type", nullable = false, length = 20)
+    private String channelType;
+
+    @Column(name = "channel_ref_id")
+    private Long channelRefId;
+
     @Column(name = "item_id", nullable = false)
     private Long itemId;
 
-    @Column(name = "item_name", nullable = false)
-    private String itemName;
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
 
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
@@ -41,16 +45,20 @@ public class OrderItem extends BaseEntity {
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
-    @Column(name = "subtotal", nullable = false)
-    private Long subtotal;
+    @Column(name = "line_amount", nullable = false)
+    private Long lineAmount;
 
-    public static OrderItem create(Long itemId, String itemName, Integer quantity, Long unitPrice) {
+    public static OrderItem create(String channelType, Long channelRefId,
+                                   Long itemId, Long storeId,
+                                   Integer quantity, Long unitPrice, Long lineAmount) {
         OrderItem item = new OrderItem();
+        item.channelType = channelType;
+        item.channelRefId = channelRefId;
         item.itemId = itemId;
-        item.itemName = itemName;
+        item.storeId = storeId;
         item.quantity = quantity;
         item.unitPrice = unitPrice;
-        item.subtotal = unitPrice * quantity;
+        item.lineAmount = lineAmount;
         return item;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderRepository.java
@@ -1,28 +1,10 @@
 package com.example.order.domain;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    Optional<Order> findByPurchaseId(Long purchaseId);
-
-    @Query("""
-            SELECT o FROM Order o
-            WHERE o.userId = :userId
-              AND (:cursorId IS NULL OR o.id < :cursorId)
-            ORDER BY o.id DESC
-            """)
-    List<Order> findByUserIdWithCursor(
-            @Param("userId") Long userId,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
-    long countByUserId(Long userId);
+    Page<Order> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 }

--- a/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
+++ b/servers/services/order/src/main/java/com/example/order/domain/OrderStatus.java
@@ -8,17 +8,21 @@ import java.util.Set;
 
 public enum OrderStatus {
 
-    CREATED,
+    PAYMENT_PENDING,
     PAID,
+    SHIPPING,
+    DELIVERED,
     COMPLETED,
     CANCELLED,
     REFUND_REQUESTED,
     REFUNDED;
 
     private static final Map<OrderStatus, Set<OrderStatus>> TRANSITIONS = Map.of(
-            CREATED, Set.of(PAID, CANCELLED),
-            PAID, Set.of(COMPLETED, REFUND_REQUESTED),
-            COMPLETED, Set.of(),
+            PAYMENT_PENDING, Set.of(PAID, CANCELLED),
+            PAID, Set.of(SHIPPING, REFUND_REQUESTED),
+            SHIPPING, Set.of(DELIVERED),
+            DELIVERED, Set.of(COMPLETED),
+            COMPLETED, Set.of(REFUND_REQUESTED),
             CANCELLED, Set.of(),
             REFUND_REQUESTED, Set.of(REFUNDED),
             REFUNDED, Set.of()

--- a/servers/services/order/src/main/java/com/example/order/dto/request/InternalCreateOrderRequest.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/request/InternalCreateOrderRequest.java
@@ -1,0 +1,59 @@
+package com.example.order.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class InternalCreateOrderRequest {
+
+    @NotNull
+    private Long orderId;
+
+    @NotNull
+    private Long userId;
+
+    private LocalDateTime expiresAt;
+
+    @NotNull
+    private Long totalAmount;
+
+    private String recipientName;
+    private String recipientPhone;
+    private Long deliveryAddressId;
+    private String deliveryMemo;
+
+    @NotEmpty
+    @Valid
+    private List<LineItem> lineItems;
+
+    @Getter
+    @NoArgsConstructor
+    public static class LineItem {
+        private String channelType;
+        private Long channelRefId;
+        @NotNull
+        private Long itemId;
+        private String itemType;
+        private String title;
+        private Long sellerId;
+        @NotNull
+        private Long storeId;
+        private String stockItemType;
+        private Long referenceId;
+        private String referenceName;
+        @NotNull
+        private Integer quantity;
+        private Long baseUnitPrice;
+        @NotNull
+        private Long finalUnitPrice;
+        @NotNull
+        private Long lineAmount;
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/InternalCreateOrderResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/InternalCreateOrderResponse.java
@@ -1,0 +1,19 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InternalCreateOrderResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/InternalOrderDetailResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/InternalOrderDetailResponse.java
@@ -1,0 +1,73 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class InternalOrderDetailResponse {
+
+    @SnowflakeId
+    private Long orderId;
+    private Long userId;
+    private String status;
+    private Long totalAmount;
+    private String recipientName;
+    private String recipientPhone;
+    private Long deliveryAddressId;
+    private String deliveryMemo;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+    private List<OrderItemDto> items;
+
+    @Getter
+    @Builder
+    public static class OrderItemDto {
+        @SnowflakeId
+        private Long id;
+        private String channelType;
+        private Long channelRefId;
+        private Long itemId;
+        private Long storeId;
+        private Integer quantity;
+        private Long unitPrice;
+        private Long lineAmount;
+    }
+
+    public static InternalOrderDetailResponse from(Order order) {
+        return InternalOrderDetailResponse.builder()
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .status(order.getStatus().name())
+                .totalAmount(order.getTotalAmount())
+                .recipientName(order.getRecipientName())
+                .recipientPhone(order.getRecipientPhone())
+                .deliveryAddressId(order.getDeliveryAddressId())
+                .deliveryMemo(order.getDeliveryMemo())
+                .expiresAt(order.getExpiresAt())
+                .createdAt(order.getCreatedAt())
+                .items(order.getOrderItems().stream()
+                        .map(InternalOrderDetailResponse::toItemDto)
+                        .toList())
+                .build();
+    }
+
+    private static OrderItemDto toItemDto(OrderItem item) {
+        return OrderItemDto.builder()
+                .id(item.getId())
+                .channelType(item.getChannelType())
+                .channelRefId(item.getChannelRefId())
+                .itemId(item.getItemId())
+                .storeId(item.getStoreId())
+                .quantity(item.getQuantity())
+                .unitPrice(item.getUnitPrice())
+                .lineAmount(item.getLineAmount())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/OrderDetailResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,71 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderDetailResponse {
+
+    @SnowflakeId
+    private Long orderId;
+    private String status;
+    private Long totalAmount;
+    private String recipientName;
+    private String recipientPhone;
+    private Long deliveryAddressId;
+    private String deliveryMemo;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+    private List<OrderItemDto> items;
+
+    @Getter
+    @Builder
+    public static class OrderItemDto {
+        @SnowflakeId
+        private Long id;
+        private String channelType;
+        private Long channelRefId;
+        private Long itemId;
+        private Long storeId;
+        private Integer quantity;
+        private Long unitPrice;
+        private Long lineAmount;
+    }
+
+    public static OrderDetailResponse from(Order order) {
+        return OrderDetailResponse.builder()
+                .orderId(order.getId())
+                .status(order.getStatus().name())
+                .totalAmount(order.getTotalAmount())
+                .recipientName(order.getRecipientName())
+                .recipientPhone(order.getRecipientPhone())
+                .deliveryAddressId(order.getDeliveryAddressId())
+                .deliveryMemo(order.getDeliveryMemo())
+                .expiresAt(order.getExpiresAt())
+                .createdAt(order.getCreatedAt())
+                .items(order.getOrderItems().stream()
+                        .map(OrderDetailResponse::toItemDto)
+                        .toList())
+                .build();
+    }
+
+    private static OrderItemDto toItemDto(OrderItem item) {
+        return OrderItemDto.builder()
+                .id(item.getId())
+                .channelType(item.getChannelType())
+                .channelRefId(item.getChannelRefId())
+                .itemId(item.getItemId())
+                .storeId(item.getStoreId())
+                .quantity(item.getQuantity())
+                .unitPrice(item.getUnitPrice())
+                .lineAmount(item.getLineAmount())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/dto/response/OrderListResponse.java
+++ b/servers/services/order/src/main/java/com/example/order/dto/response/OrderListResponse.java
@@ -1,0 +1,34 @@
+package com.example.order.dto.response;
+
+import com.example.core.id.jackson.SnowflakeId;
+import com.example.order.domain.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class OrderListResponse {
+
+    @SnowflakeId
+    private Long orderId;
+
+    private String status;
+
+    private Long totalAmount;
+
+    private LocalDateTime createdAt;
+
+    private int itemCount;
+
+    public static OrderListResponse from(Order order) {
+        return OrderListResponse.builder()
+                .orderId(order.getId())
+                .status(order.getStatus().name())
+                .totalAmount(order.getTotalAmount())
+                .createdAt(order.getCreatedAt())
+                .itemCount(order.getOrderItems().size())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/event/OrderCancelledEvent.java
+++ b/servers/services/order/src/main/java/com/example/order/event/OrderCancelledEvent.java
@@ -1,0 +1,32 @@
+package com.example.order.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OrderCancelledEvent extends DomainEvent {
+
+    private final Long orderId;
+    private final Long userId;
+
+    public OrderCancelledEvent(Long orderId, Long userId) {
+        super("order-events");
+        this.orderId = orderId;
+        this.userId = userId;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ORDER_CANCELLED_EVENT";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "orderId", orderId,
+                "userId", userId
+        );
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/event/OrderRefundRequestedEvent.java
+++ b/servers/services/order/src/main/java/com/example/order/event/OrderRefundRequestedEvent.java
@@ -1,0 +1,35 @@
+package com.example.order.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OrderRefundRequestedEvent extends DomainEvent {
+
+    private final Long orderId;
+    private final Long userId;
+    private final Long totalAmount;
+
+    public OrderRefundRequestedEvent(Long orderId, Long userId, Long totalAmount) {
+        super("order-events");
+        this.orderId = orderId;
+        this.userId = userId;
+        this.totalAmount = totalAmount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ORDER_REFUND_REQUESTED_EVENT";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "orderId", orderId,
+                "userId", userId,
+                "totalAmount", totalAmount
+        );
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/event/OrderRefundedEvent.java
+++ b/servers/services/order/src/main/java/com/example/order/event/OrderRefundedEvent.java
@@ -1,0 +1,32 @@
+package com.example.order.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OrderRefundedEvent extends DomainEvent {
+
+    private final Long orderId;
+    private final Long userId;
+
+    public OrderRefundedEvent(Long orderId, Long userId) {
+        super("order-events");
+        this.orderId = orderId;
+        this.userId = userId;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "ORDER_REFUNDED_EVENT";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        return Map.of(
+                "orderId", orderId,
+                "userId", userId
+        );
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
@@ -10,6 +10,7 @@ import com.example.order.domain.OrderStatus;
 import com.example.order.dto.request.InternalCreateOrderRequest;
 import com.example.order.dto.response.InternalCreateOrderResponse;
 import com.example.order.event.OrderCancelledEvent;
+import com.example.order.event.OrderRefundRequestedEvent;
 import com.example.order.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,6 +80,26 @@ public class OrderCommandService {
         );
 
         log.info("주문 취소 완료: orderId={}", orderId);
+    }
+
+    public void requestRefund(Long orderId, Long userId) {
+        Order order = getOrderByIdAndUserId(orderId, userId);
+
+        OrderStatus status = order.getStatus();
+        if (status != OrderStatus.PAID && status != OrderStatus.SHIPPING
+                && status != OrderStatus.DELIVERED && status != OrderStatus.COMPLETED) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_REFUNDABLE);
+        }
+
+        order.transitTo(OrderStatus.REFUND_REQUESTED);
+
+        eventPublisher.publish(
+                new OrderRefundRequestedEvent(orderId, userId, order.getTotalAmount()),
+                EventMetadata.of("Order", String.valueOf(orderId))
+        );
+
+        log.info("환불 요청 완료: orderId={}", orderId);
+        // TODO: 부분 환불 지원 시 refundAmount 필드 추가
     }
 
     private Order getOrderByIdAndUserId(Long orderId, Long userId) {

--- a/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
@@ -1,0 +1,61 @@
+package com.example.order.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderItem;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderCommandService {
+
+    private final OrderRepository orderRepository;
+
+    public InternalCreateOrderResponse createOrder(InternalCreateOrderRequest request) {
+        if (orderRepository.existsById(request.getOrderId())) {
+            throw new BusinessException(OrderErrorCode.ORDER_ALREADY_EXISTS);
+        }
+
+        Order order = Order.create(
+                request.getOrderId(),
+                request.getUserId(),
+                request.getTotalAmount(),
+                request.getRecipientName(),
+                request.getRecipientPhone(),
+                request.getDeliveryAddressId(),
+                request.getDeliveryMemo(),
+                request.getExpiresAt()
+        );
+
+        for (InternalCreateOrderRequest.LineItem lineItem : request.getLineItems()) {
+            OrderItem orderItem = OrderItem.create(
+                    lineItem.getChannelType(),
+                    lineItem.getChannelRefId(),
+                    lineItem.getItemId(),
+                    lineItem.getStoreId(),
+                    lineItem.getQuantity(),
+                    lineItem.getFinalUnitPrice(),
+                    lineItem.getLineAmount()
+            );
+            order.addItem(orderItem);
+        }
+
+        orderRepository.save(order);
+        log.info("주문 생성 완료: orderId={}", order.getId());
+
+        return InternalCreateOrderResponse.builder()
+                .orderId(order.getId())
+                .status(order.getStatus().name())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/command/OrderCommandService.java
@@ -1,11 +1,15 @@
 package com.example.order.service.command;
 
 import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
 import com.example.order.domain.Order;
 import com.example.order.domain.OrderItem;
 import com.example.order.domain.OrderRepository;
+import com.example.order.domain.OrderStatus;
 import com.example.order.dto.request.InternalCreateOrderRequest;
 import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.event.OrderCancelledEvent;
 import com.example.order.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderCommandService {
 
     private final OrderRepository orderRepository;
+    private final EventPublisher eventPublisher;
 
     public InternalCreateOrderResponse createOrder(InternalCreateOrderRequest request) {
         if (orderRepository.existsById(request.getOrderId())) {
@@ -57,5 +62,33 @@ public class OrderCommandService {
                 .status(order.getStatus().name())
                 .createdAt(order.getCreatedAt())
                 .build();
+    }
+
+    public void cancelOrder(Long orderId, Long userId) {
+        Order order = getOrderByIdAndUserId(orderId, userId);
+
+        if (order.getStatus() != OrderStatus.PAYMENT_PENDING) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
+        }
+
+        order.transitTo(OrderStatus.CANCELLED);
+
+        eventPublisher.publish(
+                new OrderCancelledEvent(orderId, userId),
+                EventMetadata.of("Order", String.valueOf(orderId))
+        );
+
+        log.info("주문 취소 완료: orderId={}", orderId);
+    }
+
+    private Order getOrderByIdAndUserId(Long orderId, Long userId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
+        }
+
+        return order;
     }
 }

--- a/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
@@ -1,0 +1,24 @@
+package com.example.order.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.dto.response.InternalOrderDetailResponse;
+import com.example.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryService {
+
+    private final OrderRepository orderRepository;
+
+    public InternalOrderDetailResponse getOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        return InternalOrderDetailResponse.from(order);
+    }
+}

--- a/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
+++ b/servers/services/order/src/main/java/com/example/order/service/query/OrderQueryService.java
@@ -4,8 +4,12 @@ import com.example.core.exception.BusinessException;
 import com.example.order.domain.Order;
 import com.example.order.domain.OrderRepository;
 import com.example.order.dto.response.InternalOrderDetailResponse;
+import com.example.order.dto.response.OrderDetailResponse;
+import com.example.order.dto.response.OrderListResponse;
 import com.example.order.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +19,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderQueryService {
 
     private final OrderRepository orderRepository;
+
+    public Page<OrderListResponse> getMyOrders(Long userId, Pageable pageable) {
+        return orderRepository.findByUserIdAndDeletedAtIsNull(userId, pageable)
+                .map(OrderListResponse::from);
+    }
+
+    public OrderDetailResponse getOrderDetail(Long orderId, Long userId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
+        }
+
+        return OrderDetailResponse.from(order);
+    }
 
     public InternalOrderDetailResponse getOrder(Long orderId) {
         Order order = orderRepository.findById(orderId)

--- a/servers/services/order/src/main/resources/application.yml
+++ b/servers/services/order/src/main/resources/application.yml
@@ -15,13 +15,18 @@ spring:
   # ─── JPA ──────────────────────────────────────
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:update}
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
     show-sql: true
     open-in-view: false
+
+  # ─── Flyway ─────────────────────────────────
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
   # ─── Redis ────────────────────────────────────
   data:

--- a/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V1__create_orders_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE orders (
+    id                  BIGINT PRIMARY KEY,
+    user_id             BIGINT NOT NULL,
+    status              VARCHAR(30) NOT NULL DEFAULT 'PAYMENT_PENDING',
+    total_amount        BIGINT NOT NULL,
+    recipient_name      VARCHAR(100),
+    recipient_phone     VARCHAR(20),
+    delivery_address_id BIGINT,
+    delivery_memo       VARCHAR(500),
+    expires_at          TIMESTAMP,
+    is_deleted          BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at          TIMESTAMP,
+    created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_status ON orders(status);

--- a/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
+++ b/servers/services/order/src/main/resources/db/migration/V2__create_order_items_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE order_items (
+    id              BIGINT PRIMARY KEY,
+    order_id        BIGINT NOT NULL REFERENCES orders(id),
+    channel_type    VARCHAR(20) NOT NULL,
+    channel_ref_id  BIGINT,
+    item_id         BIGINT NOT NULL,
+    store_id        BIGINT NOT NULL,
+    quantity        INTEGER NOT NULL,
+    unit_price      BIGINT NOT NULL,
+    line_amount     BIGINT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+CREATE INDEX idx_order_items_item_id ON order_items(item_id);

--- a/servers/services/order/src/test/java/com/example/order/consumer/payment/OrderPaymentEventProcessorTest.java
+++ b/servers/services/order/src/test/java/com/example/order/consumer/payment/OrderPaymentEventProcessorTest.java
@@ -1,0 +1,194 @@
+package com.example.order.consumer.payment;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.event.EventPublisher;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.domain.OrderStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderPaymentEventProcessorTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private IdempotentConsumerService idempotentConsumerService;
+
+    private OrderPaymentEventProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new OrderPaymentEventProcessor(orderRepository, eventPublisher, idempotentConsumerService);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_COMPLETED 이벤트 수신 시 Order 상태가 PAID로 전이된다")
+    void paymentCompleted_orderBecomesPaid() {
+        // given
+        Order order = Order.create(101L, 100L, 50000L, null, null, null, null, null);
+        when(orderRepository.findById(101L)).thenReturn(Optional.of(order));
+        when(idempotentConsumerService.executeIdempotent(eq("evt-1"), eq("PAYMENT_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        String message = """
+                {"eventId":"evt-1","eventType":"PAYMENT_COMPLETED","orderId":101,"userId":100}
+                """;
+
+        // when
+        processor.process(message, "evt-1", "PAYMENT_COMPLETED");
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_FAILED 이벤트 수신 시 Order 상태가 CANCELLED로 전이된다")
+    void paymentFailed_orderBecomesCancelled() {
+        // given
+        Order order = Order.create(102L, 100L, 50000L, null, null, null, null, null);
+        when(orderRepository.findById(102L)).thenReturn(Optional.of(order));
+        when(idempotentConsumerService.executeIdempotent(eq("evt-2"), eq("PAYMENT_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        String message = """
+                {"eventId":"evt-2","eventType":"PAYMENT_FAILED","orderId":102,"userId":100,"failReason":"잔액 부족"}
+                """;
+
+        // when
+        processor.process(message, "evt-2", "PAYMENT_FAILED");
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_TIMED_OUT 이벤트 수신 시 Order 상태가 CANCELLED로 전이된다")
+    void paymentTimedOut_orderBecomesCancelled() {
+        // given
+        Order order = Order.create(103L, 100L, 50000L, null, null, null, null, null);
+        when(orderRepository.findById(103L)).thenReturn(Optional.of(order));
+        when(idempotentConsumerService.executeIdempotent(eq("evt-3"), eq("PAYMENT_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        String message = """
+                {"eventId":"evt-3","eventType":"PAYMENT_TIMED_OUT","orderId":103,"userId":100}
+                """;
+
+        // when
+        processor.process(message, "evt-3", "PAYMENT_TIMED_OUT");
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("중복 이벤트 수신 시 멱등성 검증 - 두 번째는 스킵된다")
+    void duplicateEvent_isSkipped() {
+        // given
+        when(idempotentConsumerService.executeIdempotent(eq("evt-dup"), eq("PAYMENT_EVENT"), any()))
+                .thenReturn(Optional.empty()); // 이미 처리됨 → supplier 호출하지 않음
+
+        String message = """
+                {"eventId":"evt-dup","eventType":"PAYMENT_COMPLETED","orderId":104,"userId":100}
+                """;
+
+        // when
+        processor.process(message, "evt-dup", "PAYMENT_COMPLETED");
+
+        // then
+        verify(orderRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("orderId가 없는 이벤트는 스킵된다")
+    void missingOrderId_isSkipped() {
+        String message = """
+                {"eventId":"evt-no-order","eventType":"PAYMENT_COMPLETED","userId":100}
+                """;
+
+        processor.process(message, "evt-no-order", "PAYMENT_COMPLETED");
+
+        verifyNoInteractions(idempotentConsumerService);
+        verify(orderRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("주문을 찾을 수 없으면 로그 경고 후 스킵한다")
+    void orderNotFound_isSkipped() {
+        // given
+        when(orderRepository.findById(999L)).thenReturn(Optional.empty());
+        when(idempotentConsumerService.executeIdempotent(eq("evt-missing"), eq("PAYMENT_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        String message = """
+                {"eventId":"evt-missing","eventType":"PAYMENT_COMPLETED","orderId":999,"userId":100}
+                """;
+
+        // when - should not throw
+        processor.process(message, "evt-missing", "PAYMENT_COMPLETED");
+
+        // then
+        verify(orderRepository).findById(999L);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_REFUNDED 이벤트 수신 시 Order 상태가 REFUNDED로 전이되고 ORDER_REFUNDED_EVENT가 발행된다")
+    void paymentRefunded_orderBecomesRefunded() {
+        // given
+        Order order = Order.create(105L, 100L, 50000L, null, null, null, null, null);
+        order.transitTo(OrderStatus.PAID);
+        order.transitTo(OrderStatus.REFUND_REQUESTED);
+        when(orderRepository.findById(105L)).thenReturn(Optional.of(order));
+        when(idempotentConsumerService.executeIdempotent(eq("evt-refund"), eq("PAYMENT_EVENT"), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<?> supplier = invocation.getArgument(2);
+                    supplier.get();
+                    return Optional.empty();
+                });
+
+        String message = """
+                {"eventId":"evt-refund","eventType":"PAYMENT_REFUNDED","orderId":105,"userId":100}
+                """;
+
+        // when
+        processor.process(message, "evt-refund", "PAYMENT_REFUNDED");
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUNDED);
+        verify(eventPublisher).publish(any(), any());
+    }
+}

--- a/servers/services/order/src/test/java/com/example/order/controller/InternalOrderCommandControllerTest.java
+++ b/servers/services/order/src/test/java/com/example/order/controller/InternalOrderCommandControllerTest.java
@@ -1,0 +1,151 @@
+package com.example.order.controller;
+
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.domain.OrderStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@EmbeddedKafka(partitions = 1, topics = {"payment-events", "order-events"})
+class InternalOrderCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("정상 주문 생성 → 200, status: PAYMENT_PENDING")
+    void createOrder_success() throws Exception {
+        String requestBody = """
+                {
+                    "orderId": 12345,
+                    "userId": 100,
+                    "totalAmount": 50000,
+                    "recipientName": "홍길동",
+                    "recipientPhone": "010-1234-5678",
+                    "deliveryAddressId": 1,
+                    "deliveryMemo": "문 앞에 놓아주세요",
+                    "lineItems": [
+                        {
+                            "channelType": "NORMAL",
+                            "itemId": 1001,
+                            "storeId": 10,
+                            "quantity": 2,
+                            "finalUnitPrice": 25000,
+                            "lineAmount": 50000
+                        }
+                    ]
+                }
+                """;
+
+        mockMvc.perform(post("/internal/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("PAYMENT_PENDING"));
+
+        Order saved = orderRepository.findById(12345L).orElseThrow();
+        assertThat(saved.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        assertThat(saved.getOrderItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("중복 orderId로 주문 생성 → 409")
+    void createOrder_duplicate_returns409() throws Exception {
+        // given: 미리 주문 생성
+        Order existing = Order.create(12345L, 100L, 50000L, null, null, null, null, null);
+        orderRepository.save(existing);
+
+        String requestBody = """
+                {
+                    "orderId": 12345,
+                    "userId": 100,
+                    "totalAmount": 30000,
+                    "lineItems": [
+                        {
+                            "channelType": "NORMAL",
+                            "itemId": 1001,
+                            "storeId": 10,
+                            "quantity": 1,
+                            "finalUnitPrice": 30000,
+                            "lineAmount": 30000
+                        }
+                    ]
+                }
+                """;
+
+        mockMvc.perform(post("/internal/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락 → 400")
+    void createOrder_missingRequiredField_returns400() throws Exception {
+        String requestBody = """
+                {
+                    "orderId": 12345,
+                    "userId": 100,
+                    "lineItems": []
+                }
+                """;
+
+        mockMvc.perform(post("/internal/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내부 주문 조회 → 200")
+    void getOrder_success() throws Exception {
+        Order order = Order.create(99999L, 100L, 50000L, "홍길동", "010-1234-5678", 1L, "메모", null);
+        orderRepository.save(order);
+
+        mockMvc.perform(get("/internal/v1/orders/99999"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("PAYMENT_PENDING"))
+                .andExpect(jsonPath("$.data.userId").value(100));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주문 조회 → 404")
+    void getOrder_notFound() throws Exception {
+        mockMvc.perform(get("/internal/v1/orders/99999"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/servers/services/order/src/test/java/com/example/order/domain/OrderStatusTest.java
+++ b/servers/services/order/src/test/java/com/example/order/domain/OrderStatusTest.java
@@ -1,0 +1,54 @@
+package com.example.order.domain;
+
+import com.example.core.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderStatusTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "PAYMENT_PENDING, PAID",
+            "PAYMENT_PENDING, CANCELLED",
+            "PAID, SHIPPING",
+            "PAID, REFUND_REQUESTED",
+            "SHIPPING, DELIVERED",
+            "DELIVERED, COMPLETED",
+            "COMPLETED, REFUND_REQUESTED",
+            "REFUND_REQUESTED, REFUNDED"
+    })
+    @DisplayName("유효한 상태 전이는 성공한다")
+    void validTransition_succeeds(OrderStatus from, OrderStatus to) {
+        assertThat(from.canTransitionTo(to)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "CANCELLED, PAID",
+            "CANCELLED, PAYMENT_PENDING",
+            "REFUNDED, PAID",
+            "PAYMENT_PENDING, SHIPPING",
+            "PAID, CANCELLED",
+            "SHIPPING, PAID",
+            "DELIVERED, SHIPPING",
+            "COMPLETED, PAID"
+    })
+    @DisplayName("유효하지 않은 상태 전이는 예외를 던진다")
+    void invalidTransition_throwsException(OrderStatus from, OrderStatus to) {
+        assertThat(from.canTransitionTo(to)).isFalse();
+        assertThatThrownBy(() -> from.validateTransitionTo(to))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_PENDING에서 PAID로 전이 가능하다")
+    void paymentPendingToPaid() {
+        OrderStatus status = OrderStatus.PAYMENT_PENDING;
+        assertThat(status.canTransitionTo(OrderStatus.PAID)).isTrue();
+    }
+}

--- a/servers/services/order/src/test/java/com/example/order/service/command/OrderCommandServiceTest.java
+++ b/servers/services/order/src/test/java/com/example/order/service/command/OrderCommandServiceTest.java
@@ -1,0 +1,166 @@
+package com.example.order.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventPublisher;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import com.example.order.domain.OrderStatus;
+import com.example.order.dto.request.InternalCreateOrderRequest;
+import com.example.order.dto.response.InternalCreateOrderResponse;
+import com.example.order.exception.OrderErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCommandServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    private OrderCommandService orderCommandService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        orderCommandService = new OrderCommandService(orderRepository, eventPublisher);
+    }
+
+    @Test
+    @DisplayName("정상적인 주문 생성 요청 시 PAYMENT_PENDING 상태로 생성된다")
+    void createOrder_success() throws Exception {
+        // given
+        String json = """
+                {
+                    "orderId": 12345,
+                    "userId": 100,
+                    "totalAmount": 50000,
+                    "recipientName": "홍길동",
+                    "recipientPhone": "010-1234-5678",
+                    "deliveryAddressId": 1,
+                    "deliveryMemo": "문 앞에 놓아주세요",
+                    "lineItems": [
+                        {
+                            "channelType": "NORMAL",
+                            "itemId": 1001,
+                            "storeId": 10,
+                            "quantity": 2,
+                            "finalUnitPrice": 25000,
+                            "lineAmount": 50000
+                        }
+                    ]
+                }
+                """;
+        InternalCreateOrderRequest request = objectMapper.readValue(json, InternalCreateOrderRequest.class);
+        when(orderRepository.existsById(12345L)).thenReturn(false);
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        InternalCreateOrderResponse response = orderCommandService.createOrder(request);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(12345L);
+        assertThat(response.getStatus()).isEqualTo("PAYMENT_PENDING");
+
+        ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(captor.capture());
+        Order savedOrder = captor.getValue();
+        assertThat(savedOrder.getId()).isEqualTo(12345L);
+        assertThat(savedOrder.getUserId()).isEqualTo(100L);
+        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        assertThat(savedOrder.getOrderItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("중복 orderId로 주문 생성 시 409 에러가 발생한다")
+    void createOrder_duplicateOrderId_throws409() throws Exception {
+        // given
+        String json = """
+                {
+                    "orderId": 12345,
+                    "userId": 100,
+                    "totalAmount": 50000,
+                    "lineItems": [
+                        {
+                            "channelType": "NORMAL",
+                            "itemId": 1001,
+                            "storeId": 10,
+                            "quantity": 1,
+                            "finalUnitPrice": 50000,
+                            "lineAmount": 50000
+                        }
+                    ]
+                }
+                """;
+        InternalCreateOrderRequest request = objectMapper.readValue(json, InternalCreateOrderRequest.class);
+        when(orderRepository.existsById(12345L)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.createOrder(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_ALREADY_EXISTS));
+
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("PAYMENT_PENDING 상태에서 주문 취소가 성공한다")
+    void cancelOrder_success() {
+        // given
+        Order order = Order.create(12345L, 100L, 50000L, null, null, null, null, null);
+        when(orderRepository.findById(12345L)).thenReturn(Optional.of(order));
+
+        // when
+        orderCommandService.cancelOrder(12345L, 100L);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        verify(eventPublisher).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("PAID 상태에서 주문 취소 시 예외가 발생한다")
+    void cancelOrder_notCancellable_throwsException() {
+        // given
+        Order order = Order.create(12345L, 100L, 50000L, null, null, null, null, null);
+        order.transitTo(OrderStatus.PAID);
+        when(orderRepository.findById(12345L)).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.cancelOrder(12345L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_CANCELLABLE));
+    }
+
+    @Test
+    @DisplayName("타인의 주문 취소 시 ORDER_NOT_FOUND 예외가 발생한다")
+    void cancelOrder_otherUser_throwsNotFound() {
+        // given
+        Order order = Order.create(12345L, 100L, 50000L, null, null, null, null, null);
+        when(orderRepository.findById(12345L)).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.cancelOrder(12345L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+}

--- a/servers/services/order/src/test/resources/application-test.yml
+++ b/servers/services/order/src/test/resources/application-test.yml
@@ -1,0 +1,42 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:order_test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+
+  flyway:
+    enabled: false
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: order-service-test-group
+      auto-offset-reset: earliest
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+app:
+  snowflake:
+    datacenter-id: 1
+    worker-id: 1
+
+  gateway-security:
+    enabled: false
+    internal-auth-header: X-Gateway-Auth
+    internal-auth-token: test-token
+    user-id-header: X-User-Id
+
+  openapi:
+    enabled: false


### PR DESCRIPTION
 ## 개요

  ### 관련 이슈
  - Closes #812
  - Related: #807 (Epic)

  ### 작업 / 변경 내용

  **단위 테스트**
  - `OrderStatusTest`: 유효/무효 상태 전이 파라미터 테스트 (8개 유효, 8개 무효 케이스)
  - `OrderCommandServiceTest`: createOrder 정상/중복(409), cancelOrder 정상/불가/타인 주문 검증

  **통합 테스트**
  - `InternalOrderCommandControllerTest` (H2 인메모리 + EmbeddedKafka)
    - 정상 생성 → 200, status: PAYMENT_PENDING
    - 중복 생성 → 409
    - 필수 필드 누락 → 400
    - 내부 주문 조회 → 200 / 404

  **이벤트 Consumer 테스트**
  - `OrderPaymentEventProcessorTest`
    - PAYMENT_COMPLETED → Order PAID 전이
    - PAYMENT_FAILED → Order CANCELLED 전이
    - PAYMENT_TIMED_OUT → Order CANCELLED 전이
    - PAYMENT_REFUNDED → Order REFUNDED + ORDER_REFUNDED_EVENT 발행
    - 중복 이벤트 → 멱등성 검증 (두 번째 스킵)
    - orderId 누락 → 스킵
    - 주문 미존재 → 로그 경고 후 스킵

  **테스트 인프라**
  - `application-test.yml`: H2 인메모리 DB, Flyway 비활성화, EmbeddedKafka
  - `build.gradle.kts`: spring-boot-starter-test, spring-kafka-test 의존성 추가

  ### 참고사항
  - 통합 테스트는 `@EmbeddedKafka`로 실제 Kafka 없이 실행 가능
  - 환불 요청(`requestRefund`) 테스트는 Consumer 테스트에서 PAYMENT_REFUNDED 핸들러로 간접 검증