### PR TITLE
fix: 결제 이벤트 알림 필드 불일치 및 핸들러 누락 수정

### DIFF
--- a/servers/services/notification/src/main/java/com/example/notification/consumer/payment/NotificationPaymentEventProcessor.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/payment/NotificationPaymentEventProcessor.java
@@ -31,7 +31,11 @@ public class NotificationPaymentEventProcessor extends AbstractIdempotentEventSp
         super(idempotentConsumerService);
         this.notificationDispatchSupport = notificationDispatchSupport;
         this.eventSpecs = Map.of(
-                "PAYMENT_COMPLETED", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentCompleted)
+                "PAYMENT_COMPLETED", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentCompleted),
+                "PAYMENT_FAILED", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentFailed),
+                "PAYMENT_CANCELLED", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentCancelled),
+                "PAYMENT_TIMED_OUT", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentTimedOut),
+                "PAYMENT_REFUNDED", EventSpec.of(PaymentEventMessage.class, this::hasUserId, this::handlePaymentRefunded)
         );
     }
 
@@ -53,8 +57,8 @@ public class NotificationPaymentEventProcessor extends AbstractIdempotentEventSp
     @Override
     protected <T extends EventEnvelope> void onInvalidPayload(T event, String message, String eventId, String eventType) {
         PaymentEventMessage paymentEvent = (PaymentEventMessage) event;
-        log.warn("Skip PAYMENT_COMPLETED notification. userId is null. paymentId={}",
-                paymentEvent == null ? null : paymentEvent.getPaymentId());
+        log.warn("Skip payment notification. userId is null. eventType={}, paymentId={}",
+                eventType, paymentEvent == null ? null : paymentEvent.getPaymentId());
     }
 
     private boolean hasUserId(PaymentEventMessage event) {
@@ -64,23 +68,99 @@ public class NotificationPaymentEventProcessor extends AbstractIdempotentEventSp
     private void handlePaymentCompleted(PaymentEventMessage event) {
         Map<String, Object> variables = new LinkedHashMap<>();
         variables.put("paymentId", event.getPaymentId());
-        variables.put("purchaseId", event.getPurchaseId());
         variables.put("orderId", event.getOrderId());
-        variables.put("itemId", event.getItemId());
-        variables.put("totalAmount", event.getTotalAmount());
-        variables.put("quantity", event.getQuantity());
+        variables.put("amount", event.getAmount());
 
         notificationDispatchSupport.dispatchNotification(
                 event.getUserId(),
                 NotificationType.PAYMENT,
-                "PURCHASE",
-                event.getPurchaseId(),
+                "ORDER",
+                event.getOrderId(),
                 event.getEventId(),
                 "결제가 완료되었습니다",
                 "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "이(가) 정상 처리되었습니다.",
                 variables
         );
-        log.info("Payment completion notification dispatched. eventId={}, paymentId={}, recipientId={}",
+        log.info("Payment COMPLETED notification dispatched. eventId={}, paymentId={}, userId={}",
+                event.getEventId(), event.getPaymentId(), event.getUserId());
+    }
+
+    private void handlePaymentFailed(PaymentEventMessage event) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("paymentId", event.getPaymentId());
+        variables.put("orderId", event.getOrderId());
+        variables.put("failReason", event.getFailReason());
+
+        notificationDispatchSupport.dispatchNotification(
+                event.getUserId(),
+                NotificationType.PAYMENT,
+                "ORDER",
+                event.getOrderId(),
+                event.getEventId(),
+                "결제에 실패했습니다",
+                "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "이(가) 실패했습니다.",
+                variables
+        );
+        log.info("Payment FAILED notification dispatched. eventId={}, paymentId={}, userId={}",
+                event.getEventId(), event.getPaymentId(), event.getUserId());
+    }
+
+    private void handlePaymentCancelled(PaymentEventMessage event) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("paymentId", event.getPaymentId());
+        variables.put("orderId", event.getOrderId());
+        variables.put("amount", event.getAmount());
+
+        notificationDispatchSupport.dispatchNotification(
+                event.getUserId(),
+                NotificationType.PAYMENT,
+                "ORDER",
+                event.getOrderId(),
+                event.getEventId(),
+                "결제가 취소되었습니다",
+                "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "이(가) 취소되었습니다.",
+                variables
+        );
+        log.info("Payment CANCELLED notification dispatched. eventId={}, paymentId={}, userId={}",
+                event.getEventId(), event.getPaymentId(), event.getUserId());
+    }
+
+    private void handlePaymentTimedOut(PaymentEventMessage event) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("paymentId", event.getPaymentId());
+        variables.put("orderId", event.getOrderId());
+
+        notificationDispatchSupport.dispatchNotification(
+                event.getUserId(),
+                NotificationType.PAYMENT,
+                "ORDER",
+                event.getOrderId(),
+                event.getEventId(),
+                "결제 시간이 초과되었습니다",
+                "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "의 결제 시간이 초과되었습니다. 다시 시도해 주세요.",
+                variables
+        );
+        log.info("Payment TIMED_OUT notification dispatched. eventId={}, paymentId={}, userId={}",
+                event.getEventId(), event.getPaymentId(), event.getUserId());
+    }
+
+    private void handlePaymentRefunded(PaymentEventMessage event) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("paymentId", event.getPaymentId());
+        variables.put("orderId", event.getOrderId());
+        variables.put("amount", event.getAmount());
+
+        notificationDispatchSupport.dispatchNotification(
+                event.getUserId(),
+                NotificationType.PAYMENT,
+                "ORDER",
+                event.getOrderId(),
+                event.getEventId(),
+                "환불이 완료되었습니다",
+                "결제 건 #" + notificationDispatchSupport.safeValue(event.getPaymentId()) + "의 환불이 완료되었습니다.",
+                variables
+        );
+        log.info("Payment REFUNDED notification dispatched. eventId={}, paymentId={}, userId={}",
                 event.getEventId(), event.getPaymentId(), event.getUserId());
     }
 }

