### PR TITLE
[Story] #906 주문 환불 요청 처리 (토스 취소 → PAYMENT_REFUNDED 발행)

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/consumer/order/PaymentOrderEventProcessor.java
+++ b/servers/services/payment/src/main/java/com/example/payment/consumer/order/PaymentOrderEventProcessor.java
@@ -2,12 +2,15 @@ package com.example.payment.consumer.order;
 
 import com.example.config.kafka.IdempotentConsumerService;
 import com.example.core.id.Snowflake;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
 import com.example.event.consumer.AbstractIdempotentEventSpecProcessor;
 import com.example.event.consumer.EventEnvelope;
 import com.example.event.consumer.EventSpec;
 import com.example.event.inbox.InboxConsumerBinding;
 import com.example.payment.domain.Payment;
 import com.example.payment.domain.PaymentRepository;
+import com.example.payment.service.command.PaymentEventService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -22,19 +25,23 @@ public class PaymentOrderEventProcessor extends AbstractIdempotentEventSpecProce
     private static final String IDEMPOTENT_EVENT_TYPE = "ORDER_EVENT";
 
     private final PaymentRepository paymentRepository;
+    private final PaymentEventService paymentEventService;
     private final Snowflake snowflake;
     private final Map<String, EventSpec<OrderEventMessage>> eventSpecs;
 
     public PaymentOrderEventProcessor(
             PaymentRepository paymentRepository,
+            PaymentEventService paymentEventService,
             Snowflake snowflake,
             IdempotentConsumerService idempotentConsumerService
     ) {
         super(idempotentConsumerService);
         this.paymentRepository = paymentRepository;
+        this.paymentEventService = paymentEventService;
         this.snowflake = snowflake;
         this.eventSpecs = Map.of(
-                "ORDER_CREATED_EVENT", EventSpec.of(OrderEventMessage.class, this::hasOrderId, this::handleOrderCreated)
+                "ORDER_CREATED_EVENT", EventSpec.of(OrderEventMessage.class, this::hasOrderId, this::handleOrderCreated),
+                "ORDER_REFUND_REQUESTED_EVENT", EventSpec.of(OrderEventMessage.class, this::hasOrderId, this::handleOrderRefundRequested)
         );
     }
 
@@ -86,5 +93,9 @@ public class PaymentOrderEventProcessor extends AbstractIdempotentEventSpecProce
 
         paymentRepository.save(payment);
         log.info("결제 READY 생성: paymentId={}, orderId={}", payment.getId(), event.getOrderId());
