### PR TITLE
refactor: payment build.gradle.kts 오타 수정

### DIFF
--- a/servers/services/payment/build.gradle.kts
+++ b/servers/services/payment/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     // ─── Core ─────────────────────────────────────
     implementation(project(":libs:core:exception"))
     implementation(project(":libs:core:util"))
-    implementahttps://github.com/MZC-3rd-Project/BACKEND_SERVER/pull/926tion(project(":libs:core:id"))
+    implementation(project(":libs:core:id"))
     implementation(project(":libs:core:pagination"))
 
     // ─── API ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- PR #926 머지 충돌 해결 시 PR URL이 `implementation` 키워드에 섞여 들어간 오타 수정
- `implementahttps://...tion(...)` → `implementation(...)`
- 이 오타로 인해 전체 프로젝트 빌드가 실패하고 있었음

## Test plan
- [x] `./gradlew :servers:services:payment:build -x test` 빌드 확인
