### PR TITLE
[Story] #902 Payment 도메인 모델 및 상태 머신 구현

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/domain/Payment.java
+++ b/servers/services/payment/src/main/java/com/example/payment/domain/Payment.java
@@ -1,0 +1,116 @@
+package com.example.payment.domain;
+
+import com.example.data.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments",
+        indexes = {
+                @Index(name = "idx_payments_user_id", columnList = "user_id"),
+                @Index(name = "idx_payments_status", columnList = "status"),
+                @Index(name = "idx_payments_payment_key", columnList = "payment_key"),
+                @Index(name = "idx_payments_status_expires_at", columnList = "status, expires_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "idx_payments_order_id", columnNames = "order_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class Payment extends BaseEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private PaymentStatus status;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Column(name = "payment_key", length = 200)
+    private String paymentKey;
+
+    @Column(name = "toss_order_id", length = 200)
+    private String tossOrderId;
+
+    @Column(name = "method", length = 50)
+    private String method;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
+    @Column(name = "fail_reason", length = 500)
+    private String failReason;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Column(name = "toss_response", columnDefinition = "TEXT")
+    private String tossResponse;
+
+    public static Payment create(Long id, Long orderId, Long userId, Long amount, LocalDateTime expiresAt) {
+        Payment payment = new Payment();
+        payment.id = id;
+        payment.orderId = orderId;
+        payment.userId = userId;
+        payment.status = PaymentStatus.READY;
+        payment.amount = amount;
+        payment.expiresAt = expiresAt;
+        return payment;
+    }
+
+    public void markDone(String paymentKey, String tossOrderId, String method,
+                         LocalDateTime paidAt, String tossResponse) {
+        this.status.validateTransitionTo(PaymentStatus.DONE);
+        this.status = PaymentStatus.DONE;
+        this.paymentKey = paymentKey;
+        this.tossOrderId = tossOrderId;
+        this.method = method;
+        this.paidAt = paidAt;
+        this.tossResponse = tossResponse;
+    }
+
+    public void markFailed(String paymentKey, String failReason, String tossResponse) {
+        this.status.validateTransitionTo(PaymentStatus.FAILED);
+        this.status = PaymentStatus.FAILED;
+        this.paymentKey = paymentKey;
+        this.failReason = failReason;
+        this.failedAt = LocalDateTime.now();
+        this.tossResponse = tossResponse;
+    }
+
+    public void markExpired() {
+        this.status.validateTransitionTo(PaymentStatus.EXPIRED);
+        this.status = PaymentStatus.EXPIRED;
+    }
+
+    public void markCancelled(String cancelReason) {
+        this.status.validateTransitionTo(PaymentStatus.CANCELLED);
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelReason = cancelReason;
+        this.cancelledAt = LocalDateTime.now();
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/domain/PaymentRepository.java
+++ b/servers/services/payment/src/main/java/com/example/payment/domain/PaymentRepository.java
@@ -1,0 +1,16 @@
+package com.example.payment.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByOrderId(Long orderId);
+
+    boolean existsByOrderId(Long orderId);
+
+    List<Payment> findByStatusAndExpiresAtBefore(PaymentStatus status, LocalDateTime dateTime);
+}

--- a/servers/services/payment/src/main/java/com/example/payment/domain/PaymentStatus.java
+++ b/servers/services/payment/src/main/java/com/example/payment/domain/PaymentStatus.java
@@ -1,0 +1,34 @@
+package com.example.payment.domain;
+
+import com.example.core.exception.BusinessException;
+import com.example.payment.exception.PaymentErrorCode;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum PaymentStatus {
+
+    READY,
+    DONE,
+    FAILED,
+    EXPIRED,
+    CANCELLED;
+
+    private static final Map<PaymentStatus, Set<PaymentStatus>> TRANSITIONS = Map.of(
+            READY, Set.of(DONE, FAILED, EXPIRED),
+            DONE, Set.of(CANCELLED),
+            FAILED, Set.of(),
+            EXPIRED, Set.of(),
+            CANCELLED, Set.of()
+    );
+
+    public void validateTransitionTo(PaymentStatus target) {
+        if (!canTransitionTo(target)) {
+            throw new BusinessException(PaymentErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
+
+    public boolean canTransitionTo(PaymentStatus target) {
+        return TRANSITIONS.getOrDefault(this, Set.of()).contains(target);
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/exception/PaymentErrorCode.java
+++ b/servers/services/payment/src/main/java/com/example/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,25 @@
+package com.example.payment.exception;
+
+import com.example.core.exception.DomainErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements DomainErrorCode {
+
+    PAYMENT_NOT_FOUND("PAYMENT-001", "결제 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    INVALID_STATUS_TRANSITION("PAYMENT-002", "유효하지 않은 결제 상태 전이입니다", HttpStatus.BAD_REQUEST),
+    AMOUNT_MISMATCH("PAYMENT-003", "결제 금액이 일치하지 않습니다", HttpStatus.BAD_REQUEST),
+    PAYMENT_EXPIRED("PAYMENT-004", "결제 유효기간이 만료되었습니다", HttpStatus.BAD_REQUEST),
+    PAYMENT_NOT_READY("PAYMENT-005", "결제 대기 상태가 아닙니다", HttpStatus.BAD_REQUEST),
+    PAYMENT_ALREADY_EXISTS("PAYMENT-006", "해당 주문에 대한 결제가 이미 존재합니다", HttpStatus.CONFLICT),
+    TOSS_CONFIRM_FAILED("PAYMENT-007", "토스페이먼츠 결제 승인에 실패했습니다", HttpStatus.BAD_GATEWAY),
+    TOSS_CANCEL_FAILED("PAYMENT-008", "토스페이먼츠 결제 취소에 실패했습니다", HttpStatus.BAD_GATEWAY),
+    UNAUTHORIZED_PAYMENT_ACCESS("PAYMENT-009", "해당 결제에 대한 접근 권한이 없습니다", HttpStatus.FORBIDDEN);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/servers/services/payment/src/main/java/com/example/payment/exception/TossPaymentsApiException.java
+++ b/servers/services/payment/src/main/java/com/example/payment/exception/TossPaymentsApiException.java
@@ -1,0 +1,22 @@
+package com.example.payment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TossPaymentsApiException extends RuntimeException {
+
+    private final int statusCode;
+    private final String responseBody;
+
+    public TossPaymentsApiException(int statusCode, String responseBody) {
+        super("TossPayments API error: status=" + statusCode + ", body=" + responseBody);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    public TossPaymentsApiException(int statusCode, String responseBody, Throwable cause) {
+        super("TossPayments API error: status=" + statusCode + ", body=" + responseBody, cause);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #902
- Epic: #807
- 의존: #901

## 작업 내용
결제의 핵심 도메인 모델을 구현합니다. 상태 전이를 엔티티 메서드로 캡슐화하여 비즈니스 규칙을 도메인에 집중시킵니다.

### 변경 사항
- `PaymentStatus.java` — enum + 상태 전이 Map
  ```
  READY  → {DONE, FAILED, EXPIRED}
  DONE   → {CANCELLED}
  FAILED, EXPIRED, CANCELLED → {} (종료 상태)
  ```
- `Payment.java` — JPA Entity, BaseEntity 상속
  - `create()`, `markDone()`, `markFailed()`, `markExpired()`, `markCancelled()`
  - `@SQLRestriction("deleted_at IS NULL")` 소프트 삭제
  - `toss_response TEXT`로 PG 응답 전체 저장 (감사 로그)
- `PaymentRepository.java` — findByOrderId, existsByOrderId, findByStatusAndExpiresAtBefore
- `PaymentErrorCode.java` — 9개 에러코드 (DomainErrorCode 구현)
- `TossPaymentsApiException.java` — statusCode + responseBody

### 상태 머신
```
READY ──→ DONE ──→ CANCELLED
  │
  ├──→ FAILED
  └──→ EXPIRED
```

## 테스트
- [x] 컴파일 성공
- [ ] PaymentStatus 상태 전이 단위 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)