+    }
+
+    private void handleOrderRefundRequested(OrderEventMessage event) {
+        paymentEventService.processRefund(event.getOrderId());
     }
 }

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentCancelledEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentCancelledEvent.java
@@ -1,0 +1,39 @@
+package com.example.payment.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class PaymentCancelledEvent extends DomainEvent {
+
+    private final Long paymentId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+
+    public PaymentCancelledEvent(Long paymentId, Long orderId, Long userId, Long amount) {
+        super("payment-events");
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "PAYMENT_CANCELLED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("paymentId", paymentId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        return payload;
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentRefundedEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentRefundedEvent.java
@@ -1,0 +1,39 @@
+package com.example.payment.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class PaymentRefundedEvent extends DomainEvent {
+
+    private final Long paymentId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+
+    public PaymentRefundedEvent(Long paymentId, Long orderId, Long userId, Long amount) {
+        super("payment-events");
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "PAYMENT_REFUNDED";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("paymentId", paymentId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        return payload;
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentTimedOutEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentTimedOutEvent.java
@@ -1,0 +1,39 @@
+package com.example.payment.event;
+
+import com.example.event.DomainEvent;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class PaymentTimedOutEvent extends DomainEvent {
+
+    private final Long paymentId;
+    private final Long orderId;
+    private final Long userId;
+    private final Long amount;
+
+    public PaymentTimedOutEvent(Long paymentId, Long orderId, Long userId, Long amount) {
+        super("payment-events");
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.userId = userId;
+        this.amount = amount;
+    }
+
+    @Override
+    public String getEventTypeName() {
+        return "PAYMENT_TIMED_OUT";
+    }
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("paymentId", paymentId);
+        payload.put("orderId", orderId);
+        payload.put("userId", userId);
+        payload.put("amount", amount);
+        return payload;
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentEventService.java
+++ b/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentEventService.java
@@ -1,0 +1,86 @@
+package com.example.payment.service.command;
+
+import com.example.core.exception.BusinessException;
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.payment.client.TossPaymentsClient;
+import com.example.payment.client.dto.TossCancelRequest;
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import com.example.payment.domain.PaymentStatus;
+import com.example.payment.event.PaymentRefundedEvent;
+import com.example.payment.event.PaymentTimedOutEvent;
+import com.example.payment.exception.PaymentErrorCode;
+import com.example.payment.exception.TossPaymentsApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentEventService {
+
+    private final PaymentRepository paymentRepository;
+    private final TossPaymentsClient tossPaymentsClient;
+    private final EventPublisher eventPublisher;
+
+    public void processRefund(Long orderId) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() != PaymentStatus.DONE) {
+            log.warn("환불 불가 상태: paymentId={}, status={}", payment.getId(), payment.getStatus());
+            return;
+        }
+
+        try {
+            tossPaymentsClient.cancel(
+                    payment.getPaymentKey(),
+                    new TossCancelRequest("주문 환불 요청", payment.getAmount())
+            );
+
+            payment.markCancelled("주문 환불 요청");
+
+            eventPublisher.publish(
+                    new PaymentRefundedEvent(
+                            payment.getId(),
+                            payment.getOrderId(),
+                            payment.getUserId(),
+                            payment.getAmount()
+                    ),
+                    EventMetadata.of("Payment", String.valueOf(payment.getId()))
+            );
+
+            log.info("환불 처리 완료: paymentId={}, orderId={}", payment.getId(), orderId);
+
+        } catch (TossPaymentsApiException e) {
+            log.error("토스 환불 실패: paymentId={}, orderId={}, error={}",
+                    payment.getId(), orderId, e.getResponseBody());
+            throw new BusinessException(PaymentErrorCode.TOSS_CANCEL_FAILED);
+        }
+    }
+
+    public void processTimeout(Payment payment) {
+        if (payment.getStatus() != PaymentStatus.READY) {
+            log.warn("타임아웃 처리 불가 상태: paymentId={}, status={}", payment.getId(), payment.getStatus());
+            return;
+        }
+
+        payment.markExpired();
+
+        eventPublisher.publish(
+                new PaymentTimedOutEvent(
+                        payment.getId(),
+                        payment.getOrderId(),
+                        payment.getUserId(),
+                        payment.getAmount()
+                ),
+                EventMetadata.of("Payment", String.valueOf(payment.getId()))
+        );
+
+        log.info("결제 타임아웃 처리: paymentId={}, orderId={}", payment.getId(), payment.getOrderId());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #906
- Epic: #807
- 의존: #903, #904

## 작업 내용
Order 서비스의 ORDER_REFUND_REQUESTED 이벤트를 수신하여 토스페이먼츠 취소 API를 호출하고,
결과를 PAYMENT_REFUNDED 이벤트로 발행합니다.

### 변경 사항
- `PaymentRefundedEvent.java`, `PaymentCancelledEvent.java`, `PaymentTimedOutEvent.java` — 이벤트 3개 추가
- `PaymentEventService.java` — 환불 + 타임아웃 처리 서비스
  - `processRefund(orderId)`: 토스 cancel → markCancelled → PAYMENT_REFUNDED 발행
  - `processTimeout(payment)`: markExpired → PAYMENT_TIMED_OUT 발행
- `PaymentOrderEventProcessor.java` 수정 — ORDER_REFUND_REQUESTED 핸들링 추가

### 이벤트 흐름
```
[Order] → ORDER_REFUND_REQUESTED {orderId, userId, totalAmount}
  → PaymentOrderEventProcessor.handleOrderRefundRequested()
  → PaymentEventService.processRefund(orderId)
  → tossPaymentsClient.cancel(paymentKey, cancelRequest)
  → payment.markCancelled("주문 환불 요청")
  → PAYMENT_REFUNDED 발행 → payment-events 토픽
  → [Order] REFUNDED 전이 + OrderRefundedEvent 발행
```

### 방어 로직
- DONE 상태가 아닌 결제에 대한 환불 시도는 스킵 (에러가 아닌 warn 로그)
- 토스 API 실패 시 `BusinessException(TOSS_CANCEL_FAILED)` → inbox 재시도

## 테스트
- [x] 컴파일 성공
- [ ] 환불 요청 → 토스 취소 → PAYMENT_REFUNDED 발행 확인
- [ ] DONE 아닌 상태에서 환불 시도 시 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)