### PR TITLE
fix: PAYMENT_FAILED 이벤트 수신 시 재고 예약 취소 처리 누락

### DIFF
--- a/servers/services/stock/src/main/java/com/example/stock/consumer/payment/StockPaymentEventProcessor.java
+++ b/servers/services/stock/src/main/java/com/example/stock/consumer/payment/StockPaymentEventProcessor.java
@@ -29,6 +29,7 @@ public class StockPaymentEventProcessor extends AbstractIdempotentEventSpecProce
         this.stockCommandService = stockCommandService;
         this.eventSpecs = Map.of(
                 "PAYMENT_COMPLETED", EventSpec.of(PaymentEventMessage.class, this::hasOrderOrReservation, this::handlePaymentCompleted),
+                "PAYMENT_FAILED", EventSpec.of(PaymentEventMessage.class, this::hasOrderOrReservation, this::handlePaymentFailed),
                 "PAYMENT_CANCELLED", EventSpec.of(PaymentEventMessage.class, this::hasOrderOrReservation, this::handlePaymentCancelled),
                 "PAYMENT_TIMED_OUT", EventSpec.of(PaymentEventMessage.class, this::hasOrderOrReservation, this::handlePaymentTimedOut)
         );
@@ -78,6 +79,16 @@ public class StockPaymentEventProcessor extends AbstractIdempotentEventSpecProce
         }
         log.info("결제 완료 -> 예약 확정 처리: reservationId={}", event.getReservationId());
         stockCommandService.confirmReservationById(event.getReservationId());
+    }
+
+    private void handlePaymentFailed(PaymentEventMessage event) {
+        if (event.getOrderId() != null) {
+            log.info("결제 실패 -> order 예약 취소 처리: orderId={}", event.getOrderId());
+            stockCommandService.cancelReservationsByOrderId(event.getOrderId());
+            return;
+        }
+        log.info("결제 실패 -> 예약 취소 처리: reservationId={}", event.getReservationId());
+        stockCommandService.cancelReservation(event.getReservationId());
     }
 
     private void handlePaymentCancelled(PaymentEventMessage event) {


### PR DESCRIPTION
## Summary
- Stock 서비스에서 `PAYMENT_FAILED` 이벤트를 처리하지 않아 결제 실패 시 재고 예약이 해제되지 않는 문제 수정
- `StockPaymentEventProcessor`에 `PAYMENT_FAILED` EventSpec 및 `handlePaymentFailed()` 핸들러 추가
- 기존 `PAYMENT_CANCELLED`/`PAYMENT_TIMED_OUT`과 동일한 패턴으로 `orderId` 기반 또는 `reservationId` 기반 예약 취소 수행

## 영향 범위
- `StockPaymentEventProcessor.java` — 핸들러 1개 추가

## Test plan
- [ ] 결제 실패 시 `PAYMENT_FAILED` 이벤트가 Stock 서비스에서 정상 소비되는지 확인
- [ ] 재고 예약이 정상적으로 취소(release)되는지 확인
- [ ] 기존 COMPLETED/CANCELLED/TIMED_OUT 이벤트 처리에 영향 없는지 확인

