### PR TITLE
feat: Profile 서비스 게이트웨이 라우트 추가 및 수령인 필드 보강

### DIFF
--- a/servers/gateways/client-gateway/src/main/resources/application.yml
+++ b/servers/gateways/client-gateway/src/main/resources/application.yml
@@ -75,6 +75,10 @@ spring:
               uri: ${app.service.review-url:http://localhost:8097}
               predicates:
                 - Path=/api/v1/reviews/**
+            - id: profile-service
+              uri: ${app.service.profile-url:http://localhost:8071}
+              predicates:
+                - Path=/api/profile/**
             - id: chat-service-ws
               uri: ${app.service.chat-ws-url:ws://localhost:8093}
               predicates:

--- a/servers/services/profile/src/main/java/com/example/profile/dto/request/ProfileAddressRequest.java
+++ b/servers/services/profile/src/main/java/com/example/profile/dto/request/ProfileAddressRequest.java
@@ -11,5 +11,7 @@ public record ProfileAddressRequest(
     String roadName,
     String buildingNumber,
     String buildingName,
-    String detailAddress) {
+    String detailAddress,
+    String recipientName,
+    String recipientPhone) {
 }

--- a/servers/services/profile/src/main/java/com/example/profile/dto/response/AddressResponse.java
+++ b/servers/services/profile/src/main/java/com/example/profile/dto/response/AddressResponse.java
@@ -7,14 +7,20 @@ public record AddressResponse(
     Long id,
     String deliveryName,
     boolean isDefault,
-    String fullAddress
+    String fullAddress,
+    String recipientName,
+    String recipientPhone,
+    String zipcode
 ) {
     public static AddressResponse from(ProfileAddress address) {
         return new AddressResponse(
             address.getId(),
             address.getDeliveryName(),
             address.isDefault(),
-            buildFullAddress(address)
+            buildFullAddress(address),
+            address.getRecipientName(),
+            address.getRecipientPhone(),
+            address.getZipcode()
         );
     }
 

--- a/servers/services/profile/src/main/java/com/example/profile/dto/response/ProfileAddressResponse.java
+++ b/servers/services/profile/src/main/java/com/example/profile/dto/response/ProfileAddressResponse.java
@@ -13,7 +13,9 @@ public record ProfileAddressResponse(
     String buildingNumber,
     String buildingName,
     String detailAddress,
-    int sortOrder
+    int sortOrder,
+    String recipientName,
+    String recipientPhone
 ) {
     public static ProfileAddressResponse from(ProfileAddress address) {
         return new ProfileAddressResponse(
@@ -26,7 +28,9 @@ public record ProfileAddressResponse(
             address.getBuildingNumber(),
             address.getBuildingName(),
             address.getDetailAddress(),
-            address.getSortOrder()
+            address.getSortOrder(),
+            address.getRecipientName(),
+            address.getRecipientPhone()
         );
     }
 

--- a/servers/services/profile/src/main/java/com/example/profile/entity/ProfileAddress.java
+++ b/servers/services/profile/src/main/java/com/example/profile/entity/ProfileAddress.java
@@ -54,6 +54,12 @@ public class ProfileAddress extends BaseEntity {
     @Column(name = "sort_order", columnDefinition = "INT DEFAULT 0")
     private int sortOrder = 0;
 
+    @Column(name = "recipient_name", nullable = true, length = 50)
+    private String recipientName;
+
+    @Column(name = "recipient_phone", nullable = true, length = 20)
+    private String recipientPhone;
+
     @Builder.Default
     @Column(name = "is_default", nullable = false)
     private boolean isDefault = false;
@@ -78,6 +84,8 @@ public class ProfileAddress extends BaseEntity {
         this.buildingNumber = req.buildingNumber();
         this.buildingName   = req.buildingName();
         this.detailAddress  = req.detailAddress();
+        this.recipientName  = req.recipientName();
+        this.recipientPhone = req.recipientPhone();
         // sortOrder는 클라이언트에서 관리하지 않음
     }
 

--- a/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
+++ b/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
@@ -126,6 +126,8 @@ public class ProfileCommandService {
             .buildingNumber(req.buildingNumber())
             .buildingName(req.buildingName())
             .detailAddress(req.detailAddress())
+            .recipientName(req.recipientName())
+            .recipientPhone(req.recipientPhone())
             .build();
 
         if (existing.isEmpty()) {


### PR DESCRIPTION
closes #937

## 요약

- `client-gateway`에 `profile-service` 라우트 추가 (`/api/profile/**`)
- `ProfileAddress` 엔티티에 수령인 이름/전화번호 컬럼 추가 (nullable, 기존 데이터 호환)
- `ProfileAddressRequest` / `AddressResponse` / `ProfileAddressResponse` DTO에 수령인 필드 보강
- `ProfileCommandService.createAddress`에 수령인 필드 반영

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `client-gateway/application.yml` | `profile-service` 라우트 추가 (포트 8071) |
| `ProfileAddress.java` | `recipientName`, `recipientPhone` 컬럼 추가 (nullable); `update()` 메서드 반영 |
| `ProfileAddressRequest.java` | `recipientName`, `recipientPhone` 파라미터 추가 |
| `AddressResponse.java` | `recipientName`, `recipientPhone`, `zipcode` 필드 추가 |
| `ProfileAddressResponse.java` | `recipientName`, `recipientPhone` 필드 추가 |
| `ProfileCommandService.java` | `createAddress` 빌더에 수령인 필드 추가 |

## 테스트 체크리스트

- [ ] `/api/profile/**` 경로가 게이트웨이를 통해 정상 라우팅되는지 확인
- [ ] 배송지 생성 시 `recipientName`, `recipientPhone` 저장 확인
- [ ] 배송지 수정 시 수령인 필드 업데이트 확인
- [ ] `AddressResponse` 응답에 `recipientName`, `recipientPhone`, `zipcode` 포함 확인
- [ ] 기존 배송지 데이터(수령인 필드 null) 조회 정상 동작 확인
