### PR TITLE
feat(#501): 이메일 인증 코드 시스템 구현 (Notification 서비스 연동)

### DIFF
--- a/servers/services/auth/src/main/java/com/example/auth/controller/AuthController.java
+++ b/servers/services/auth/src/main/java/com/example/auth/controller/AuthController.java
@@ -5,9 +5,11 @@ import com.example.auth.dto.request.ChangeEmailRequest;
 import com.example.auth.dto.request.ChangePasswordRequest;
 import com.example.auth.dto.request.SendVerificationRequest;
 import com.example.auth.dto.request.SignupRequest;
+import com.example.auth.dto.request.VerifyEmailRequest;
 import com.example.auth.dto.request.WithdrawRequest;
 import com.example.auth.dto.response.CheckAvailableResponse;
 import com.example.auth.dto.response.SignupResponse;
+import com.example.auth.dto.response.VerifyEmailResponse;
 import com.example.auth.service.AuthService;
 import com.example.security.gateway.CurrentUserId;
 import jakarta.validation.Valid;
@@ -53,7 +55,12 @@ public class AuthController {
         return ApiResponse.success();
     }
 
-    // Keycloak 인증 메일 재발송
+    @PostMapping("/emails/verify")
+    public ApiResponse<VerifyEmailResponse> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
+        VerifyEmailResponse response = authService.verifyEmail(request.email(), request.code());
+        return ApiResponse.success(response);
+    }
+
     @PostMapping("/emails/verification")
     public ApiResponse<Void> resendVerification(@Valid @RequestBody SendVerificationRequest request) {
         authService.resendVerificationEmail(request.email());

--- a/servers/services/auth/src/main/java/com/example/auth/dto/request/VerifyEmailRequest.java
+++ b/servers/services/auth/src/main/java/com/example/auth/dto/request/VerifyEmailRequest.java
@@ -1,0 +1,14 @@
+package com.example.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record VerifyEmailRequest(
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "인증 코드는 필수입니다")
+        String code
+) {
+}

--- a/servers/services/auth/src/main/java/com/example/auth/dto/response/VerifyEmailResponse.java
+++ b/servers/services/auth/src/main/java/com/example/auth/dto/response/VerifyEmailResponse.java
@@ -1,0 +1,10 @@
+package com.example.auth.dto.response;
+
+public record VerifyEmailResponse(
+        boolean verified,
+        String email
+) {
+    public static VerifyEmailResponse of(boolean verified, String email) {
+        return new VerifyEmailResponse(verified, email);
+    }
+}