--- a/servers/services/notification/src/main/java/com/example/notification/consumer/payment/PaymentEventMessage.java
+++ b/servers/services/notification/src/main/java/com/example/notification/consumer/payment/PaymentEventMessage.java
@@ -4,6 +4,8 @@ import com.example.event.consumer.EventEnvelope;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class PaymentEventMessage implements EventEnvelope {
@@ -11,10 +13,9 @@ public class PaymentEventMessage implements EventEnvelope {
     private String eventId;
     private String eventType;
     private Long paymentId;
-    private Long purchaseId;
     private Long orderId;
     private Long userId;
-    private Long itemId;
-    private Long totalAmount;
-    private Integer quantity;
+    private Long amount;
+    private LocalDateTime paidAt;
+    private String failReason;
 }


### PR DESCRIPTION
## 문제

`PaymentEventMessage`의 필드명이 실제 `payment-events` 토픽 페이로드와 달라
`PAYMENT_COMPLETED` 알림이 항상 `null` 값으로 발송되고 있었습니다.
또한 `PAYMENT_FAILED`, `PAYMENT_CANCELLED`, `PAYMENT_TIMED_OUT`, `PAYMENT_REFUNDED`
이벤트에 대한 핸들러가 없어 결제 실패·취소·환불 시 사용자에게 알림이 전달되지 않았습니다.

### 원인

| 기존 필드 | 실제 페이로드 필드 | 비고 |
|---|---|---|
| `purchaseId` | (없음) | payment 이벤트에 존재하지 않는 필드 |
| `totalAmount` | `amount` | 필드명 불일치 |
| `itemId` | (없음) | payment 이벤트에 존재하지 않는 필드 |
| `quantity` | (없음) | payment 이벤트에 존재하지 않는 필드 |

`COMPLETED` 핸들러의 `referenceType`도 `"PURCHASE"` / `referenceId = purchaseId` 로
잘못 설정되어 있었습니다.

## 변경 사항

**`PaymentEventMessage.java`**
- `purchaseId`, `itemId`, `quantity` 제거
- `totalAmount` → `amount` 수정
- `paidAt`, `failReason` 추가

**`NotificationPaymentEventProcessor.java`**
- `COMPLETED` 핸들러: `referenceType` `PURCHASE` → `ORDER`, `referenceId` `purchaseId` → `orderId` 수정
- `FAILED` 핸들러 추가 — "결제에 실패했습니다" (`failReason` 포함)
- `CANCELLED` 핸들러 추가 — "결제가 취소되었습니다"
- `TIMED_OUT` 핸들러 추가 — "결제 시간이 초과되었습니다"
- `REFUNDED` 핸들러 추가 — "환불이 완료되었습니다"

## 테스트 체크리스트

- [ ] 결제 완료 시 알림 수신 확인 (amount, orderId 정상 값)
- [ ] 결제 실패 시 알림 수신 확인 (failReason 포함)
- [ ] 결제 취소 시 알림 수신 확인
- [ ] 결제 타임아웃 시 알림 수신 확인
- [ ] 환불 완료 시 알림 수신 확인
- [ ] userId null인 이벤트는 알림 스킵되는지 확인
