### PR TITLE
feat : UserStatus 값으로 NONE 추가

### DIFF
--- a/servers/services/auth/src/main/java/com/example/auth/entity/UserStatus.java
+++ b/servers/services/auth/src/main/java/com/example/auth/entity/UserStatus.java
@@ -1,6 +1,7 @@
 package com.example.auth.entity;
 
 public enum UserStatus {
+    NONE,
     ACTIVE,
     SUSPENDED,
     WITHDRAWN

--- a/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
+++ b/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
@@ -101,7 +101,7 @@ public class AuthService {
 
             // 5. 상태 이력 기록
             UserStatusHistory history = UserStatusHistory.create(
-                    user.getId(), null, UserStatus.ACTIVE, "회원가입", user.getId());
+                    user.getId(), UserStatus.NONE, UserStatus.ACTIVE, "회원가입", user.getId());
             statusHistoryRepository.save(history);
 
             // 6. Profile Service 동기 호출 (feature flag)


### PR DESCRIPTION
## 작업 내용
 UserStatusHistory.create(user.getId(), null, UserStatus.ACTIVE, "회원가입", user.getId()); 에서

  - previousStatus에 null을 넘기는데, @Column(name = "previous_status", nullable = false) + DB NOT NULL 제약 조건 때문에 INSERT 시 오류가 발생

  두가지 방법 중 1번으로 

  1. UserStatus에 NONE 추가 — UserStatusHistory.create(userId, UserStatus.NONE, ...)
  2. 컬럼을 nullable로 변경 — @Column(nullable = true) + DB 마이그레이션
