### PR TITLE
[Story] #905 결제 승인(confirm) API 및 이벤트 발행

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/controller/api/command/PaymentCommandApi.java
+++ b/servers/services/payment/src/main/java/com/example/payment/controller/api/command/PaymentCommandApi.java
@@ -1,0 +1,21 @@
+package com.example.payment.controller.api.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.payment.dto.request.PaymentConfirmRequest;
+import com.example.payment.dto.response.PaymentConfirmResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Payment Command", description = "결제 변경 API")
+public interface PaymentCommandApi {
+
+    @Operation(summary = "결제 승인", description = "토스페이먼츠 결제를 승인합니다")
+    @PostMapping("/api/v1/payments/confirm")
+    ApiResponse<PaymentConfirmResponse> confirmPayment(
+            @Valid @RequestBody PaymentConfirmRequest request,
+            Long userId
+    );
+}

--- a/servers/services/payment/src/main/java/com/example/payment/controller/command/PaymentCommandController.java
+++ b/servers/services/payment/src/main/java/com/example/payment/controller/command/PaymentCommandController.java
@@ -1,0 +1,27 @@
+package com.example.payment.controller.command;
+
+import com.example.api.response.ApiResponse;
+import com.example.payment.controller.api.command.PaymentCommandApi;
+import com.example.payment.dto.request.PaymentConfirmRequest;
+import com.example.payment.dto.response.PaymentConfirmResponse;
+import com.example.payment.service.command.PaymentCommandService;
+import com.example.security.gateway.CurrentUserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentCommandController implements PaymentCommandApi {
+
+    private final PaymentCommandService paymentCommandService;
+
+    @Override
+    public ApiResponse<PaymentConfirmResponse> confirmPayment(
+            @Valid @RequestBody PaymentConfirmRequest request,
+            @CurrentUserId Long userId
+    ) {
+        return ApiResponse.success(paymentCommandService.confirmPayment(request, userId));
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/dto/request/PaymentConfirmRequest.java
+++ b/servers/services/payment/src/main/java/com/example/payment/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.example.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record PaymentConfirmRequest(
+        @NotBlank String paymentKey,
+        @NotNull Long orderId,
+        @NotNull @Positive Long amount
+) {
+}

--- a/servers/services/payment/src/main/java/com/example/payment/dto/response/PaymentConfirmResponse.java
+++ b/servers/services/payment/src/main/java/com/example/payment/dto/response/PaymentConfirmResponse.java
@@ -1,0 +1,27 @@
+package com.example.payment.dto.response;
+
+import com.example.payment.domain.Payment;
+
+import java.time.LocalDateTime;
+
+public record PaymentConfirmResponse(
+        Long paymentId,
+        Long orderId,
+        String status,
+        Long amount,
+        String paymentKey,
+        String method,
+        LocalDateTime paidAt
+) {
+    public static PaymentConfirmResponse from(Payment payment) {
+        return new PaymentConfirmResponse(
+                payment.getId(),
+                payment.getOrderId(),
+                payment.getStatus().name(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getMethod(),
+                payment.getPaidAt()
+        );
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
@@ -1,0 +1,46 @@
+package com.example.payment.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class PaymentCompletedEvent extends DomainEvent {
+
+    private final Long paymentId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+    private final LocalDateTime paidAt;
+    private final Long totalAmount;
+
+    public PaymentCompletedEvent(Long paymentId, Long orderId, Long userId, Long amount, LocalDateTime paidAt) {
+        super("payment-events");
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+        this.paidAt = paidAt;
+        this.totalAmount = amount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "PAYMENT_COMPLETED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("paymentId", paymentId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        payload.put("paidAt", paidAt);
+        payload.put("totalAmount", totalAmount);
+        return payload;
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentFailedEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentFailedEvent.java
@@ -1,0 +1,42 @@
+package com.example.payment.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class PaymentFailedEvent extends DomainEvent {
+
+    private final Long paymentId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+    private final String failReason;
+
+    public PaymentFailedEvent(Long paymentId, Long orderId, Long userId, Long amount, String failReason) {
+        super("payment-events");
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+        this.failReason = failReason;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "PAYMENT_FAILED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("paymentId", paymentId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        payload.put("failReason", failReason);
+        return payload;
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentCommandService.java
+++ b/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentCommandService.java
@@ -1,0 +1,119 @@
+package com.example.payment.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.payment.client.TossPaymentsClient;
+import com.example.payment.client.dto.TossConfirmRequest;
+import com.example.payment.client.dto.TossConfirmResponse;
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import com.example.payment.domain.PaymentStatus;
+import com.example.payment.dto.request.PaymentConfirmRequest;
+import com.example.payment.dto.response.PaymentConfirmResponse;
+import com.example.payment.event.PaymentCompletedEvent;
+import com.example.payment.event.PaymentFailedEvent;
+import com.example.payment.exception.PaymentErrorCode;
+import com.example.payment.exception.TossPaymentsApiException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentCommandService {
+
+    private final PaymentRepository paymentRepository;
+    private final TossPaymentsClient tossPaymentsClient;
+    private final EventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+
+    public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request, Long userId) {
+        Payment payment = paymentRepository.findByOrderId(request.orderId())
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        if (!payment.getUserId().equals(userId)) {
+            throw new BusinessException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+        }
+
+        if (payment.getStatus() != PaymentStatus.READY) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_READY);
+        }
+
+        if (!payment.getAmount().equals(request.amount())) {
+            throw new BusinessException(PaymentErrorCode.AMOUNT_MISMATCH);
+        }
+
+        if (payment.getExpiresAt() != null && payment.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_EXPIRED);
+        }
+
+        try {
+            TossConfirmResponse tossResponse = tossPaymentsClient.confirm(
+                    new TossConfirmRequest(request.paymentKey(), String.valueOf(request.orderId()), request.amount())
+            );
+
+            String tossResponseJson = serializeResponse(tossResponse);
+
+            LocalDateTime paidAt = tossResponse.approvedAt() != null
+                    ? LocalDateTime.parse(tossResponse.approvedAt().substring(0, 19))
+                    : LocalDateTime.now();
+
+            payment.markDone(
+                    tossResponse.paymentKey(),
+                    tossResponse.orderId(),
+                    tossResponse.method(),
+                    paidAt,
+                    tossResponseJson
+            );
+
+            eventPublisher.publish(
+                    new PaymentCompletedEvent(
+                            payment.getId(),
+                            payment.getOrderId(),
+                            payment.getUserId(),
+                            payment.getAmount(),
+                            paidAt
+                    ),
+                    EventMetadata.of("Payment", String.valueOf(payment.getId()))
+            );
+
+            log.info("결제 승인 완료: paymentId={}, orderId={}", payment.getId(), payment.getOrderId());
+            return PaymentConfirmResponse.from(payment);
+
+        } catch (TossPaymentsApiException e) {
+            payment.markFailed(request.paymentKey(), e.getResponseBody(), e.getResponseBody());
+
+            eventPublisher.publish(
+                    new PaymentFailedEvent(
+                            payment.getId(),
+                            payment.getOrderId(),
+                            payment.getUserId(),
+                            payment.getAmount(),
+                            e.getResponseBody()
+                    ),
+                    EventMetadata.of("Payment", String.valueOf(payment.getId()))
+            );
+
+            log.error("결제 승인 실패: paymentId={}, orderId={}, error={}",
+                    payment.getId(), payment.getOrderId(), e.getResponseBody());
+            throw new BusinessException(PaymentErrorCode.TOSS_CONFIRM_FAILED);
+        }
+    }
+
+    private String serializeResponse(Object response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            log.warn("토스 응답 직렬화 실패", e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #905
- Epic: #807
- 의존: #902, #903

## 작업 내용
프론트가 토스 SDK 결제 완료 후 호출하는 confirm API를 구현합니다.
토스 PG 승인 결과에 따라 PAYMENT_COMPLETED 또는 PAYMENT_FAILED 이벤트를 발행합니다.

### 변경 사항
- `PaymentCompletedEvent.java` — payload: paymentId, orderId, userId, amount, paidAt, totalAmount
- `PaymentFailedEvent.java` — payload: paymentId, orderId, userId, amount, failReason
- `PaymentConfirmRequest.java` — paymentKey, orderId, amount (validation 포함)
- `PaymentConfirmResponse.java` — paymentId, orderId, status, amount, paymentKey, method, paidAt
- `PaymentCommandService.confirmPayment()` — 핵심 승인 로직
- `PaymentCommandApi.java` + `PaymentCommandController.java`

### 승인 흐름
```
POST /api/v1/payments/confirm {paymentKey, orderId, amount}
  → findByOrderId (존재 확인)
  → userId 소유권 검증
  → status == READY 검증
  → amount 일치 검증
  → expiresAt 만료 확인
  → tossPaymentsClient.confirm()
  ├─ 성공 → markDone() + PAYMENT_COMPLETED 발행
  └─ 실패 → markFailed() + PAYMENT_FAILED 발행
```

### 기존 소비자 호환성
| 소비자 | 사용 필드 | 호환 |
|--------|----------|------|
| Order | paymentId, orderId, paidAt | ✅ |
| Stock | orderId | ✅ |
| Notification | paymentId, orderId, userId, totalAmount | ✅ |

## 테스트
- [x] 컴파일 성공
- [ ] 토스 테스트 키로 confirm → PAYMENT_COMPLETED 이벤트 발행 확인
- [ ] 승인 실패 시 PAYMENT_FAILED 이벤트 발행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)