### PR TITLE
[Story] #908 결제 조회 API

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/controller/api/query/PaymentQueryApi.java
+++ b/servers/services/payment/src/main/java/com/example/payment/controller/api/query/PaymentQueryApi.java
@@ -1,0 +1,16 @@
+package com.example.payment.controller.api.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.payment.dto.response.PaymentDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Payment Query", description = "결제 조회 API")
+public interface PaymentQueryApi {
+
+    @Operation(summary = "주문별 결제 조회", description = "주문 ID로 결제 정보를 조회합니다 (본인 결제만)")
+    @GetMapping("/api/v1/payments/orders/{orderId}")
+    ApiResponse<PaymentDetailResponse> getPaymentByOrderId(@PathVariable Long orderId, Long userId);
+}

--- a/servers/services/payment/src/main/java/com/example/payment/controller/query/PaymentQueryController.java
+++ b/servers/services/payment/src/main/java/com/example/payment/controller/query/PaymentQueryController.java
@@ -1,0 +1,25 @@
+package com.example.payment.controller.query;
+
+import com.example.api.response.ApiResponse;
+import com.example.payment.controller.api.query.PaymentQueryApi;
+import com.example.payment.dto.response.PaymentDetailResponse;
+import com.example.payment.service.query.PaymentQueryService;
+import com.example.security.gateway.CurrentUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentQueryController implements PaymentQueryApi {
+
+    private final PaymentQueryService paymentQueryService;
+
+    @Override
+    public ApiResponse<PaymentDetailResponse> getPaymentByOrderId(
+            @PathVariable Long orderId,
+            @CurrentUserId Long userId
+    ) {
+        return ApiResponse.success(paymentQueryService.getPaymentByOrderId(orderId, userId));
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/dto/response/PaymentDetailResponse.java
+++ b/servers/services/payment/src/main/java/com/example/payment/dto/response/PaymentDetailResponse.java
@@ -1,0 +1,39 @@
+package com.example.payment.dto.response;
+
+import com.example.payment.domain.Payment;
+
+import java.time.LocalDateTime;
+
+public record PaymentDetailResponse(
+        Long paymentId,
+        Long orderId,
+        String status,
+        Long amount,
+        String paymentKey,
+        String method,
+        LocalDateTime paidAt,
+        LocalDateTime failedAt,
+        String failReason,
+        LocalDateTime cancelledAt,
+        String cancelReason,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+) {
+    public static PaymentDetailResponse from(Payment payment) {
+        return new PaymentDetailResponse(
+                payment.getId(),
+                payment.getOrderId(),
+                payment.getStatus().name(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getMethod(),
+                payment.getPaidAt(),
+                payment.getFailedAt(),
+                payment.getFailReason(),
+                payment.getCancelledAt(),
+                payment.getCancelReason(),
+                payment.getExpiresAt(),
+                payment.getCreatedAt()
+        );
+    }
+}

--- a/servers/services/payment/src/main/java/com/example/payment/service/query/PaymentQueryService.java
+++ b/servers/services/payment/src/main/java/com/example/payment/service/query/PaymentQueryService.java
@@ -1,0 +1,29 @@
+package com.example.payment.service.query;
+
+import com.example.core.exception.BusinessException;
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import com.example.payment.dto.response.PaymentDetailResponse;
+import com.example.payment.exception.PaymentErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentQueryService {
+
+    private final PaymentRepository paymentRepository;
+
+    public PaymentDetailResponse getPaymentByOrderId(Long orderId, Long userId) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        if (!payment.getUserId().equals(userId)) {
+            throw new BusinessException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+        }
+
+        return PaymentDetailResponse.from(payment);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #908
- Epic: #807
- 의존: #902

## 작업 내용
주문 ID 기반으로 결제 상세 정보를 조회하는 API를 제공합니다.

### 변경 사항
- `PaymentDetailResponse.java` — 결제 상세 DTO (13개 필드)
- `PaymentQueryService.java` — getPaymentByOrderId(orderId, userId)
- `PaymentQueryApi.java` + `PaymentQueryController.java`

### API 스펙
```
GET /api/v1/payments/orders/{orderId}
Headers: X-User-Id (게이트웨이에서 주입)

200 OK:
{
  "success": true,
  "data": {
    "paymentId": 123456789,
    "orderId": 987654321,
    "status": "DONE",
    "amount": 50000,
    "paymentKey": "toss_xxx",
    "method": "카드",
    "paidAt": "2026-03-22T10:30:00",
    ...
  }
}
```

### 보안
- `@CurrentUserId`로 userId 주입 → 본인 결제만 조회 가능
- 타인의 결제 접근 시 `UNAUTHORIZED_PAYMENT_ACCESS` (403)

## 테스트
- [x] `compileJava` 빌드 성공 (전체 Payment 서비스)
- [ ] 본인 결제 조회 → 상세 정보 반환 확인
- [ ] 타인 결제 접근 시 403 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)