### PR TITLE
fix(#501): signup 트랜잭션 안전성 개선 — DB flush 후 외부 호출

### DIFF
--- a/servers/services/auth/src/main/java/com/example/auth/entity/UserStatus.java
+++ b/servers/services/auth/src/main/java/com/example/auth/entity/UserStatus.java
@@ -1,6 +1,7 @@
 package com.example.auth.entity;
 
 public enum UserStatus {
+    NONE,
     ACTIVE,
     SUSPENDED,
     WITHDRAWN

--- a/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
+++ b/servers/services/auth/src/main/java/com/example/auth/service/AuthService.java
@@ -24,6 +24,7 @@ import com.example.core.exception.BusinessException;
 import com.example.core.exception.TechnicalException;
 import com.example.event.EventMetadata;
 import com.example.event.EventPublisher;
+import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.admin.client.Keycloak;
@@ -52,6 +53,7 @@ public class AuthService {
     private final Keycloak keycloakAdminClient;
     private final ProfileServicePort profileServiceClient;
     private final EventPublisher eventPublisher;
+    private final EntityManager entityManager;
     private final String realm;
     private final String keycloakServerUrl;
     private final String directGrantClientId;
@@ -63,6 +65,7 @@ public class AuthService {
                        Keycloak keycloakAdminClient,
                        ProfileServicePort profileServiceClient,
                        EventPublisher eventPublisher,
+                       EntityManager entityManager,
                        @Value("${keycloak.admin.realm}") String realm,
                        @Value("${keycloak.admin.server-url}") String keycloakServerUrl,
                        @Value("${keycloak.admin.direct-grant-client-id}") String directGrantClientId,
@@ -73,6 +76,7 @@ public class AuthService {
         this.keycloakAdminClient = keycloakAdminClient;
         this.profileServiceClient = profileServiceClient;
         this.eventPublisher = eventPublisher;
+        this.entityManager = entityManager;
         this.realm = realm;
         this.keycloakServerUrl = keycloakServerUrl;
         this.directGrantClientId = directGrantClientId;
@@ -101,33 +105,35 @@ public class AuthService {
 
             // 5. 상태 이력 기록
             UserStatusHistory history = UserStatusHistory.create(
-                    user.getId(), null, UserStatus.ACTIVE, "회원가입", user.getId());
+                    user.getId(), UserStatus.NONE, UserStatus.ACTIVE, "회원가입", user.getId());
             statusHistoryRepository.save(history);
 
-            // 6. Profile Service 동기 호출 (feature flag)
-            if (syncProfileCreateOnSignup) {
-                profileServiceClient.createProfile(user.getId(), user.getEmail(), request.nickname());
-            } else {
-                log.info("Sync profile create disabled by feature flag. userId={}", user.getId());
-            }
-
-            // 7. Outbox 이벤트 발행
-            eventPublisher.publish(
-                    new UserCreatedEvent(user.getId(), user.getEmail(), user.getNickname()),
-                    EventMetadata.of("USER", String.valueOf(user.getId()))
-            );
-
-            // 8. 이메일 인증 코드 생성 및 발행
+            // 6. 이메일 인증 코드 생성
             String verificationCode = VerificationCodeGenerator.generate();
             EmailVerification emailVerification = EmailVerification.create(
                     request.email(), verificationCode,
                     LocalDateTime.now().plusMinutes(VERIFICATION_CODE_EXPIRY_MINUTES));
             emailVerificationRepository.save(emailVerification);
 
+            // 7. Outbox 이벤트 발행
+            eventPublisher.publish(
+                    new UserCreatedEvent(user.getId(), user.getEmail(), user.getNickname()),
+                    EventMetadata.of("USER", String.valueOf(user.getId()))
+            );
             eventPublisher.publish(
                     new EmailConfirmEvent(request.email(), verificationCode),
                     EventMetadata.of("USER", String.valueOf(user.getId()))
             );
+
+            // 8. DB flush — 제약 조건 위반을 외부 호출 전에 즉시 감지
+            entityManager.flush();
+
+            // 9. Profile Service 동기 호출 (DB 성공 확인 후 실행)
+            if (syncProfileCreateOnSignup) {
+                profileServiceClient.createProfile(user.getId(), user.getEmail(), request.nickname());
+            } else {
+                log.info("Sync profile create disabled by feature flag. userId={}", user.getId());
+            }
 
             log.info("Signup completed: userId={}, email={}", user.getId(), user.getEmail());
             return SignupResponse.of(user.getId(), user.getEmail());


### PR DESCRIPTION
## Summary

- `EntityManager.flush()`를 Profile Service 호출 전에 실행하여 DB 제약 조건 위반을 외부 호출 전에 즉시 감지
- DB 작업(User, StatusHistory, EmailVerification, Outbox) → flush() → Profile Service 호출 순서로 재배치
- `UserStatus.NONE` 추가로 회원가입 시 previousStatus null 제약 조건 위반 방지

### 기존 문제

```
User.save()           → JPA 큐 (지연)
StatusHistory.save()  → JPA 큐 (지연)
Profile.create()      → 외부 HTTP 호출 성공 
── 트랜잭션 커밋 ──
flush → INSERT 실패 (NOT NULL 제약 위반 등)
→ DB 롤백 → Profile 서비스에 고아 데이터 잔존
```

### 수정 후

```
User.save()              → JPA 큐
StatusHistory.save()     → JPA 큐
EmailVerification.save() → JPA 큐
Outbox events            → JPA 큐
entityManager.flush()    → INSERT 즉시 실행 (실패 시 여기서 catch)
Profile.create()         → DB 성공 확인 후에만 외부 호출
```

## 관련 이슈

- Related #501
- Related #681

## Test plan

- [ ] `./gradlew :servers:services:auth:compileJava` 빌드 성공
- [ ] 회원가입 API 호출 → User, StatusHistory, EmailVerification INSERT 정상 확인
- [ ] Profile Service 호출이 DB flush 이후에만 실행되는지 확인
- [ ] DB 제약 조건 위반 시 Profile 고아 데이터 미발생 확인
