### PR TITLE
[Story] #907 결제 타임아웃 스케줄러

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/scheduler/PaymentTimeoutScheduler.java
+++ b/servers/services/payment/src/main/java/com/example/payment/scheduler/PaymentTimeoutScheduler.java
@@ -1,0 +1,45 @@
+package com.example.payment.scheduler;
+
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import com.example.payment.domain.PaymentStatus;
+import com.example.payment.service.command.PaymentEventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentTimeoutScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentEventService paymentEventService;
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void processExpiredPayments() {
+        List<Payment> expiredPayments = paymentRepository.findByStatusAndExpiresAtBefore(
+                PaymentStatus.READY, LocalDateTime.now()
+        );
+
+        if (expiredPayments.isEmpty()) {
+            return;
+        }
+
+        log.info("만료된 결제 처리 시작: count={}", expiredPayments.size());
+
+        for (Payment payment : expiredPayments) {
+            try {
+                paymentEventService.processTimeout(payment);
+            } catch (Exception e) {
+                log.error("결제 타임아웃 처리 실패: paymentId={}", payment.getId(), e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #907
- Epic: #807
- 의존: #902

## 작업 내용
expiresAt이 지난 READY 상태 결제를 주기적으로 탐지하여
EXPIRED 상태로 전이하고 PAYMENT_TIMED_OUT 이벤트를 발행합니다.

### 변경 사항
- `PaymentTimeoutScheduler.java`
  - `@Scheduled(fixedDelay = 60_000)` — 60초 간격 폴링
  - `findByStatusAndExpiresAtBefore(READY, now())` 조회
  - 개별 건에 대해 `paymentEventService.processTimeout()` 호출
  - 1건 실패해도 try-catch로 나머지 건 처리 계속

### 동작 흐름
```
[Scheduler] 매 60초
  → SELECT * FROM payments WHERE status='READY' AND expires_at < now()
  → 각 건: payment.markExpired() + PAYMENT_TIMED_OUT 발행
  → [Order] CANCELLED 전이
  → [Stock] reservations 반환
```

## 테스트
- [x] 컴파일 성공
- [ ] 만료된 READY 결제 → EXPIRED 전이 확인
- [ ] PAYMENT_TIMED_OUT 이벤트 발행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)