### PR TITLE
[Story] #904 ORDER_CREATED 이벤트 소비 → Payment(READY) 자동 생성

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/consumer/order/OrderEventConsumer.java
+++ b/servers/services/payment/src/main/java/com/example/payment/consumer/order/OrderEventConsumer.java
@@ -1,0 +1,33 @@
+package com.example.payment.consumer.order;
+
+import com.example.event.consumer.ConsumerRoutingMode;
+import com.example.event.consumer.RoutedEventConsumer;
+import com.example.event.inbox.AbstractProcessorRoutingConsumer;
+import com.example.event.inbox.InboxRoutingSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RoutedEventConsumer(
+        consumerName = PaymentOrderEventProcessor.CONSUMER_NAME,
+        defaultMode = ConsumerRoutingMode.INBOX
+)
+public class OrderEventConsumer extends AbstractProcessorRoutingConsumer {
+
+    public OrderEventConsumer(
+            InboxRoutingSupport inboxRoutingSupport,
+            PaymentOrderEventProcessor paymentOrderEventProcessor
+    ) {
+        super(inboxRoutingSupport, paymentOrderEventProcessor);
+    }
+
+    @KafkaListener(topics = "order-events", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(ConsumerRecord<String, Object> record) {
+        consumeRecord(record);
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/consumer/order/OrderEventMessage.java
+++ b/servers/services/payment/src/main/java/com/example/payment/consumer/order/OrderEventMessage.java
@@ -1,0 +1,19 @@
+package com.example.payment.consumer.order;
+
+import com.example.event.consumer.EventEnvelope;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class OrderEventMessage implements EventEnvelope {
+
+    private String eventId;
+    private String eventType;
+    private Long orderId;
+    private Long userId;
+    private Long totalAmount;
+    private LocalDateTime expiresAt;
+}

--- a/servers/services/payment/src/main/java/com/example/payment/consumer/order/PaymentOrderEventProcessor.java
+++ b/servers/services/payment/src/main/java/com/example/payment/consumer/order/PaymentOrderEventProcessor.java
@@ -1,0 +1,90 @@
+package com.example.payment.consumer.order;
+
+import com.example.config.kafka.IdempotentConsumerService;
+import com.example.core.id.Snowflake;
+import com.example.event.consumer.AbstractIdempotentEventSpecProcessor;
+import com.example.event.consumer.EventEnvelope;
+import com.example.event.consumer.EventSpec;
+import com.example.event.inbox.InboxConsumerBinding;
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@InboxConsumerBinding(consumerName = PaymentOrderEventProcessor.CONSUMER_NAME)
+public class PaymentOrderEventProcessor extends AbstractIdempotentEventSpecProcessor {
+
+    public static final String CONSUMER_NAME = "payment-order-events-consumer";
+    private static final String IDEMPOTENT_EVENT_TYPE = "ORDER_EVENT";
+
+    private final PaymentRepository paymentRepository;
+    private final Snowflake snowflake;
+    private final Map<String, EventSpec<OrderEventMessage>> eventSpecs;
+
+    public PaymentOrderEventProcessor(
+            PaymentRepository paymentRepository,
+            Snowflake snowflake,
+            IdempotentConsumerService idempotentConsumerService
+    ) {
+        super(idempotentConsumerService);
+        this.paymentRepository = paymentRepository;
+        this.snowflake = snowflake;
+        this.eventSpecs = Map.of(
+                "ORDER_CREATED_EVENT", EventSpec.of(OrderEventMessage.class, this::hasOrderId, this::handleOrderCreated)
+        );
+    }
+
+    @Override
+    protected String idempotentEventType() {
+        return IDEMPOTENT_EVENT_TYPE;
+    }
+
+    @Override
+    protected <T extends EventEnvelope> void onInvalidPayload(T event, String message, String eventId, String eventType) {
+        log.error("[PaymentOrderConsumer] orderId가 null입니다. message={}", message);
+    }
+
+    @Override
+    protected void onInvalidEnvelope(String eventId, String eventType, String message) {
+        log.error("[PaymentOrderConsumer] eventId 또는 eventType이 null입니다. message={}", message);
+    }
+
+    @Override
+    protected <T extends EventEnvelope> void onProcessingException(
+            T event, String message, String eventId, String eventType, Exception exception
+    ) {
+        log.error("[PaymentOrderConsumer] 이벤트 처리 실패: {}", message, exception);
+        throw propagate(exception);
+    }
+
+    @Override
+    protected Map<String, EventSpec<OrderEventMessage>> eventSpecs() {
+        return eventSpecs;
+    }
+
+    private boolean hasOrderId(OrderEventMessage event) {
+        return event.getOrderId() != null;
+    }
+
+    private void handleOrderCreated(OrderEventMessage event) {
+        if (paymentRepository.existsByOrderId(event.getOrderId())) {
+            log.warn("이미 결제가 존재합니다. 스킵합니다: orderId={}", event.getOrderId());
+            return;
+        }
+
+        Payment payment = Payment.create(
+                snowflake.nextId(),
+                event.getOrderId(),
+                event.getUserId(),
+                event.getTotalAmount(),
+                event.getExpiresAt()
+        );
+
+        paymentRepository.save(payment);
+        log.info("결제 READY 생성: paymentId={}, orderId={}", payment.getId(), event.getOrderId());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #904
- Epic: #807
- 의존: #902

## 작업 내용
Order 서비스가 발행한 ORDER_CREATED 이벤트를 소비하여 Payment(READY) 레코드를 자동 생성합니다.
Inbox 모드 + 멱등성 보장으로 중복/재처리에 안전합니다.

### 변경 사항
- `OrderEventMessage.java` — EventEnvelope 구현 (orderId, userId, totalAmount, expiresAt)
- `OrderEventConsumer.java` — `@KafkaListener(topics = "order-events")`, INBOX 모드
- `PaymentOrderEventProcessor.java` — ORDER_CREATED_EVENT 핸들링
  - `existsByOrderId` 중복 체크
  - `Payment.create(snowflake.nextId(), ...)` → READY 상태

### 이벤트 흐름
```
[Order Service] → order-events 토픽
  → ORDER_CREATED_EVENT {orderId, userId, totalAmount, expiresAt}
  → [Payment] OrderEventConsumer → INBOX 큐
  → PaymentOrderEventProcessor → Payment(READY) 생성
```

> **Note**: ORDER_REFUND_REQUESTED 핸들링은 #906에서 추가됩니다.

## 테스트
- [x] 컴파일 성공
- [ ] ORDER_CREATED 수신 → payments 테이블 READY 레코드 생성 확인
- [ ] 중복 이벤트 수신 시 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)