### PR TITLE
fix: payment/order 서비스 gateway-security 경로 설정 추가

### DIFF
--- a/servers/services/order/src/main/resources/application.yml
+++ b/servers/services/order/src/main/resources/application.yml
@@ -52,10 +52,16 @@ app:
     worker-id: ${SNOWFLAKE_WORKER_ID:9}
 
   gateway-security:
-    enabled: ${APP_GATEWAY_SECURITY_ENABLED:false}
-    internal-auth-header: X-Gateway-Auth
+    enabled: ${APP_GATEWAY_SECURITY_ENABLED:true}
+    gateway-auth-enabled: ${APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED:true}
+    internal-auth-header: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
     internal-auth-token: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}
-    user-id-header: X-User-Id
+    user-id-header: ${APP_GATEWAY_SECURITY_USER_ID_HEADER:X-User-Id}
+    required-paths:
+      - /api/v1/orders/*/cancel
+      - /api/v1/orders/*/refund
+    optional-user-context-paths:
+      - /api/v1/orders/**
 
   openapi:
     enabled: true

--- a/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsWebClient.java
+++ b/servers/services/payment/src/main/java/com/example/payment/client/TossPaymentsWebClient.java
@@ -58,6 +58,9 @@ public class TossPaymentsWebClient implements TossPaymentsClient {
             } catch (WebClientResponseException e) {
                 log.error("토스페이먼츠 결제 승인 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
                 throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+            } catch (Exception e) {
+                log.error("토스페이먼츠 결제 승인 중 연결 오류: {}", e.getMessage(), e);
+                throw new TossPaymentsApiException(0, e.getMessage(), e);
             }
         };
         return circuitBreakerHelper.executeWithCircuitBreakerAndRetry(CB_CONFIRM, supplier);
@@ -76,6 +79,9 @@ public class TossPaymentsWebClient implements TossPaymentsClient {
             } catch (WebClientResponseException e) {
                 log.error("토스페이먼츠 결제 취소 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
                 throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+            } catch (Exception e) {
+                log.error("토스페이먼츠 결제 취소 중 연결 오류: {}", e.getMessage(), e);
+                throw new TossPaymentsApiException(0, e.getMessage(), e);
             }
         };
         return circuitBreakerHelper.executeWithCircuitBreakerAndRetry(CB_CANCEL, supplier);
@@ -92,6 +98,9 @@ public class TossPaymentsWebClient implements TossPaymentsClient {
         } catch (WebClientResponseException e) {
             log.error("토스페이먼츠 결제 조회 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
             throw new TossPaymentsApiException(e.getStatusCode().value(), e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            log.error("토스페이먼츠 결제 조회 중 연결 오류: {}", e.getMessage(), e);
+            throw new TossPaymentsApiException(0, e.getMessage(), e);
         }
     }
 }

--- a/servers/services/payment/src/main/resources/application.yml
+++ b/servers/services/payment/src/main/resources/application.yml
@@ -52,10 +52,15 @@ app:
     worker-id: ${SNOWFLAKE_WORKER_ID:10}
 
   gateway-security:
-    enabled: ${APP_GATEWAY_SECURITY_ENABLED:false}
-    internal-auth-header: X-Gateway-Auth
+    enabled: ${APP_GATEWAY_SECURITY_ENABLED:true}
+    gateway-auth-enabled: ${APP_GATEWAY_SECURITY_GATEWAY_AUTH_ENABLED:true}
+    internal-auth-header: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_HEADER:X-Gateway-Auth}
     internal-auth-token: ${APP_GATEWAY_SECURITY_INTERNAL_AUTH_TOKEN:}
-    user-id-header: X-User-Id
+    user-id-header: ${APP_GATEWAY_SECURITY_USER_ID_HEADER:X-User-Id}
+    required-paths:
+      - /api/v1/payments/confirm
+    optional-user-context-paths:
+      - /api/v1/payments/**
 
   tosspayments:
     secret-key: ${TOSSPAYMENTS_SECRET_KEY:test_sk_placeholder}


### PR DESCRIPTION
## Summary
- Payment/Order 서비스에서 결제 confirm API 호출 시 500 에러 (SYS-001) 수정
- **근본 원인**: `gateway-security.enabled: true`(Helm env var)이지만 `required-paths`와 `optional-user-context-paths`가 비어있어 `GatewaySecurityValidationFilter.shouldNotFilter()`가 **모든 경로를 스킵** → AuthContext 미설정 → `@CurrentUserId` 실패

### 변경 내용
1. **payment-service application.yml**
   - `required-paths: [/api/v1/payments/confirm]` 추가
   - `optional-user-context-paths: [/api/v1/payments/**]` 추가
   - `gateway-auth-enabled: true` 명시

2. **order-service application.yml**
   - `required-paths` 추가 (cancel, refund)
   - `optional-user-context-paths: [/api/v1/orders/**]` 추가

3. **TossPaymentsWebClient.java**
   - 모든 메서드에 `catch (Exception e)` 추가하여 연결 오류도 `TossPaymentsApiException`으로 래핑

## 왜 env var만으로는 안 되는가
`required-paths`와 `optional-user-context-paths`는 Spring Boot의 List 타입 속성이라 Helm env var로 전달 불가. application.yml에 직접 정의 필요.

## Test plan
- [ ] POST /api/v1/payments/confirm 호출 시 500 에러 대신 정상 처리 확인
- [ ] 결제 완료 → PaymentCompletedEvent 발행 → 주문 PAID 전환 확인
- [ ] 결제 실패 시 PaymentFailedEvent → 재고 복귀 확인

https://claude.ai/code/session_01TLQ2fbwXGA2vAuit2itqde