### PR TITLE
fix(#940): Notification 서비스 PaymentEventMessage 필드 불일치 수정

### DIFF
--- a/servers/services/notification/src/main/java/com/example/notification/consumer/payment/NotificationPaymentEventProcessor.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/payment/NotificationPaymentEventProcessor.java
@@ -64,17 +64,20 @@ public class NotificationPaymentEventProcessor extends AbstractIdempotentEventSp
     private void handlePaymentCompleted(PaymentEventMessage event) {
         Map<String, Object> variables = new LinkedHashMap<>();
         variables.put("paymentId", event.getPaymentId());
-        variables.put("purchaseId", event.getPurchaseId());
         variables.put("orderId", event.getOrderId());
-        variables.put("itemId", event.getItemId());
         variables.put("totalAmount", event.getTotalAmount());
-        variables.put("quantity", event.getQuantity());
+        if (event.getPurchaseId() != null) variables.put("purchaseId", event.getPurchaseId());
+        if (event.getItemId() != null) variables.put("itemId", event.getItemId());
+        if (event.getQuantity() != null) variables.put("quantity", event.getQuantity());
+
+        Long referenceId = event.getPurchaseId() != null ? event.getPurchaseId() : event.getOrderId();
+        String referenceType = event.getPurchaseId() != null ? "PURCHASE" : "ORDER";
 
         notificationDispatchSupport.dispatchNotification(
                 event.getUserId(),
                 NotificationType.PAYMENT,
-                "PURCHASE",
-                event.getPurchaseId(),
+                referenceType,
+                referenceId,
                 event.getEventId(),
                 "결제가 완료되었습니다",
                 "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "이(가) 정상 처리되었습니다.",

--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
@@ -13,18 +13,16 @@ public class PaymentCompletedEvent extends DomainEvent {
     private final Long paymentId;
     private final Long orderId;
     private final Long userId;
-    private final Long amount;
-    private final LocalDateTime paidAt;
     private final Long totalAmount;
+    private final LocalDateTime paidAt;
 
-    public PaymentCompletedEvent(Long paymentId, Long orderId, Long userId, Long amount, LocalDateTime paidAt) {
+    public PaymentCompletedEvent(Long paymentId, Long orderId, Long userId, Long totalAmount, LocalDateTime paidAt) {
         super("payment-events");
         this.paymentId = paymentId;
         this.orderId = orderId;
         this.userId = userId;
-        this.amount = amount;
+        this.totalAmount = totalAmount;
         this.paidAt = paidAt;
-        this.totalAmount = amount;
     }
 
     @Override
@@ -38,9 +36,8 @@ public class PaymentCompletedEvent extends DomainEvent {
         payload.put("paymentId", paymentId);
         payload.put("orderId", orderId);
         payload.put("userId", userId);
-        payload.put("amount", amount);
-        payload.put("paidAt", paidAt);
         payload.put("totalAmount", totalAmount);
+        payload.put("paidAt", paidAt);
         return payload;
     }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #940

## 개요

- `PaymentCompletedEvent`에서 `amount`/`totalAmount` 중복 필드 제거 → `totalAmount`로 통일
- `NotificationPaymentEventProcessor.handlePaymentCompleted()`에서 `purchaseId`, `itemId`, `quantity` null 안전 처리 추가
- `purchaseId`가 null일 경우 `referenceType`/`referenceId`를 `PURCHASE/null` 대신 `ORDER/orderId`로 fallback 처리

## 문제

Payment 도메인에는 `purchaseId`, `itemId`, `quantity` 개념이 없음. Notification 서비스의 `PaymentEventMessage`는 이 필드들을 선언하고 있지만, 결제 이벤트에 포함되지 않아 항상 null → `referenceType="PURCHASE"`, `referenceId=null`인 의미 없는 알림이 생성되는 문제.

## 변경 내용

| 파일 | 변경 내용 |
|------|----------|
| `PaymentCompletedEvent.java` | `amount` 필드 제거, `totalAmount`로 통일 |
| `NotificationPaymentEventProcessor.java` | null-safe 변수 처리, purchaseId null 시 orderId fallback |

## 테스트

- [ ] 결제 완료 후 `PAYMENT_COMPLETED` 이벤트 발행 확인
- [ ] Notification 서비스에서 이벤트 수신 후 알림 생성 확인 (referenceType=ORDER, referenceId=orderId)
- [ ] `purchaseId`가 있는 경우 기존대로 referenceType=PURCHASE 동작 확인

