### PR TITLE
fix: PaymentCompletedEvent 페이로드의 totalAmount 중복 필드 제거

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
+++ b/servers/services/payment/src/main/java/com/example/payment/event/PaymentCompletedEvent.java
@@ -15,7 +15,6 @@ public class PaymentCompletedEvent extends DomainEvent {
     private final Long userId;
     private final Long amount;
     private final LocalDateTime paidAt;
-    private final Long totalAmount;
 
     public PaymentCompletedEvent(Long paymentId, Long orderId, Long userId, Long amount, LocalDateTime paidAt) {
         super("payment-events");
@@ -24,7 +23,6 @@ public class PaymentCompletedEvent extends DomainEvent {
         this.userId = userId;
         this.amount = amount;
         this.paidAt = paidAt;
-        this.totalAmount = amount;
     }
 
     @Override
@@ -40,7 +38,6 @@ public class PaymentCompletedEvent extends DomainEvent {
         payload.put("userId", userId);
         payload.put("amount", amount);
         payload.put("paidAt", paidAt);
-        payload.put("totalAmount", totalAmount);
         return payload;
     }
 }


### PR DESCRIPTION

### 작업 / 변경 내용
- `PaymentCompletedEvent.getPayload()`가 `amount`와 동일한 값을 `totalAmount`라는
  별도 키로 중복 발행하고 있었습니다. 소비자(알림·재고·주문 서비스)가 `amount`와
  `totalAmount` 중 어느 필드를 사용해야 하는지 불명확해지는 문제입니다.
- `totalAmount` 필드 및 생성자 내 대입 코드를 제거하고 `amount`만 유지합니다.
- 다른 이벤트(`PaymentFailedEvent`, `PaymentCancelledEvent` 등)는 처음부터
  `amount`만 발행하고 있어 이 PR로 전체 페이로드 명세가 통일됩니다.

### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
- 기존에 `totalAmount`를 읽던 소비자 코드가 있다면 `amount`로 교체 필요
- `fix/notification-payment-handlers` PR에서 알림 서비스의 `PaymentEventMessage`가
  이미 `amount` 필드로 정정되었으므로 해당 PR과 함께 머지하는 것을 권장합니다.
