### PR TITLE
fix(#939): 결제 승인 실패 시 트랜잭션 롤백으로 실패 상태 유실 수정

### DIFF
--- a/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentCommandService.java
+++ b/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentCommandService.java
@@ -13,7 +13,6 @@ import com.example.payment.domain.PaymentStatus;
 import com.example.payment.dto.request.PaymentConfirmRequest;
 import com.example.payment.dto.response.PaymentConfirmResponse;
 import com.example.payment.event.PaymentCompletedEvent;
-import com.example.payment.event.PaymentFailedEvent;
 import com.example.payment.exception.PaymentErrorCode;
 import com.example.payment.exception.TossPaymentsApiException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,6 +34,7 @@ public class PaymentCommandService {
     private final TossPaymentsClient tossPaymentsClient;
     private final EventPublisher eventPublisher;
     private final ObjectMapper objectMapper;
+    private final PaymentFailureHandler paymentFailureHandler;
 
     @DistributedLock(key = "'payment:confirm:' + #request.orderId()", waitTime = 5, leaseTime = 15)
     public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request, Long userId) {
@@ -91,19 +91,9 @@ public class PaymentCommandService {
             return PaymentConfirmResponse.from(payment);
 
         } catch (TossPaymentsApiException e) {
-            payment.markFailed(request.paymentKey(), e.getResponseBody(), e.getResponseBody());
-
-            eventPublisher.publish(
-                    new PaymentFailedEvent(
-                            payment.getId(),
-                            payment.getOrderId(),
-                            payment.getUserId(),
-                            payment.getAmount(),
-                            e.getResponseBody()
-                    ),
-                    EventMetadata.of("Payment", String.valueOf(payment.getId()))
+            paymentFailureHandler.handleConfirmFailure(
+                    payment.getId(), request.paymentKey(), e.getResponseBody()
             );
-
             log.error("결제 승인 실패: paymentId={}, orderId={}, error={}",
                     payment.getId(), payment.getOrderId(), e.getResponseBody());
             throw new BusinessException(PaymentErrorCode.TOSS_CONFIRM_FAILED);

--- a/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentFailureHandler.java
+++ b/servers/services/payment/src/main/java/com/example/payment/service/command/PaymentFailureHandler.java
@@ -1,0 +1,46 @@
+package com.example.payment.service.command;
+
+import com.example.event.EventMetadata;
+import com.example.event.EventPublisher;
+import com.example.payment.domain.Payment;
+import com.example.payment.domain.PaymentRepository;
+import com.example.payment.event.PaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentFailureHandler {
+
+    private final PaymentRepository paymentRepository;
+    private final EventPublisher eventPublisher;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleConfirmFailure(Long paymentId, String paymentKey, String failReason) {
+        Payment payment = paymentRepository.findById(paymentId).orElse(null);
+        if (payment == null) {
+            log.warn("결제 실패 처리 대상 없음: paymentId={}", paymentId);
+            return;
+        }
+
+        payment.markFailed(paymentKey, failReason, failReason);
+
+        eventPublisher.publish(
+                new PaymentFailedEvent(
+                        payment.getId(),
+                        payment.getOrderId(),
+                        payment.getUserId(),
+                        payment.getAmount(),
+                        failReason
+                ),
+                EventMetadata.of("Payment", String.valueOf(payment.getId()))
+        );
+
+        log.info("결제 실패 처리 완료 (REQUIRES_NEW): paymentId={}, orderId={}",
+                payment.getId(), payment.getOrderId());
+    }
+}


### PR DESCRIPTION
## Summary
- 결제 승인(`confirmPayment`) 실패 시 `@Transactional` 롤백으로 인해 `markFailed()` 상태 변경과 `PaymentFailedEvent` 아웃박스 INSERT가 모두 유실되는 문제 수정
- `PaymentFailureHandler`를 `@Transactional(propagation = REQUIRES_NEW)`로 분리하여 외부 트랜잭션 롤백과 무관하게 실패 상태가 커밋되도록 개선
- 기존 catch 블록의 직접 처리를 `paymentFailureHandler.handleConfirmFailure()` 위임으로 변경

## 원인 분석
`PaymentCommandService.confirmPayment()`에서 `TossPaymentsApiException` catch 후 `markFailed()` + 이벤트 발행 + `throw BusinessException` 순서로 처리되었으나, `throw`로 인한 `@Transactional` 롤백이 동일 트랜잭션 내의 모든 변경을 취소함

## Test plan
- [ ] 토스 결제 승인 실패 케이스에서 Payment 상태가 FAILED로 정상 전이되는지 확인
- [ ] 실패 시 `PaymentFailedEvent`가 아웃박스 테이블에 정상 INSERT되는지 확인
- [ ] 결제 승인 성공 케이스가 기존과 동일하게 동작하는지 확인

Closes #939
