### PR TITLE
[Story] #903 TossPayments PG 클라이언트 구현

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsClient.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsClient.java
@@ -1,0 +1,16 @@
+package com.example.payment.client;
+
+import com.example.payment.client.dto.TossCancelRequest;
+import com.example.payment.client.dto.TossCancelResponse;
+import com.example.payment.client.dto.TossConfirmRequest;
+import com.example.payment.client.dto.TossConfirmResponse;
+import com.example.payment.client.dto.TossPaymentResponse;
+
+public interface TossPaymentsClient {
+
+    TossConfirmResponse confirm(TossConfirmRequest request);
+
+    TossCancelResponse cancel(String paymentKey, TossCancelRequest request);
+
+    TossPaymentResponse query(String paymentKey);
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsClientConfig.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsClientConfig.java
@@ -1,0 +1,19 @@
+package com.example.payment.client;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@EnableConfigurationProperties(TossPaymentsProperties.class)
+public class TossPaymentsClientConfig {
+
+    @Bean
+    public TossPaymentsClient tossPaymentsClient(
+            TossPaymentsProperties properties,
+            WebClient.Builder webClientBuilder
+    ) {
+        return new TossPaymentsWebClient(properties, webClientBuilder);
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsProperties.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsProperties.java
@@ -1,0 +1,15 @@
+package com.example.payment.client;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.tosspayments")
+public class TossPaymentsProperties {
+
+    private String secretKey;
+    private String baseUrl = "https://api.tosspayments.com";
+    private int confirmTimeoutSeconds = 30;
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsWebClient.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsWebClient.java
@@ -1,0 +1,81 @@
+package com.example.payment.client;
+
+import com.example.payment.client.dto.TossCancelRequest;
+import com.example.payment.client.dto.TossCancelResponse;
+import com.example.payment.client.dto.TossConfirmRequest;
+import com.example.payment.client.dto.TossConfirmResponse;
+import com.example.payment.client.dto.TossPaymentResponse;
+import com.example.payment.exception.TossPaymentsApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.util.Base64;
+
+@Slf4j
+public class TossPaymentsWebClient implements TossPaymentsClient {
+
+    private final WebClient webClient;
+    private final Duration confirmTimeout;
+
+    public TossPaymentsWebClient(TossPaymentsProperties properties, WebClient.Builder webClientBuilder) {
+        String encodedKey = Base64.getEncoder().encodeToString(
+                (properties.getSecretKey() + ":").getBytes()
+        );
+
+        this.webClient = webClientBuilder
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        this.confirmTimeout = Duration.ofSeconds(properties.getConfirmTimeoutSeconds());
+    }
+
+    @Override
+    public TossConfirmResponse confirm(TossConfirmRequest request) {
+        try {
+            return webClient.post()
+                    .uri("/v1/payments/confirm")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(TossConfirmResponse.class)
+                    .block(confirmTimeout);
+        } catch (WebClientResponseException e) {
+            log.error("토스페이먼츠 결제 승인 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+        }
+    }
+
+    @Override
+    public TossCancelResponse cancel(String paymentKey, TossCancelRequest request) {
+        try {
+            return webClient.post()
+                    .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(TossCancelResponse.class)
+                    .block(confirmTimeout);
+        } catch (WebClientResponseException e) {
+            log.error("토스페이먼츠 결제 취소 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+        }
+    }
+
+    @Override
+    public TossPaymentResponse query(String paymentKey) {
+        try {
+            return webClient.get()
+                    .uri("/v1/payments/{paymentKey}", paymentKey)
+                    .retrieve()
+                    .bodyToMono(TossPaymentResponse.class)
+                    .block(confirmTimeout);
+        } catch (WebClientResponseException e) {
+            log.error("토스페이먼츠 결제 조회 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+        }
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/dto/TossCancelRequest.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/dto/TossCancelRequest.java
@@ -1,0 +1,7 @@
+package com.example.payment.client.dto;
+
+public record TossCancelRequest(
+        String cancelReason,
+        Long cancelAmount
+) {
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/dto/TossCancelResponse.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/dto/TossCancelResponse.java
@@ -1,0 +1,12 @@
+package com.example.payment.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossCancelResponse(
+        String paymentKey,
+        String orderId,
+        String status,
+        Long totalAmount
+) {
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/dto/TossConfirmRequest.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/dto/TossConfirmRequest.java
@@ -1,0 +1,8 @@
+package com.example.payment.client.dto;
+
+public record TossConfirmRequest(
+        String paymentKey,
+        String orderId,
+        Long amount
+) {
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/dto/TossConfirmResponse.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/dto/TossConfirmResponse.java
@@ -1,0 +1,15 @@
+package com.example.payment.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossConfirmResponse(
+        String paymentKey,
+        String orderId,
+        String status,
+        Long totalAmount,
+        String method,
+        String approvedAt,
+        String requestedAt
+) {
+}

--- a/servers/services/payment/src/main/java/com/example/payment/client/dto/TossPaymentResponse.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/dto/TossPaymentResponse.java
@@ -1,0 +1,15 @@
+package com.example.payment.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossPaymentResponse(
+        String paymentKey,
+        String orderId,
+        String status,
+        Long totalAmount,
+        String method,
+        String approvedAt,
+        String requestedAt
+) {
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #903
- Epic: #807
- 의존: #901

## 작업 내용
토스페이먼츠 REST API를 호출하는 WebClient 기반 클라이언트를 구현합니다.
인터페이스/구현체 분리로 테스트 시 Mock 교체가 가능합니다.

### 변경 사항
- `TossPaymentsProperties.java` — `@ConfigurationProperties(prefix = "app.tosspayments")`
- `TossPaymentsClient.java` — interface (confirm, cancel, query)
- `TossPaymentsWebClient.java` — 구현체
  - Basic Auth: `Base64(secretKey + ":")`
  - `POST /v1/payments/confirm`
  - `POST /v1/payments/{paymentKey}/cancel`
  - `GET /v1/payments/{paymentKey}`
  - `WebClientResponseException` → `TossPaymentsApiException` 변환
- `TossPaymentsClientConfig.java` — Bean 등록
- DTO records 5개 (`@JsonIgnoreProperties(ignoreUnknown = true)`)

### 아키텍처
```
PaymentCommandService ──→ TossPaymentsClient (interface)
                                  │
                          TossPaymentsWebClient (impl)
                                  │
                          WebClient + Basic Auth
                                  │
                          https://api.tosspayments.com
```

## 테스트
- [x] 컴파일 성공
- [ ] 토스 테스트 키로 confirm API 호출 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)