### PR TITLE
feat: add edge nginx eks demo deployment

### DIFF
--- a/deploy/catalog/runtime-services.yaml
+++ b/deploy/catalog/runtime-services.yaml
@@ -34,6 +34,29 @@ spec:
         - redis
         - keycloak
 
+    - key: edge-nginx
+      runtime:
+        type: nginx
+        applicationName: edge-nginx
+      build:
+        type: external-image
+        sourceImage: nginxinc/nginx-unprivileged:1.27-alpine
+      image:
+        ecrRepository: donmoa-dev-edge-nginx
+        foundationRepositorySuffix: edge-nginx
+      deployment:
+        namespace: donmoa-dev
+        releaseName: edge-nginx
+        serviceName: edge-nginx
+        containerPort: 8080
+        public: true
+        ingressHost: edge.dev.<domain>
+        rolloutWave: 4
+      datastore:
+        type: none
+        readWriteSplit: false
+      externalDependencies: []
+
     - key: keycloak
       runtime:
         type: keycloak

--- a/deploy/helm/environments/dev/README.md
+++ b/deploy/helm/environments/dev/README.md
@@ -5,6 +5,7 @@ Place one values file per runtime service in this directory.
 Suggested naming:
 
 - `client-gateway.yaml`
+- `edge-nginx.yaml`
 - `keycloak.yaml`
 - `auth.yaml`
 - `profile.yaml`
@@ -29,3 +30,15 @@ Each values file should map to one entry in `deploy/catalog/runtime-services.yam
 These files are intended for local/private environment management. If GitHub-based deploy
 automation is enabled later, keep runtime secrets in AWS Secrets Manager and only commit
 public-safe examples or sanitized values files.
+
+`edge-nginx.yaml` is reserved for the EKS connection-management demo edge that fronts
+`client-gateway` behind a dedicated ALB host.
+
+To generate a focused deploy plan for the demo, run:
+
+```bash
+DEPLOY_TARGETS=client-gateway,edge-nginx \
+AWS_DEFAULT_REGION=ap-northeast-2 \
+ACCOUNT_ID=<aws-account-id> \
+ruby scripts/ci/export-eks-deploy-plan.rb
+```

--- a/deploy/helm/environments/dev/edge-nginx.yaml
+++ b/deploy/helm/environments/dev/edge-nginx.yaml
@@ -1,0 +1,129 @@
+fullnameOverride: edge-nginx
+
+replicaCount: 2
+
+image:
+  repository: nginxinc/nginx-unprivileged
+  tag: 1.27-alpine
+
+externalSecret:
+  enabled: false
+
+service:
+  port: 8080
+
+container:
+  port: 8080
+  extraVolumeMounts:
+    - name: file-cm-nginx-conf
+      mountPath: /etc/nginx/conf.d/default.conf
+      subPath: default.conf
+
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/group.name: donmoa-dev-edge-nginx
+    alb.ingress.kubernetes.io/healthcheck-path: /nginx-health
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/success-codes: 200-399
+    alb.ingress.kubernetes.io/target-type: ip
+  hosts:
+    - host: "edge.dev.<domain>"
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+probes:
+  liveness:
+    enabled: true
+    path: /nginx-health
+    port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /nginx-health
+    port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podSecurityContext:
+  fsGroup: 101
+
+securityContext:
+  runAsUser: 101
+  runAsGroup: 101
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
+fileConfigMaps:
+  - name: nginx-conf
+    files:
+      default.conf:
+        content: |
+          log_format edge_demo '$remote_addr - $remote_user [$time_local] "$request" '
+                               '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
+                               'conn=$connection conn_reqs=$connection_requests '
+                               'rt=$request_time uct=$upstream_connect_time '
+                               'uht=$upstream_header_time urt=$upstream_response_time '
+                               'ua="$upstream_addr" us="$upstream_status"';
+
+          upstream gateway_backend {
+              server client-gateway:8080;
+              keepalive 128;
+          }
+
+          server {
+              listen 8080;
+              server_name _;
+              access_log /var/log/nginx/access.log edge_demo;
+
+              location = /nginx-health {
+                  access_log off;
+                  add_header Content-Type text/plain;
+                  return 200 'ok';
+              }
+
+              location = /nginx_status {
+                  access_log off;
+                  stub_status;
+                  allow 127.0.0.1;
+                  allow 10.0.0.0/8;
+                  deny all;
+              }
+
+              location / {
+                  proxy_http_version 1.1;
+                  proxy_set_header Connection "";
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_set_header X-Request-Id $request_id;
+                  proxy_connect_timeout 3s;
+                  proxy_send_timeout 30s;
+                  proxy_read_timeout 30s;
+                  proxy_next_upstream error timeout http_502 http_503 http_504;
+                  proxy_pass http://gateway_backend;
+              }
+          }

--- a/deploy/helm/environments/dev/edge-nginx.yaml
+++ b/deploy/helm/environments/dev/edge-nginx.yaml
@@ -98,6 +98,19 @@ fileConfigMaps:
               listen 8080;
               server_name _;
               access_log /var/log/nginx/access.log edge_demo;
+              gzip on;
+              gzip_vary on;
+              gzip_proxied any;
+              gzip_comp_level 5;
+              gzip_min_length 1024;
+              gzip_types
+                  text/plain
+                  text/css
+                  text/xml
+                  application/json
+                  application/javascript
+                  application/xml
+                  image/svg+xml;
 
               location = /nginx-health {
                   access_log off;


### PR DESCRIPTION
## Summary
- add an `edge-nginx` runtime service to the EKS runtime catalog
- add dev Helm values for a dedicated ALB-backed nginx demo edge in front of `client-gateway`
- document focused deploy plan generation for the connection-management demo

## Validation
- `helm template edge-nginx deploy/helm/charts/spring-service --values deploy/helm/environments/dev/edge-nginx.yaml --set image.repository=nginxinc/nginx-unprivileged --set image.tag=1.27-alpine`
- `DEPLOY_TARGETS=client-gateway,edge-nginx AWS_DEFAULT_REGION=ap-northeast-2 ACCOUNT_ID=000000000000 ruby scripts/ci/export-eks-deploy-plan.rb --output .context/edge-nginx-focused-plan.json`

## Notes
- full `bash scripts/ci/validate-eks-runtime-inputs.sh` still fails on the repository's pre-existing search-config validation error and was not introduced by this change
