### PR TITLE
fix: 결제 페이지 배송지 추가 후 즉시 반영되지 않는 버그 수정

### DIFF
--- a/servers/services/profile/src/main/java/com/example/profile/controller/api/command/ProfileCommandApi.java
+++ b/servers/services/profile/src/main/java/com/example/profile/controller/api/command/ProfileCommandApi.java
@@ -3,6 +3,7 @@ package com.example.profile.controller.api.command;
 import com.example.api.response.ApiResponse;
 import com.example.profile.dto.request.ProfileAddressRequest;
 import com.example.profile.dto.request.ProfileRequest;
+import com.example.profile.dto.response.AddressResponse;
 import com.example.profile.dto.response.ProfileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,7 +27,7 @@ public interface ProfileCommandApi {
 
     @Operation(summary = "배송지 추가")
     @PostMapping("/addresses")
-    ApiResponse<Void> createAddress(
+    ApiResponse<AddressResponse> createAddress(
         @RequestBody ProfileAddressRequest req,
         @RequestHeader("X-User-Id") Long userId
     );

--- a/servers/services/profile/src/main/java/com/example/profile/controller/command/ProfileCommandController.java
+++ b/servers/services/profile/src/main/java/com/example/profile/controller/command/ProfileCommandController.java
@@ -5,6 +5,8 @@ import com.example.api.response.ApiResponse;
 import com.example.profile.controller.api.command.ProfileCommandApi;
 import com.example.profile.dto.request.ProfileAddressRequest;
 import com.example.profile.dto.request.ProfileRequest;
+import com.example.profile.dto.response.AddressResponse;
+import com.example.profile.entity.ProfileAddress;
 import com.example.profile.service.command.ProfileCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,9 +27,9 @@ public class ProfileCommandController implements ProfileCommandApi {
     }
 
     @Override
-    public ApiResponse<Void> createAddress(ProfileAddressRequest req, Long userId) {
-        profileService.createAddress(userId, req);
-        return ApiResponse.success();
+    public ApiResponse<AddressResponse> createAddress(ProfileAddressRequest req, Long userId) {
+        ProfileAddress created = profileService.createAddress(userId, req);
+        return ApiResponse.success(AddressResponse.from(created));
     }
 
     @Override

--- a/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
+++ b/servers/services/profile/src/main/java/com/example/profile/service/command/ProfileCommandService.java
@@ -113,7 +113,7 @@ public class ProfileCommandService {
     }
 
     @Transactional
-    public void createAddress(Long userId, ProfileAddressRequest req) {
+    public ProfileAddress createAddress(Long userId, ProfileAddressRequest req) {
         profileProjectionRepairService.ensureProfile(userId)
             .orElseThrow(() -> new BusinessException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
@@ -140,7 +140,7 @@ public class ProfileCommandService {
             address.setAsDefault();
         }
 
-        profileAddressRepository.save(address);
+        return profileAddressRepository.save(address);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- `createAddress` API가 `ApiResponse<Void>` 대신 `ApiResponse<AddressResponse>`를 반환하도록 변경
- 프론트엔드에서 생성된 배송지 ID를 즉시 받아 선택할 수 있도록 개선
- `ProfileCommandService.createAddress()`가 저장된 `ProfileAddress` 엔티티를 반환하도록 변경

## Test plan
- [ ] 배송지가 없는 상태에서 결제 페이지 진입 후 새 배송지 추가 시 즉시 반영되는지 확인
- [ ] 배송지가 있는 상태에서 추가 배송지 등록 후 정상 선택되는지 확인
- [ ] 기본 배송지 설정 체크박스 동작 확인
- [ ] 기존 배송지 관리 페이지(마이페이지) 정상 동작 확인