--- a/servers/services/auth/src/main/java/com/example/auth/entity/EmailVerification.java
+++ b/servers/services/auth/src/main/java/com/example/auth/entity/EmailVerification.java
@@ -1,0 +1,58 @@
+package com.example.auth.entity;
+
+import com.example.core.id.jpa.SnowflakeGenerated;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_verifications", indexes = {
+        @Index(name = "idx_email_verifications_email", columnList = "email")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification {
+
+    @Id
+    @SnowflakeGenerated
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "code", nullable = false, length = 10)
+    private String code;
+
+    @Column(name = "verified", nullable = false)
+    private boolean verified;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static EmailVerification create(String email, String code, LocalDateTime expiresAt) {
+        EmailVerification ev = new EmailVerification();
+        ev.email = email;
+        ev.code = code;
+        ev.verified = false;
+        ev.expiresAt = expiresAt;
+        ev.createdAt = LocalDateTime.now();
+        return ev;
+    }
+
+    public void verify() {
+        if (isExpired()) {
+            throw new IllegalStateException("인증 코드가 만료되었습니다");
+        }
+        this.verified = true;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/servers/services/auth/src/main/java/com/example/auth/exception/AuthErrorCode.java
+++ b/servers/services/auth/src/main/java/com/example/auth/exception/AuthErrorCode.java
@@ -29,6 +29,12 @@ public enum AuthErrorCode implements DomainErrorCode {
     // 탈퇴
     WITHDRAW_KEYCLOAK_FAILED("AUTH-040", "Keycloak 사용자 비활성화에 실패했습니다", HttpStatus.BAD_GATEWAY),
 
+    // 이메일 인증
+    VERIFICATION_CODE_EXPIRED("AUTH-050", "인증 코드가 만료되었습니다", HttpStatus.BAD_REQUEST),
+    VERIFICATION_CODE_INVALID("AUTH-051", "인증 코드가 일치하지 않습니다", HttpStatus.BAD_REQUEST),
+    EMAIL_ALREADY_VERIFIED("AUTH-052", "이미 인증된 이메일입니다", HttpStatus.CONFLICT),
+    VERIFICATION_NOT_FOUND("AUTH-053", "인증 요청을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
     // Keycloak 통신
     KEYCLOAK_COMMUNICATION_ERROR("AUTH-090", "Keycloak 서버와 통신에 실패했습니다", HttpStatus.BAD_GATEWAY),
 

--- a/servers/services/auth/src/main/java/com/example/auth/repository/EmailVerificationRepository.java
+++ b/servers/services/auth/src/main/java/com/example/auth/repository/EmailVerificationRepository.java
@@ -1,0 +1,13 @@
+package com.example.auth.repository;
+
+import com.example.auth.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findTopByEmailAndVerifiedFalseOrderByCreatedAtDesc(String email);
+
+    boolean existsByEmailAndVerifiedTrue(String email);
+}

--- a/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
+++ b/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
@@ -6,15 +6,20 @@ import com.example.auth.dto.request.ChangePasswordRequest;
 import com.example.auth.dto.request.SignupRequest;
 import com.example.auth.dto.request.WithdrawRequest;
 import com.example.auth.dto.response.SignupResponse;
+import com.example.auth.dto.response.VerifyEmailResponse;
+import com.example.auth.entity.EmailVerification;
 import com.example.auth.entity.User;
 import com.example.auth.entity.UserStatus;
 import com.example.auth.entity.UserStatusHistory;
+import com.example.auth.event.EmailConfirmEvent;
 import com.example.auth.event.UserCreatedEvent;
 import com.example.auth.event.UserEmailChangedEvent;
 import com.example.auth.event.UserWithdrawnEvent;
 import com.example.auth.exception.AuthErrorCode;
+import com.example.auth.repository.EmailVerificationRepository;
 import com.example.auth.repository.UserRepository;
 import com.example.auth.repository.UserStatusHistoryRepository;
+import com.example.auth.util.VerificationCodeGenerator;
 import com.example.core.exception.BusinessException;
 import com.example.core.exception.TechnicalException;
 import com.example.event.EventMetadata;
@@ -30,6 +35,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -37,8 +44,11 @@ import java.util.Map;
 @Service
 public class AuthService {
 
+    private static final int VERIFICATION_CODE_EXPIRY_MINUTES = 10;
+
     private final UserRepository userRepository;
     private final UserStatusHistoryRepository statusHistoryRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
     private final Keycloak keycloakAdminClient;
     private final ProfileServicePort profileServiceClient;
     private final EventPublisher eventPublisher;
@@ -49,6 +59,7 @@ public class AuthService {
 
     public AuthService(UserRepository userRepository,
                        UserStatusHistoryRepository statusHistoryRepository,
+                       EmailVerificationRepository emailVerificationRepository,
                        Keycloak keycloakAdminClient,
                        ProfileServicePort profileServiceClient,
                        EventPublisher eventPublisher,
@@ -58,6 +69,7 @@ public class AuthService {
                        @Value("${feature.sync-profile-create-on-signup:true}") boolean syncProfileCreateOnSignup) {
         this.userRepository = userRepository;
         this.statusHistoryRepository = statusHistoryRepository;
+        this.emailVerificationRepository = emailVerificationRepository;
         this.keycloakAdminClient = keycloakAdminClient;
         this.profileServiceClient = profileServiceClient;
         this.eventPublisher = eventPublisher;
@@ -102,6 +114,18 @@ public class AuthService {
             // 7. Outbox 이벤트 발행
             eventPublisher.publish(
                     new UserCreatedEvent(user.getId(), user.getEmail(), user.getNickname()),
+                    EventMetadata.of("USER", String.valueOf(user.getId()))
+            );
+
+            // 8. 이메일 인증 코드 생성 및 발행
+            String verificationCode = VerificationCodeGenerator.generate();
+            EmailVerification emailVerification = EmailVerification.create(
+                    request.email(), verificationCode,
+                    LocalDateTime.now().plusMinutes(VERIFICATION_CODE_EXPIRY_MINUTES));
+            emailVerificationRepository.save(emailVerification);
+
+            eventPublisher.publish(
+                    new EmailConfirmEvent(request.email(), verificationCode),
                     EventMetadata.of("USER", String.valueOf(user.getId()))
             );
 
@@ -187,21 +211,58 @@ public class AuthService {
         log.info("User withdrawn: userId={}", userId);
     }
 
+    // ─── 이메일 인증 검증 ────────────────────────────────────
+
+    @Transactional
+    public VerifyEmailResponse verifyEmail(String email, String code) {
+        EmailVerification verification = emailVerificationRepository
+                .findTopByEmailAndVerifiedFalseOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.VERIFICATION_NOT_FOUND));
+
+        if (verification.isExpired()) {
+            throw new BusinessException(AuthErrorCode.VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!verification.getCode().equals(code)) {
+            throw new BusinessException(AuthErrorCode.VERIFICATION_CODE_INVALID);
+        }
+
+        verification.verify();
+
+        // Keycloak emailVerified=true 업데이트
+        updateKeycloakEmailVerified(email);
+
+        log.info("Email verified: email={}", email);
+        return VerifyEmailResponse.of(true, email);
+    }
+
     // ─── 이메일 인증 재발송 ────────────────────────────────────
 
+    @Transactional
     public void resendVerificationEmail(String email) {
-        try {
-            List<org.keycloak.representations.idm.UserRepresentation> users =
-                    keycloakAdminClient.realm(realm).users().searchByEmail(email, true);
-            if (users.isEmpty()) {
-                throw new BusinessException(AuthErrorCode.USER_NOT_FOUND);
-            }
-            sendKeycloakVerificationEmailSafely(users.get(0).getId());
-        } catch (BusinessException e) {
-            throw e;
-        } catch (Exception e) {
-            log.warn("Keycloak 인증 메일 재발송 실패 (Admin 설정 확인): email={}, error={}", email, e.getMessage());
+        // 사용자 존재 확인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 이미 인증 완료 여부 확인
+        if (emailVerificationRepository.existsByEmailAndVerifiedTrue(email)) {
+            throw new BusinessException(AuthErrorCode.EMAIL_ALREADY_VERIFIED);
         }
+
+        // 새 인증 코드 생성 및 저장
+        String verificationCode = VerificationCodeGenerator.generate();
+        EmailVerification emailVerification = EmailVerification.create(
+                email, verificationCode,
+                LocalDateTime.now().plusMinutes(VERIFICATION_CODE_EXPIRY_MINUTES));
+        emailVerificationRepository.save(emailVerification);
+
+        // EmailConfirmEvent 발행
+        eventPublisher.publish(
+                new EmailConfirmEvent(email, verificationCode),
+                EventMetadata.of("USER", String.valueOf(user.getId()))
+        );
+
+        log.info("Verification email resent: email={}", email);
     }
 
     // ─── 중복 확인 ────────────────────────────────────────────
@@ -234,7 +295,7 @@ public class AuthService {
             kcUser.setEmail(email);
             kcUser.setEnabled(true);
             kcUser.setEmailVerified(false);
-            kcUser.setRequiredActions(List.of("VERIFY_EMAIL"));
+            kcUser.setRequiredActions(Collections.emptyList());
 
             CredentialRepresentation credential = new CredentialRepresentation();
             credential.setType(CredentialRepresentation.PASSWORD);
@@ -356,14 +417,19 @@ public class AuthService {
 
     // ─── Keycloak 이메일 인증 ─────────────────────────────────
 
-    private void sendKeycloakVerificationEmailSafely(String keycloakUserId) {
+    private void updateKeycloakEmailVerified(String email) {
         try {
-            keycloakAdminClient.realm(realm).users().get(keycloakUserId)
-                    .executeActionsEmail(List.of("VERIFY_EMAIL"));
-            log.info("Keycloak verification email sent: keycloakId={}", keycloakUserId);
+            List<UserRepresentation> users =
+                    keycloakAdminClient.realm(realm).users().searchByEmail(email, true);
+            if (!users.isEmpty()) {
+                UserRepresentation kcUser = users.get(0);
+                kcUser.setEmailVerified(true);
+                kcUser.setRequiredActions(Collections.emptyList());
+                keycloakAdminClient.realm(realm).users().get(kcUser.getId()).update(kcUser);
+                log.info("Keycloak emailVerified updated: email={}", email);
+            }
         } catch (Exception e) {
-            log.warn("Keycloak verification email failed (SMTP 설정 확인 필요): keycloakId={}, error={}",
-                    keycloakUserId, e.getMessage());
+            log.warn("Keycloak emailVerified 업데이트 실패: email={}, error={}", email, e.getMessage());
         }
     }
 

--- a/servers/services/auth/src/main/java/com/example/auth/util/VerificationCodeGenerator.java
+++ b/servers/services/auth/src/main/java/com/example/auth/util/VerificationCodeGenerator.java
@@ -1,0 +1,17 @@
+package com.example.auth.util;
+
+import java.security.SecureRandom;
+
+public final class VerificationCodeGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int CODE_LENGTH = 6;
+
+    private VerificationCodeGenerator() {
+    }
+
+    public static String generate() {
+        int code = RANDOM.nextInt(900_000) + 100_000;
+        return String.valueOf(code);
+    }
+}


### PR DESCRIPTION
## Summary

- 회원가입 시 6자리 인증 코드 생성 → `EmailConfirmEvent` Kafka 발행 → Notification 서비스 이메일 발송
- `POST /api/v1/auth/emails/verify` 인증 코드 검증 엔드포인트 추가
- 인증 메일 재발송을 Keycloak SMTP → Notification 서비스 연동으로 전환
- Keycloak `requiredActions`에서 `VERIFY_EMAIL` 제거 (자체 인증 전환)

## 관련 이슈

- Closes #501
- Related #681 (EPIC: 사용자 인증 시스템)
- Related #498 (Keycloak 인증 서버 환경 구성)
- Related #506 (Gateway BFF 인증 연동)
- Related #683 (User Service 구현)

## 변경 파일

| 구분 | 파일 | 설명 |
|------|------|------|
| 신규 | `entity/EmailVerification.java` | JPA 엔티티 (email_verifications 테이블 매핑) |
| 신규 | `repository/EmailVerificationRepository.java` | 최신 미인증 건 조회, 인증 완료 여부 확인 |
| 신규 | `util/VerificationCodeGenerator.java` | SecureRandom 기반 6자리 코드 생성 |
| 신규 | `dto/request/VerifyEmailRequest.java` | 인증 코드 검증 요청 DTO |
| 신규 | `dto/response/VerifyEmailResponse.java` | 인증 코드 검증 응답 DTO |
| 수정 | `service/AuthService.java` | signup, verifyEmail, resendVerificationEmail 로직 |
| 수정 | `controller/AuthController.java` | verify 엔드포인트 추가 |
| 수정 | `exception/AuthErrorCode.java` | AUTH-050~053 에러 코드 추가 |

## Test plan

- [ ] `./gradlew :servers:services:auth:compileJava` 빌드 성공 확인
- [ ] 회원가입 API 호출 → `email_verifications` 테이블에 코드 저장 확인
- [ ] Kafka `auth-events` 토픽에 `EMAIL_CONFIRM_EVENT` 발행 확인
- [ ] Notification 서비스가 이메일 발송 확인
- [ ] `POST /api/v1/auth/emails/verify` → verified=true + Keycloak emailVerified 업데이트 확인
- [ ] 인증 메일 재발송 → 새 코드 생성 + 이벤트 발행 확인
